### PR TITLE
refactor(retry): consolidate crash and stagnation counters; preserve in Failed state

### DIFF
--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -1125,6 +1125,8 @@ def get_stagnation_config(project_name: str = "") -> dict:
             per-system limits still apply). Default 0 (disabled). When set,
             provides a single operator knob to bound the total number of
             automatic retry attempts regardless of which system triggered them.
+        max_crash_retries (int): maximum crash-recovery attempts before
+            escalating a mission to Failed. Must be >= 1. Default 3.
 
     Per-project overrides via ``projects.yaml`` ``stagnation:`` take
     precedence. Setting ``enabled: false`` at project level disables the
@@ -1135,7 +1137,7 @@ def get_stagnation_config(project_name: str = "") -> dict:
         project_name: Optional project name for per-project overrides.
 
     Returns:
-        Dict with the resolved values — always contains all six keys.
+        Dict with the resolved values — always contains all seven keys.
     """
     defaults = {
         "enabled": True,
@@ -1144,6 +1146,7 @@ def get_stagnation_config(project_name: str = "") -> dict:
         "sample_lines": 50,
         "max_retry_on_stagnation": 3,
         "max_total_retries": 0,
+        "max_crash_retries": 3,
     }
     config = _load_config()
     base = config.get("stagnation", {})
@@ -1173,6 +1176,10 @@ def get_stagnation_config(project_name: str = "") -> dict:
     if max_total < 0:
         max_total = 0
 
+    max_crash = _safe_int(merged.get("max_crash_retries"), defaults["max_crash_retries"])
+    if max_crash < 1:
+        max_crash = 1
+
     return {
         "enabled": bool(merged.get("enabled", defaults["enabled"])),
         "check_interval_seconds": max(
@@ -1182,6 +1189,7 @@ def get_stagnation_config(project_name: str = "") -> dict:
         "sample_lines": max(1, _safe_int(merged.get("sample_lines"), defaults["sample_lines"])),
         "max_retry_on_stagnation": max_retry,
         "max_total_retries": max_total,
+        "max_crash_retries": max_crash,
     }
 
 

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -1119,6 +1119,12 @@ def get_stagnation_config(project_name: str = "") -> dict:
             is re-queued before being marked Failed. ``0`` disables the
             retry loop entirely (mission is failed on the first stagnation).
             Default 3.
+        max_total_retries (int): ceiling on combined retry attempts across
+            both stagnation requeues and crash-recovery requeues for the same
+            logical mission. ``0`` disables the combined cap (independent
+            per-system limits still apply). Default 0 (disabled). When set,
+            provides a single operator knob to bound the total number of
+            automatic retry attempts regardless of which system triggered them.
 
     Per-project overrides via ``projects.yaml`` ``stagnation:`` take
     precedence. Setting ``enabled: false`` at project level disables the
@@ -1129,7 +1135,7 @@ def get_stagnation_config(project_name: str = "") -> dict:
         project_name: Optional project name for per-project overrides.
 
     Returns:
-        Dict with the resolved values — always contains all five keys.
+        Dict with the resolved values — always contains all six keys.
     """
     defaults = {
         "enabled": True,
@@ -1137,6 +1143,7 @@ def get_stagnation_config(project_name: str = "") -> dict:
         "abort_after_cycles": 3,
         "sample_lines": 50,
         "max_retry_on_stagnation": 3,
+        "max_total_retries": 0,
     }
     config = _load_config()
     base = config.get("stagnation", {})
@@ -1162,6 +1169,10 @@ def get_stagnation_config(project_name: str = "") -> dict:
     if max_retry < 0:
         max_retry = 0
 
+    max_total = _safe_int(merged.get("max_total_retries"), defaults["max_total_retries"])
+    if max_total < 0:
+        max_total = 0
+
     return {
         "enabled": bool(merged.get("enabled", defaults["enabled"])),
         "check_interval_seconds": max(
@@ -1170,6 +1181,7 @@ def get_stagnation_config(project_name: str = "") -> dict:
         "abort_after_cycles": abort_after,
         "sample_lines": max(1, _safe_int(merged.get("sample_lines"), defaults["sample_lines"])),
         "max_retry_on_stagnation": max_retry,
+        "max_total_retries": max_total,
     }
 
 

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -771,7 +771,7 @@ def _run_iteration(
     # needle recorded in missions.md "In Progress" section.
     original_mission_title = mission_title
     if mission_title:
-        if not _run._start_mission_in_file(instance, mission_title):
+        if not _run._start_mission_in_file(instance, mission_title, project_name):
             log("warning", f"start_mission transition failed for '{mission_title[:60]}' — "
                 "mission may still be in Pending; aborting this run to avoid duplicate execution.")
             return False

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -5,13 +5,16 @@ Kōan — Crash recovery
 Detects missions left in "In Progress" from a previous interrupted run.
 Classifies each stale mission and takes appropriate action:
 
-  - dead:          Standard crash — move back to Pending (increment [r:N] counter)
+  - dead:          Standard crash — move back to Pending
   - partial:       Interrupted run with pending.md context — recover with context
   - unrecoverable: Too many recovery attempts — move to Failed, notify human
 
-Recovery attempts are tracked via an [r:N] tag embedded in the mission text.
-After MAX_RECOVERY_ATTEMPTS consecutive failures, the mission is escalated to Failed
-and the human is notified via Telegram.
+Recovery attempts are now tracked in the stagnation_monitor tracker
+(instance/.stagnation-retries.json), keyed by mission title. The legacy
+[r:N] tag embedded in mission text is still supported for backward
+compatibility — if a mission carries an [r:N] tag from a previous Kōan
+version and that count exceeds the tracker value, the tag value is used
+instead. New missions will not have [r:N] tags written back to missions.md.
 
 All recovery events are logged to instance/recovery.jsonl for forensics.
 
@@ -33,34 +36,10 @@ from pathlib import Path
 from app.notify import format_and_send
 
 
-# Number of failed recovery attempts before a mission is marked unrecoverable
-MAX_RECOVERY_ATTEMPTS = 3
-
 # Regex to parse and strip the [r:N] recovery counter tag from mission text.
 # Matches any content inside [r:...] (not just digits) so malformed tags
 # are still caught by strip/set operations.
 _RECOVERY_COUNTER_RE = re.compile(r"\s*\[r:([^\]]*)\]")
-
-
-# ---------------------------------------------------------------------------
-# Recovery counter helpers
-# ---------------------------------------------------------------------------
-
-def _get_recovery_attempts(mission_line: str) -> int:
-    """Parse the [r:N] counter from a mission line. Returns 0 if absent or malformed."""
-    m = _RECOVERY_COUNTER_RE.search(mission_line)
-    if not m:
-        return 0
-    try:
-        return int(m.group(1))
-    except (ValueError, TypeError):
-        return 0
-
-
-def _set_recovery_attempts(mission_line: str, n: int) -> str:
-    """Set the [r:N] counter in a mission line, replacing any existing one."""
-    line = _RECOVERY_COUNTER_RE.sub("", mission_line).rstrip()
-    return f"{line} [r:{n}]"
 
 
 def _strip_recovery_counter(mission_line: str) -> str:
@@ -73,7 +52,8 @@ def _strip_recovery_counter(mission_line: str) -> str:
 # ---------------------------------------------------------------------------
 
 def classify_mission_state(
-    mission_line: str,
+    crash_count: int = 0,
+    max_crash_retries: int = 3,
     has_pending_journal: bool = False,
     has_checkpoint: bool = False,
     total_attempts: int = 0,
@@ -87,19 +67,17 @@ def classify_mission_state(
         "dead"          — Standard crash, no special context. Simple recovery.
 
     Args:
-        mission_line: The raw mission text line.
+        crash_count: Number of crash recovery attempts so far (from tracker).
+        max_crash_retries: Maximum crash retries before escalation.
         has_pending_journal: True if a pending.md exists from an interrupted run.
         has_checkpoint: True if a structured checkpoint file exists for this mission.
-        total_attempts: Combined retry count across stagnation and crash-recovery
-            (from stagnation_monitor tracker). Used with max_total_retries.
-        max_total_retries: When > 0, escalate to "unrecoverable" if total_attempts
-            reaches this ceiling regardless of [r:N] counter value.
+        total_attempts: Total number of attempts (crash + stagnation) from tracker.
+        max_total_retries: Maximum total retries before escalation (0 = disabled).
 
     Returns:
         One of "unrecoverable", "partial", or "dead".
     """
-    attempts = _get_recovery_attempts(mission_line)
-    if attempts >= MAX_RECOVERY_ATTEMPTS:
+    if crash_count >= max_crash_retries:
         return "unrecoverable"
     if max_total_retries > 0 and total_attempts >= max_total_retries:
         return "unrecoverable"
@@ -185,7 +163,7 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     """Move stale in-progress missions back to pending or escalate to failed.
 
     Enhanced recovery with state classification:
-    - Simple stale missions (dead/partial): move back to Pending, increment [r:N]
+    - Simple stale missions (dead/partial): move back to Pending
     - Repeatedly failing missions (unrecoverable): move to Failed, notify human
 
     All events are logged to recovery.jsonl for forensics.
@@ -223,17 +201,24 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     except ImportError:
         _read_cp = None
 
-    # Load combined retry cap (max_total_retries) and stagnation tracker helpers.
-    # These are optional — if unavailable, the combined cap is simply not enforced.
+    # Load stagnation config for retry limits
     try:
         from app.config import get_stagnation_config as _get_stag_cfg
-        from app.stagnation_monitor import get_total_attempts as _get_total, increment_total_attempts as _inc_total
+        from app.stagnation_monitor import (
+            get_total_attempts as _get_total,
+            get_crash_count as _get_crash,
+            increment_crash_count as _inc_crash,
+        )
         _stagnation_cfg = _get_stag_cfg()
         _max_total_retries = int(_stagnation_cfg.get("max_total_retries", 0))
-    except Exception:
+        _max_crash_retries = int(_stagnation_cfg.get("max_crash_retries", 3))
+    except Exception as e:
+        print(f"[recover] Warning: could not load stagnation config or tracker: {e}", file=sys.stderr)
         _get_total = None
-        _inc_total = None
+        _get_crash = None
+        _inc_crash = None
         _max_total_retries = 0
+        _max_crash_retries = 3
 
     recovered_count = 0
     escalated_missions: list = []
@@ -263,6 +248,14 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
         complex_block_header: str = ""   # raw header line for current ### block
         complex_block_lines: list = []   # all lines in the current ### block
 
+        def _get_old_r_count(line: str) -> int:
+            m = _RECOVERY_COUNTER_RE.search(line)
+            if not m:
+                return 0
+            with contextlib.suppress(ValueError, TypeError):
+                return int(m.group(1))
+            return 0
+
         def _append_escalated_entry(out: list, m: str) -> None:
             """Append one escalated item to out, handling complex blocks (multi-line)."""
             if "\n" in m:
@@ -286,9 +279,17 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                 cp = _read_cp(instance_dir, clean_title)
                 has_checkpoint = cp is not None
 
+            old_r = _get_old_r_count(header)
+            crash_count = _get_crash(instance_dir, clean_title) if _get_crash else 0
+            # Backward compat: if [r:N] tag has higher count, use it for
+            # classification only — the tracker is NOT seeded from the legacy tag
+            if old_r > crash_count:
+                crash_count = old_r
             total = _get_total(instance_dir, clean_title) if _get_total else 0
+
             state = classify_mission_state(
-                header,
+                crash_count=crash_count,
+                max_crash_retries=_max_crash_retries,
                 has_pending_journal=journal_available,
                 has_checkpoint=has_checkpoint,
                 total_attempts=total,
@@ -297,30 +298,28 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
             if journal_available and state == "partial":
                 journal_available = False
 
-            attempts = _get_recovery_attempts(header)
-
             if dry_run:
                 print(f"[recover] [dry-run] mission={header!r:.60} state={state} "
-                      f"attempts={attempts} checkpoint={has_checkpoint}")
-                _log_recovery_event(instance_dir, header, state, "dry_run", attempts,
+                      f"attempts={crash_count} checkpoint={has_checkpoint}")
+                _log_recovery_event(instance_dir, header, state, "dry_run", crash_count,
                                     has_checkpoint=has_checkpoint)
                 remaining_in_progress.extend(complex_block_lines)
                 return
 
             if state == "unrecoverable":
                 escalated.append("\n".join(complex_block_lines))
-                _log_recovery_event(instance_dir, header, state, "escalated", attempts,
+                _log_recovery_event(instance_dir, header, state, "escalated", crash_count,
                                     has_checkpoint=has_checkpoint)
             else:
                 # Convert ### block to - item: extract_next_pending() treats ### as
                 # project sub-headers in Pending, which would fragment the block on
                 # the next mission pick. Use - format so it's picked up as a unit.
-                dash_line = _set_recovery_attempts(f"- {clean_title}", attempts + 1)
+                dash_line = f"- {clean_title}"
                 recovered.append(dash_line)
                 recovered_mission_texts.append(clean_title)
-                if _inc_total is not None:
-                    _inc_total(instance_dir, clean_title)
-                _log_recovery_event(instance_dir, header, state, "recovered", attempts + 1,
+                if _inc_crash is not None:
+                    _inc_crash(instance_dir, clean_title)
+                _log_recovery_event(instance_dir, header, state, "recovered", crash_count + 1,
                                     has_checkpoint=has_checkpoint)
 
         for i in range(in_progress_start + 1, in_progress_end):
@@ -348,8 +347,18 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                 continue
 
             if stripped.startswith("- ") and "~~" not in stripped:
-                # Extract clean mission text (no "- " prefix, no [r:N])
-                clean_text = _strip_recovery_counter(stripped).removeprefix("- ").strip()
+                old_r = _get_old_r_count(line)
+                clean_line = _strip_recovery_counter(line).rstrip()
+                clean_text = clean_line.removeprefix("- ").strip()
+
+                # Get crash_count from tracker
+                crash_count = _get_crash(instance_dir, clean_text) if _get_crash else 0
+                # Backward compat: if [r:N] tag has higher count, use it for
+                # classification only — the tracker is NOT seeded from the legacy tag
+                if old_r > crash_count:
+                    crash_count = old_r
+                total = _get_total(instance_dir, clean_text) if _get_total else 0
+
                 # Check for a structured checkpoint for this mission
                 has_checkpoint = False
                 if _read_cp is not None:
@@ -357,9 +366,9 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                     has_checkpoint = cp is not None
 
                 # Classify this mission; journal context is single-use
-                total = _get_total(instance_dir, clean_text) if _get_total else 0
                 state = classify_mission_state(
-                    line,
+                    crash_count=crash_count,
+                    max_crash_retries=_max_crash_retries,
                     has_pending_journal=journal_available,
                     has_checkpoint=has_checkpoint,
                     total_attempts=total,
@@ -369,9 +378,8 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                 if journal_available and state == "partial":
                     journal_available = False
 
-                attempts = _get_recovery_attempts(line)
-
                 if dry_run:
+                    attempts = crash_count
                     print(f"[recover] [dry-run] mission={stripped!r:.60} state={state} "
                           f"attempts={attempts} checkpoint={has_checkpoint}")
                     _log_recovery_event(instance_dir, line, state, "dry_run", attempts,
@@ -381,16 +389,15 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
 
                 if state == "unrecoverable":
                     escalated.append(line)
-                    _log_recovery_event(instance_dir, line, state, "escalated", attempts,
+                    _log_recovery_event(instance_dir, line, state, "escalated", crash_count,
                                         has_checkpoint=has_checkpoint)
                 else:
-                    # Increment counter and move to Pending
-                    updated_line = _set_recovery_attempts(line, attempts + 1)
-                    recovered.append(updated_line)
+                    # Move to Pending (clean line, no [r:N] tag)
+                    recovered.append(clean_line)
                     recovered_mission_texts.append(clean_text)
-                    if _inc_total is not None:
-                        _inc_total(instance_dir, clean_text)
-                    _log_recovery_event(instance_dir, line, state, "recovered", attempts + 1,
+                    if _inc_crash is not None:
+                        _inc_crash(instance_dir, clean_text)
+                    _log_recovery_event(instance_dir, line, state, "recovered", crash_count + 1,
                                         has_checkpoint=has_checkpoint)
 
             elif stripped == "(aucune)" or stripped == "(none)":
@@ -541,7 +548,7 @@ if __name__ == "__main__":
                 escalated_summary += f" (+{len(escalated_msgs) - 3} more)"
             needs_input_msg = (
                 f"⚠️ Recovery escalation: {len(escalated_msgs)} mission(s) failed "
-                f"{MAX_RECOVERY_ATTEMPTS} recovery attempts and need human review:\n"
+                f"the maximum number of recovery attempts and need human review:\n"
                 f"{escalated_summary}"
             )
             format_and_send(needs_input_msg)

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -52,6 +52,7 @@ def _strip_recovery_counter(mission_line: str) -> str:
 # ---------------------------------------------------------------------------
 
 def classify_mission_state(
+    *,
     crash_count: int = 0,
     max_crash_retries: int = 3,
     has_pending_journal: bool = False,
@@ -208,6 +209,7 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
             get_total_attempts as _get_total,
             get_crash_count as _get_crash,
             increment_crash_count as _inc_crash,
+            seed_crash_count as _seed_crash,
         )
         _stagnation_cfg = _get_stag_cfg()
         _max_total_retries = int(_stagnation_cfg.get("max_total_retries", 0))
@@ -217,6 +219,7 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
         _get_total = None
         _get_crash = None
         _inc_crash = None
+        _seed_crash = None
         _max_total_retries = 0
         _max_crash_retries = 3
 
@@ -281,10 +284,14 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
 
             old_r = _get_old_r_count(header)
             crash_count = _get_crash(instance_dir, clean_title) if _get_crash else 0
-            # Backward compat: if [r:N] tag has higher count, use it for
-            # classification only — the tracker is NOT seeded from the legacy tag
+            # Backward compat: if a legacy [r:N] tag carries a higher count than
+            # the tracker, seed it into the tracker so the migrated count survives
+            # this recovery cycle (without seeding, the next cycle would read only
+            # the freshly-incremented tracker value, granting one extra retry).
             if old_r > crash_count:
                 crash_count = old_r
+                if _seed_crash is not None:
+                    _seed_crash(instance_dir, clean_title, old_r)
             total = _get_total(instance_dir, clean_title) if _get_total else 0
 
             state = classify_mission_state(
@@ -353,10 +360,15 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
 
                 # Get crash_count from tracker
                 crash_count = _get_crash(instance_dir, clean_text) if _get_crash else 0
-                # Backward compat: if [r:N] tag has higher count, use it for
-                # classification only — the tracker is NOT seeded from the legacy tag
+                # Backward compat: if a legacy [r:N] tag carries a higher count
+                # than the tracker, seed it into the tracker so the migrated count
+                # survives this recovery cycle (without seeding, the next cycle
+                # would read only the freshly-incremented tracker value, granting
+                # one extra retry).
                 if old_r > crash_count:
                     crash_count = old_r
+                    if _seed_crash is not None:
+                        _seed_crash(instance_dir, clean_text, old_r)
                 total = _get_total(instance_dir, clean_text) if _get_total else 0
 
                 # Check for a structured checkpoint for this mission

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -14,7 +14,11 @@ Recovery attempts are now tracked in the stagnation_monitor tracker
 [r:N] tag embedded in mission text is still supported for backward
 compatibility — if a mission carries an [r:N] tag from a previous Kōan
 version and that count exceeds the tracker value, the tag value is used
-instead. New missions will not have [r:N] tags written back to missions.md.
+instead. Normally [r:N] tags are not written back to missions.md (the
+tracker owns the count). The one exception is the degraded path: if the
+tracker module fails to import, recovery falls back to persisting the
+incremented count inline as [r:N] so escalation still progresses instead
+of resetting to 0 every cycle.
 
 All recovery events are logged to instance/recovery.jsonl for forensics.
 
@@ -45,6 +49,17 @@ _RECOVERY_COUNTER_RE = re.compile(r"\s*\[r:([^\]]*)\]")
 def _strip_recovery_counter(mission_line: str) -> str:
     """Remove the [r:N] counter from a mission line for clean display."""
     return _RECOVERY_COUNTER_RE.sub("", mission_line).rstrip()
+
+
+def _set_recovery_counter(mission_line: str, count: int) -> str:
+    """Return *mission_line* with any existing [r:N] replaced by [r:count].
+
+    Used only in the degraded path where the stagnation tracker is unavailable:
+    the crash count must then be persisted inline so the next recovery cycle
+    sees a higher value and escalation still progresses (otherwise the count
+    resets to 0 every cycle and the mission retries forever).
+    """
+    return f"{_strip_recovery_counter(mission_line)} [r:{count}]"
 
 
 # ---------------------------------------------------------------------------
@@ -202,26 +217,44 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     except ImportError:
         _read_cp = None
 
-    # Load stagnation config for retry limits
+    # Retry limits and the crash tracker are loaded as two SEPARATE concerns,
+    # because they fail differently:
+    #
+    #  1. Config load — safe to fall back to defaults. The defaults below match
+    #     get_stagnation_config()'s own defaults, so escalation still works.
+    #  2. Tracker functions — these are the escalation safety net. If they fail
+    #     and we silently set everything to 0/None, classify_mission_state can
+    #     NEVER return "unrecoverable" (crash_count is always 0, max_total is 0),
+    #     so a repeatedly crashing mission loops Pending→crash→Pending forever.
+    #     When the tracker is unavailable we fall back to the legacy inline
+    #     [r:N] counter (read by _get_old_r_count, persisted via
+    #     _set_recovery_counter) as the sole crash-count rail so escalation
+    #     still progresses.
     try:
         from app.config import get_stagnation_config as _get_stag_cfg
+        _stagnation_cfg = _get_stag_cfg()
+        _max_total_retries = int(_stagnation_cfg.get("max_total_retries", 0))
+        _max_crash_retries = int(_stagnation_cfg.get("max_crash_retries", 3))
+    except Exception as e:
+        print(f"[recover] Warning: could not load stagnation config; using defaults: {e}",
+              file=sys.stderr)
+        _max_total_retries = 0
+        _max_crash_retries = 3
+
+    try:
         from app.stagnation_monitor import (
             get_total_attempts as _get_total,
             get_crash_count as _get_crash,
             increment_crash_count as _inc_crash,
             seed_crash_count as _seed_crash,
         )
-        _stagnation_cfg = _get_stag_cfg()
-        _max_total_retries = int(_stagnation_cfg.get("max_total_retries", 0))
-        _max_crash_retries = int(_stagnation_cfg.get("max_crash_retries", 3))
     except Exception as e:
-        print(f"[recover] Warning: could not load stagnation config or tracker: {e}", file=sys.stderr)
+        print(f"[recover] Warning: retry tracker unavailable; falling back to inline "
+              f"[r:N] counter so escalation still works: {e}", file=sys.stderr)
         _get_total = None
         _get_crash = None
         _inc_crash = None
         _seed_crash = None
-        _max_total_retries = 0
-        _max_crash_retries = 3
 
     recovered_count = 0
     escalated_missions: list = []
@@ -322,10 +355,15 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                 # project sub-headers in Pending, which would fragment the block on
                 # the next mission pick. Use - format so it's picked up as a unit.
                 dash_line = f"- {clean_title}"
-                recovered.append(dash_line)
-                recovered_mission_texts.append(clean_title)
                 if _inc_crash is not None:
                     _inc_crash(instance_dir, clean_title)
+                else:
+                    # Degraded mode (no tracker): persist the incremented count
+                    # inline so the next crash sees a higher [r:N] and escalation
+                    # still progresses instead of resetting to 0 each cycle.
+                    dash_line = _set_recovery_counter(dash_line, crash_count + 1)
+                recovered.append(dash_line)
+                recovered_mission_texts.append(clean_title)
                 _log_recovery_event(instance_dir, header, state, "recovered", crash_count + 1,
                                     has_checkpoint=has_checkpoint)
 
@@ -404,11 +442,16 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                     _log_recovery_event(instance_dir, line, state, "escalated", crash_count,
                                         has_checkpoint=has_checkpoint)
                 else:
-                    # Move to Pending (clean line, no [r:N] tag)
-                    recovered.append(clean_line)
-                    recovered_mission_texts.append(clean_text)
                     if _inc_crash is not None:
+                        # Tracker holds the count — move to Pending clean (no [r:N]).
                         _inc_crash(instance_dir, clean_text)
+                        recovered.append(clean_line)
+                    else:
+                        # Degraded mode (no tracker): persist the incremented count
+                        # inline so the next crash sees a higher [r:N] and escalation
+                        # still progresses instead of resetting to 0 each cycle.
+                        recovered.append(_set_recovery_counter(clean_line, crash_count + 1))
+                    recovered_mission_texts.append(clean_text)
                     _log_recovery_event(instance_dir, line, state, "recovered", crash_count + 1,
                                         has_checkpoint=has_checkpoint)
 

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -76,6 +76,8 @@ def classify_mission_state(
     mission_line: str,
     has_pending_journal: bool = False,
     has_checkpoint: bool = False,
+    total_attempts: int = 0,
+    max_total_retries: int = 0,
 ) -> str:
     """Classify a stale in-progress mission's recovery state.
 
@@ -88,12 +90,18 @@ def classify_mission_state(
         mission_line: The raw mission text line.
         has_pending_journal: True if a pending.md exists from an interrupted run.
         has_checkpoint: True if a structured checkpoint file exists for this mission.
+        total_attempts: Combined retry count across stagnation and crash-recovery
+            (from stagnation_monitor tracker). Used with max_total_retries.
+        max_total_retries: When > 0, escalate to "unrecoverable" if total_attempts
+            reaches this ceiling regardless of [r:N] counter value.
 
     Returns:
         One of "unrecoverable", "partial", or "dead".
     """
     attempts = _get_recovery_attempts(mission_line)
     if attempts >= MAX_RECOVERY_ATTEMPTS:
+        return "unrecoverable"
+    if max_total_retries > 0 and total_attempts >= max_total_retries:
         return "unrecoverable"
     if has_checkpoint or has_pending_journal:
         return "partial"
@@ -215,6 +223,18 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     except ImportError:
         _read_cp = None
 
+    # Load combined retry cap (max_total_retries) and stagnation tracker helpers.
+    # These are optional — if unavailable, the combined cap is simply not enforced.
+    try:
+        from app.config import get_stagnation_config as _get_stag_cfg
+        from app.stagnation_monitor import get_total_attempts as _get_total, increment_total_attempts as _inc_total
+        _stagnation_cfg = _get_stag_cfg()
+        _max_total_retries = int(_stagnation_cfg.get("max_total_retries", 0))
+    except Exception:
+        _get_total = None
+        _inc_total = None
+        _max_total_retries = 0
+
     recovered_count = 0
     escalated_missions: list = []
     recovered_mission_texts: list = []  # clean mission texts for checkpoint lookup
@@ -266,10 +286,13 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                 cp = _read_cp(instance_dir, clean_title)
                 has_checkpoint = cp is not None
 
+            total = _get_total(instance_dir, clean_title) if _get_total else 0
             state = classify_mission_state(
                 header,
                 has_pending_journal=journal_available,
                 has_checkpoint=has_checkpoint,
+                total_attempts=total,
+                max_total_retries=_max_total_retries,
             )
             if journal_available and state == "partial":
                 journal_available = False
@@ -295,6 +318,8 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                 dash_line = _set_recovery_attempts(f"- {clean_title}", attempts + 1)
                 recovered.append(dash_line)
                 recovered_mission_texts.append(clean_title)
+                if _inc_total is not None:
+                    _inc_total(instance_dir, clean_title)
                 _log_recovery_event(instance_dir, header, state, "recovered", attempts + 1,
                                     has_checkpoint=has_checkpoint)
 
@@ -332,10 +357,13 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                     has_checkpoint = cp is not None
 
                 # Classify this mission; journal context is single-use
+                total = _get_total(instance_dir, clean_text) if _get_total else 0
                 state = classify_mission_state(
                     line,
                     has_pending_journal=journal_available,
                     has_checkpoint=has_checkpoint,
+                    total_attempts=total,
+                    max_total_retries=_max_total_retries,
                 )
                 # Once a mission claims the journal context, mark it consumed
                 if journal_available and state == "partial":
@@ -360,6 +388,8 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
                     updated_line = _set_recovery_attempts(line, attempts + 1)
                     recovered.append(updated_line)
                     recovered_mission_texts.append(clean_text)
+                    if _inc_total is not None:
+                        _inc_total(instance_dir, clean_text)
                     _log_recovery_event(instance_dir, line, state, "recovered", attempts + 1,
                                         has_checkpoint=has_checkpoint)
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1766,7 +1766,7 @@ def _reset_usage_session(instance: str):
         log("error", f"Usage session reset failed: {e}")
 
 
-def _clear_if_cap_hit(instance: str, mission_title: str) -> None:
+def _clear_if_cap_hit(instance: str, mission_title: str, project_name: str = "") -> bool:
     """Clear retry counter when a capped mission is being restarted by the human.
 
     The retry counter is preserved while a mission is in Failed state so the
@@ -1777,41 +1777,63 @@ def _clear_if_cap_hit(instance: str, mission_title: str) -> None:
 
     For ongoing stagnation-retry requeus (count < cap) the counter is NOT
     cleared — the stagnation cap check in _finalize_mission depends on it.
+
+    *project_name* must match the value _finalize_mission uses so the cap
+    detection here reads the same per-project overrides; passing "" (global
+    config) when the mission has project-specific caps would diverge — a
+    human retry could be silently ignored.
+
+    Returns True when nothing needed clearing or the counter was cleared
+    successfully; returns False when a cap was hit but clearing the counter
+    failed (the caller should warn prominently — the mission will re-escalate
+    to Failed on the next finalize).
+
+    Only ImportError is caught (retry tracking simply unavailable). Schema
+    mismatches in get_retry_info/get_stagnation_config are allowed to propagate
+    so genuine bugs surface rather than being silently swallowed; the caller
+    guards the call so such an error cannot abort an already-started mission.
     """
     try:
         from app.stagnation_monitor import clear_retry_count, get_retry_info
-
-        # Hot path: this runs on every mission start, including brand-new
-        # missions that have never been retried. Read the tracker once and bail
-        # before loading config when there is no entry (all counts zero) — those
-        # missions can never have hit a cap, so there is nothing to clear.
-        info = get_retry_info(instance, mission_title)
-        stag_count = info["count"]
-        crash_count = info["crash_count"]
-        total = info["total_attempts"]
-        if not (stag_count or crash_count or total):
-            return
-
         from app.config import get_stagnation_config
-        cfg = get_stagnation_config()
-        # get_stagnation_config() always returns every key, so read them directly:
-        # fallback defaults here would silently drift from the centralized config
-        # defaults if those ever change.
-        max_stag = cfg["max_retry_on_stagnation"]
-        max_crash = cfg["max_crash_retries"]
-        max_total = cfg["max_total_retries"]
+    except ImportError as e:
+        # Retry tracking unavailable — there is nothing to clear.
+        log("error", f"Retry counter clear skipped (import failed): {e}")
+        return True
 
-        stag_capped = max_stag > 0 and stag_count >= max_stag
-        crash_capped = crash_count >= max_crash
-        total_capped = max_total > 0 and total >= max_total
+    # Hot path: this runs on every mission start, including brand-new
+    # missions that have never been retried. Read the tracker once and bail
+    # before loading config when there is no entry (all counts zero) — those
+    # missions can never have hit a cap, so there is nothing to clear.
+    info = get_retry_info(instance, mission_title)
+    stag_count = info["count"]
+    crash_count = info["crash_count"]
+    total = info["total_attempts"]
+    if not (stag_count or crash_count or total):
+        return True
 
-        if stag_capped or crash_capped or total_capped:
+    cfg = get_stagnation_config(project_name)
+    # get_stagnation_config() always returns every key, so read them directly:
+    # fallback defaults here would silently drift from the centralized config
+    # defaults if those ever change.
+    max_stag = cfg["max_retry_on_stagnation"]
+    max_crash = cfg["max_crash_retries"]
+    max_total = cfg["max_total_retries"]
+
+    stag_capped = max_stag > 0 and stag_count >= max_stag
+    crash_capped = crash_count >= max_crash
+    total_capped = max_total > 0 and total >= max_total
+
+    if stag_capped or crash_capped or total_capped:
+        try:
             clear_retry_count(instance, mission_title)
-    except Exception as e:
-        log("error", f"Retry counter clear failed: {e}")
+        except Exception as e:
+            log("error", f"Retry counter clear failed for capped mission: {e}")
+            return False
+    return True
 
 
-def _start_mission_in_file(instance: str, mission_title: str) -> bool:
+def _start_mission_in_file(instance: str, mission_title: str, project_name: str = "") -> bool:
     """Move mission from Pending to In Progress via locked write.
 
     Returns True if the transition was confirmed (mission visible in In Progress
@@ -1836,7 +1858,19 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
                 # Clear counter only if a cap was previously hit (human deliberate
                 # retry) — stagnation-retry requeus must keep their count intact
                 # so the stagnation cap check in _finalize_mission still fires.
-                _clear_if_cap_hit(instance, mission_title)
+                # The transition above already succeeded, so a failure to clear
+                # the counter must NOT abort the start; surface it as a prominent
+                # warning instead, since the mission will otherwise re-escalate to
+                # Failed on the next finalize.
+                try:
+                    if not _clear_if_cap_hit(instance, mission_title, project_name):
+                        log("warning",
+                            f"Retry counter NOT cleared for '{clean_title[:60]}' — "
+                            "clear failed; mission may re-escalate to Failed on next finalize.")
+                except Exception as e:
+                    log("warning",
+                        f"Retry counter clear errored for '{clean_title[:60]}' ({e}); "
+                        "mission may re-escalate to Failed on next finalize.")
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
             "not found in In Progress after start_mission(). "

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1779,20 +1779,27 @@ def _clear_if_cap_hit(instance: str, mission_title: str) -> None:
     cleared — the stagnation cap check in _finalize_mission depends on it.
     """
     try:
+        from app.stagnation_monitor import clear_retry_count, get_retry_info
+
+        # Hot path: this runs on every mission start, including brand-new
+        # missions that have never been retried. Read the tracker once and bail
+        # before loading config when there is no entry (all counts zero) — those
+        # missions can never have hit a cap, so there is nothing to clear.
+        info = get_retry_info(instance, mission_title)
+        stag_count = info["count"]
+        crash_count = info["crash_count"]
+        total = info["total_attempts"]
+        if not (stag_count or crash_count or total):
+            return
+
         from app.config import get_stagnation_config
-        from app.stagnation_monitor import (
-            clear_retry_count,
-            get_crash_count,
-            get_retry_count,
-            get_total_attempts,
-        )
         cfg = get_stagnation_config()
-        max_stag = int(cfg.get("max_retry_on_stagnation", 0))
-        max_crash = int(cfg.get("max_crash_retries", 3))
-        max_total = int(cfg.get("max_total_retries", 0))
-        stag_count = get_retry_count(instance, mission_title)
-        crash_count = get_crash_count(instance, mission_title)
-        total = get_total_attempts(instance, mission_title)
+        # get_stagnation_config() always returns every key, so read them directly:
+        # fallback defaults here would silently drift from the centralized config
+        # defaults if those ever change.
+        max_stag = cfg["max_retry_on_stagnation"]
+        max_crash = cfg["max_crash_retries"]
+        max_total = cfg["max_total_retries"]
 
         stag_capped = max_stag > 0 and stag_count >= max_stag
         crash_capped = crash_count >= max_crash
@@ -1972,7 +1979,7 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
         # Retry cap reached (or retries disabled): mark Failed with cause tag.
         # Counter is preserved — cleared when the human retries the mission.
         if total_cap_hit:
-            cause_tag = f"stagnation:{pattern}:total_cap"
+            cause_tag = f"stagnation:{pattern}:total_cap({total}/{max_total})"
         else:
             cause_tag = f"stagnation:{pattern}"
         _notify_stagnation(mission_title, project_name, pattern, excerpt)

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1766,6 +1766,44 @@ def _reset_usage_session(instance: str):
         log("error", f"Usage session reset failed: {e}")
 
 
+def _clear_if_cap_hit(instance: str, mission_title: str) -> None:
+    """Clear retry counter when a capped mission is being restarted by the human.
+
+    The retry counter is preserved while a mission is in Failed state so the
+    human can inspect the count. This function clears it when start_mission()
+    signals a deliberate human retry: we detect a "human retry" by checking
+    whether any per-system cap was hit (stagnation count >= max_retry, or
+    crash_count >= max_crash_retries, or total_attempts >= max_total_retries).
+
+    For ongoing stagnation-retry requeus (count < cap) the counter is NOT
+    cleared — the stagnation cap check in _finalize_mission depends on it.
+    """
+    try:
+        from app.config import get_stagnation_config
+        from app.stagnation_monitor import (
+            clear_retry_count,
+            get_crash_count,
+            get_retry_count,
+            get_total_attempts,
+        )
+        cfg = get_stagnation_config()
+        max_stag = int(cfg.get("max_retry_on_stagnation", 0))
+        max_crash = int(cfg.get("max_crash_retries", 3))
+        max_total = int(cfg.get("max_total_retries", 0))
+        stag_count = get_retry_count(instance, mission_title)
+        crash_count = get_crash_count(instance, mission_title)
+        total = get_total_attempts(instance, mission_title)
+
+        stag_capped = max_stag > 0 and stag_count >= max_stag
+        crash_capped = crash_count >= max_crash
+        total_capped = max_total > 0 and total >= max_total
+
+        if stag_capped or crash_capped or total_capped:
+            clear_retry_count(instance, mission_title)
+    except Exception as e:
+        log("error", f"Retry counter clear failed: {e}")
+
+
 def _start_mission_in_file(instance: str, mission_title: str) -> bool:
     """Move mission from Pending to In Progress via locked write.
 
@@ -1788,6 +1826,10 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
         for entry in in_progress:
             entry_text = re.sub(r"\s+", " ", entry.strip().removeprefix("- "))
             if clean_title in entry_text:
+                # Clear counter only if a cap was previously hit (human deliberate
+                # retry) — stagnation-retry requeus must keep their count intact
+                # so the stagnation cap check in _finalize_mission still fires.
+                _clear_if_cap_hit(instance, mission_title)
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
             "not found in In Progress after start_mission(). "
@@ -1874,12 +1916,13 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
       re-queued to Pending (not failed), the counter is incremented,
       and a "retry" Telegram notification is sent;
     - once the cap is reached, the mission is marked Failed with a
-      ``[stagnation]`` tag, the counter is cleared, and the regular
-      stagnation notification is sent.
+      ``[stagnation]`` tag. The counter is preserved so the human can
+      inspect it while the mission sits in Failed. It is cleared when
+      the human deliberately retries via ``_start_mission_in_file``.
 
-    Successful completions and non-stagnation failures clear any
-    pending retry counter so the next attempt at the same mission
-    title starts fresh.
+    On success, all retry counters are cleared. On failure (stagnation
+    cap or crash) the counters are left intact for diagnostic visibility
+    while the mission remains in Failed state.
     """
     failed = exit_code != 0
     cause_tag = ""
@@ -1891,7 +1934,6 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
     if stagnated:
         from app.config import get_stagnation_config
         from app.stagnation_monitor import (
-            clear_retry_count,
             get_retry_count,
             get_total_attempts,
             increment_retry_count,
@@ -1928,21 +1970,22 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
             return
 
         # Retry cap reached (or retries disabled): mark Failed with cause tag.
+        # Counter is preserved — cleared when the human retries the mission.
         if total_cap_hit:
             cause_tag = f"stagnation:{pattern}:total_cap"
         else:
             cause_tag = f"stagnation:{pattern}"
-        clear_retry_count(instance, mission_title)
         _notify_stagnation(mission_title, project_name, pattern, excerpt)
     else:
-        # A non-stagnation outcome resets the stagnation-specific counter.
-        # total_attempts is preserved (clear_total=False) so the cross-system
-        # cap (max_total_retries) remains effective across crash-recovery cycles.
-        try:
-            from app.stagnation_monitor import clear_retry_count
-            clear_retry_count(instance, mission_title, clear_total=(exit_code == 0))
-        except Exception as e:
-            log("error", f"Stagnation retry counter cleanup error: {e}")
+        # On success, clear all retry counters so the next run starts fresh.
+        # On failure, leave counters intact so the human can see why the
+        # mission ended up in Failed while inspecting .mission-retries.json.
+        if exit_code == 0:
+            try:
+                from app.stagnation_monitor import clear_retry_count
+                clear_retry_count(instance, mission_title)
+            except Exception as e:
+                log("error", f"Stagnation retry counter cleanup error: {e}")
 
     _update_mission_in_file(
         instance, mission_title, failed=failed, cause_tag=cause_tag,

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1893,6 +1893,7 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
         from app.stagnation_monitor import (
             clear_retry_count,
             get_retry_count,
+            get_total_attempts,
             increment_retry_count,
         )
 
@@ -1901,8 +1902,11 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
 
         cfg = get_stagnation_config(project_name)
         max_retry = int(cfg.get("max_retry_on_stagnation", 0))
+        max_total = int(cfg.get("max_total_retries", 0))
         already = get_retry_count(instance, mission_title)
-        if max_retry > 0 and already < max_retry:
+        total = get_total_attempts(instance, mission_title)
+        total_cap_hit = max_total > 0 and total >= max_total
+        if max_retry > 0 and already < max_retry and not total_cap_hit:
             new_count = increment_retry_count(
                 instance, mission_title,
                 pattern_type=pattern, pattern_excerpt=excerpt,
@@ -1924,16 +1928,19 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
             return
 
         # Retry cap reached (or retries disabled): mark Failed with cause tag.
-        cause_tag = f"stagnation:{pattern}"
+        if total_cap_hit:
+            cause_tag = f"stagnation:{pattern}:total_cap"
+        else:
+            cause_tag = f"stagnation:{pattern}"
         clear_retry_count(instance, mission_title)
         _notify_stagnation(mission_title, project_name, pattern, excerpt)
     else:
-        # A non-stagnation outcome resets any prior retry counter so a
-        # mission that completes (or fails for a different reason) does
-        # not carry stale stagnation state into a later attempt.
+        # A non-stagnation outcome resets the stagnation-specific counter.
+        # total_attempts is preserved (clear_total=False) so the cross-system
+        # cap (max_total_retries) remains effective across crash-recovery cycles.
         try:
             from app.stagnation_monitor import clear_retry_count
-            clear_retry_count(instance, mission_title)
+            clear_retry_count(instance, mission_title, clear_total=(exit_code == 0))
         except Exception as e:
             log("error", f"Stagnation retry counter cleanup error: {e}")
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1868,9 +1868,15 @@ def _start_mission_in_file(instance: str, mission_title: str, project_name: str 
                             f"Retry counter NOT cleared for '{clean_title[:60]}' — "
                             "clear failed; mission may re-escalate to Failed on next finalize.")
                 except Exception as e:
-                    log("warning",
+                    # _clear_if_cap_hit only catches ImportError internally and lets
+                    # schema mismatches (e.g. a missing get_retry_info key) propagate —
+                    # those are real bugs, so log at error level with a traceback
+                    # rather than burying them in a warning.
+                    import traceback
+                    log("error",
                         f"Retry counter clear errored for '{clean_title[:60]}' ({e}); "
-                        "mission may re-escalate to Failed on next finalize.")
+                        "mission may re-escalate to Failed on next finalize.\n"
+                        f"{traceback.format_exc()}")
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
             "not found in In Progress after start_mission(). "
@@ -1984,8 +1990,13 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str, exit
         excerpt = _stagnation_pattern_excerpt or ""
 
         cfg = get_stagnation_config(project_name)
-        max_retry = int(cfg.get("max_retry_on_stagnation", 0))
-        max_total = int(cfg.get("max_total_retries", 0))
+        # Direct key access (no .get() fallback): get_stagnation_config() always
+        # returns every key, so a missing key is a real schema bug that should
+        # surface loudly rather than silently defaulting — and a `0` fallback for
+        # max_retry_on_stagnation would be semantically wrong (0 disables retries;
+        # the actual default is 3). Consistent with _clear_if_cap_hit.
+        max_retry = cfg["max_retry_on_stagnation"]
+        max_total = cfg["max_total_retries"]
         already = get_retry_count(instance, mission_title)
         total = get_total_attempts(instance, mission_title)
         total_cap_hit = max_total > 0 and total >= max_total

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -363,10 +363,28 @@ class StagnationMonitor:
 # Per-mission retry tracking
 # ---------------------------------------------------------------------------
 #
-# When a mission stagnates, we don't want to fail it outright on the first
-# detection — Claude can be unstuck by a fresh start. The tracker records
-# how many times each mission has stagnated so :func:`run._finalize_mission`
-# can decide between "requeue and try again" and "give up, mark Failed".
+# Two failure modes can interrupt a mission mid-run: stagnation (Claude loops
+# without progress, killed by this monitor) and crash (run.py unexpectedly
+# terminates, recovered by recover.py at next startup).  Both share a single
+# tracker file (.mission-retries.json) so one combined cap can guard against
+# infinite requeue cycles regardless of which failure mode triggered each retry.
+#
+# Tracker entry structure (one entry per mission key):
+#   {
+#     "count":          <int>  # stagnation-only requeues (reset on success)
+#     "crash_count":    <int>  # crash-recovery requeues (reset on success)
+#     "total_attempts": <int>  # count + crash_count; only cap that combines both
+#     "pattern_type":   <str>  # optional: stagnation classification (last event)
+#     "sample_lines":   <int>  # optional: tail-window used for last classification
+#   }
+#
+# When to increment which counter:
+#   - ``count`` / ``total_attempts`` — :func:`increment_retry_count`, called by
+#     :func:`run._finalize_mission` on each stagnation-triggered requeue.
+#   - ``crash_count`` / ``total_attempts`` — :func:`increment_crash_count`, called
+#     by :func:`recover.recover_missions` each time a crash is detected at startup.
+#   - Both counters are cleared on genuine success (zero exit, not stagnation).
+#
 # Counters are keyed by a stable SHA-256 of the *clean* mission title —
 # stripped of lifecycle markers (timestamps, recovery counters, complexity
 # tags) — so the SAME logical mission maps to the SAME key across requeue

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -385,6 +385,19 @@ class StagnationMonitor:
 #     by :func:`recover.recover_missions` each time a crash is detected at startup.
 #   - Both counters are cleared on genuine success (zero exit, not stagnation).
 #
+# Counter lifetime / known limitation:
+#   Counters are intentionally PRESERVED when a mission ends in Failed (cap hit,
+#   crash escalation, or any non-stagnation, non-zero exit) so the human can
+#   inspect why it failed. They are cleared only on (a) genuine success, or
+#   (b) a deliberate human retry, detected in run._clear_if_cap_hit when a cap
+#   was previously hit. Consequently a mission that fails for a non-stagnation
+#   reason and is then *manually* removed/edited in missions.md (never going
+#   back through start_mission) leaves an orphan entry here indefinitely. There
+#   is no age-based expiry; entries are keyed by mission-title hash, so this
+#   grows at most one stale entry per such mission and is harmless beyond a
+#   slowly-growing JSON file. Reap manually by deleting .mission-retries.json
+#   (it is rebuilt lazily) if it ever grows unwieldy.
+#
 # Counters are keyed by a stable SHA-256 of the *clean* mission title —
 # stripped of lifecycle markers (timestamps, recovery counters, complexity
 # tags) — so the SAME logical mission maps to the SAME key across requeue

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -31,6 +31,7 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 import re
@@ -52,7 +53,8 @@ _CLASSIFY_TAIL_LINES = 100        # lines to read for pattern classification
 # Filename of the per-mission stagnation retry tracker (lives under
 # instance/). Persists across restarts so a stagnated mission requeued
 # right before a crash doesn't lose its retry count.
-_RETRY_TRACKER_FILENAME = ".stagnation-retries.json"
+_RETRY_TRACKER_FILENAME = ".mission-retries.json"
+_RETRY_TRACKER_OLD_FILENAME = ".stagnation-retries.json"
 
 
 def _read_tail(stdout_file: str, lines: int) -> Optional[bytes]:
@@ -383,8 +385,22 @@ _STRIP_FOR_KEY_RE = re.compile(
 )
 
 
+def _migrate_tracker_filename(instance_dir: str) -> None:
+    """Rename old .stagnation-retries.json to .mission-retries.json if needed.
+
+    One-shot migration: runs at path-resolution time so any existing tracker
+    data is preserved across the rename without operator intervention.
+    """
+    old = Path(instance_dir) / _RETRY_TRACKER_OLD_FILENAME
+    new = Path(instance_dir) / _RETRY_TRACKER_FILENAME
+    if old.exists() and not new.exists():
+        with contextlib.suppress(OSError):
+            old.rename(new)
+
+
 def _retry_tracker_path(instance_dir: str) -> Path:
     """Path to the per-instance stagnation retry counter file."""
+    _migrate_tracker_filename(instance_dir)
     return Path(instance_dir) / _RETRY_TRACKER_FILENAME
 
 
@@ -425,6 +441,94 @@ def get_retry_count(instance_dir: str, mission_title: str) -> int:
     return _extract_count(data.get(_mission_key(mission_title), 0))
 
 
+def get_crash_count(instance_dir: str, mission_title: str) -> int:
+    """Return how many times *mission_title* has been crash-recovery requeued.
+
+    Tracks only crash-recovery requeues (from recover.py), not stagnation
+    requeues. Used by crash recovery to decide when to escalate to Failed.
+    """
+    path = _retry_tracker_path(instance_dir)
+    data = locked_json_read(path, default={})
+    if not isinstance(data, dict):
+        return 0
+    raw = data.get(_mission_key(mission_title), {})
+    if isinstance(raw, dict):
+        try:
+            return max(0, int(raw.get("crash_count", 0)))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def increment_crash_count(instance_dir: str, mission_title: str) -> int:
+    """Increment both crash_count and total_attempts for *mission_title*.
+
+    Called by crash-recovery (recover.py) when a mission is requeued after
+    a crash, so that both the per-system crash cap and the combined
+    max_total_retries cap remain effective.
+
+    Returns the new crash_count value.
+    """
+    path = _retry_tracker_path(instance_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = _mission_key(mission_title)
+
+    def _mutate(data: dict) -> int:
+        existing = data.get(key, {})
+        total = max(0, int(existing.get("total_attempts", 0))) if isinstance(existing, dict) else 0
+        crash = max(0, int(existing.get("crash_count", 0))) if isinstance(existing, dict) else 0
+        new_crash = crash + 1
+        new_total = total + 1
+        if isinstance(existing, dict):
+            data[key] = {**existing, "crash_count": new_crash, "total_attempts": new_total}
+        else:
+            data[key] = {
+                "count": _extract_count(existing),
+                "crash_count": new_crash,
+                "total_attempts": new_total,
+            }
+        return new_crash
+
+    try:
+        return locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
+    except OSError as e:
+        print(f"[stagnation_monitor] crash_count save error: {e}", file=sys.stderr)
+        return 1
+
+
+def seed_crash_count(instance_dir: str, mission_title: str, seed_value: int) -> None:
+    """Set crash_count to at least *seed_value* without changing total_attempts.
+
+    Used during backward-compat migration when a mission carries an [r:N] tag
+    from an older Kōan version. The seed does NOT bump total_attempts because
+    these are historical attempt counts already captured in the legacy tag;
+    only the subsequent real increment (via increment_crash_count) adds to total.
+
+    No-op if the current crash_count is already >= seed_value.
+    """
+    if seed_value <= 0:
+        return
+    path = _retry_tracker_path(instance_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = _mission_key(mission_title)
+
+    def _mutate(data: dict) -> None:
+        existing = data.get(key, {})
+        crash = max(0, int(existing.get("crash_count", 0))) if isinstance(existing, dict) else 0
+        if seed_value <= crash:
+            return  # already at or above seed value
+        if isinstance(existing, dict):
+            data[key] = {**existing, "crash_count": seed_value}
+        else:
+            data[key] = {
+                "count": _extract_count(existing),
+                "crash_count": seed_value,
+            }
+
+    with contextlib.suppress(OSError):
+        locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
+
+
 def get_total_attempts(instance_dir: str, mission_title: str) -> int:
     """Return total retry attempts across stagnation and crash-recovery for *mission_title*.
 
@@ -450,21 +554,22 @@ def get_retry_info(instance_dir: str, mission_title: str) -> dict:
     """Return full retry info for *mission_title* including pattern classification.
 
     Returns a dict with keys ``count``, ``pattern_type``, ``sample_lines``,
-    ``total_attempts``.
+    ``total_attempts``, ``crash_count``.
     """
     path = _retry_tracker_path(instance_dir)
     data = locked_json_read(path, default={})
     raw = data.get(_mission_key(mission_title), {}) if isinstance(data, dict) else {}
     if isinstance(raw, int):
-        return {"count": max(0, raw), "pattern_type": "", "sample_lines": "", "total_attempts": 0}
+        return {"count": max(0, raw), "pattern_type": "", "sample_lines": "", "total_attempts": 0, "crash_count": 0}
     if isinstance(raw, dict):
         return {
             "count": _extract_count(raw),
             "pattern_type": raw.get("pattern_type", ""),
             "sample_lines": raw.get("sample_lines", ""),
             "total_attempts": max(0, int(raw.get("total_attempts", 0))),
+            "crash_count": max(0, int(raw.get("crash_count", 0))),
         }
-    return {"count": 0, "pattern_type": "", "sample_lines": "", "total_attempts": 0}
+    return {"count": 0, "pattern_type": "", "sample_lines": "", "total_attempts": 0, "crash_count": 0}
 
 
 def increment_retry_count(
@@ -476,8 +581,10 @@ def increment_retry_count(
     """Increment and persist the stagnation retry counter for *mission_title*.
 
     Also increments total_attempts (the combined cross-system cap counter).
+    Preserves crash_count so stagnation requeues do not affect crash-recovery caps.
     When *pattern_type* is provided, the tracker entry is upgraded to a dict
-    with ``count``, ``pattern_type``, ``sample_lines``, and ``total_attempts``.
+    with ``count``, ``pattern_type``, ``sample_lines``, ``total_attempts``,
+    and ``crash_count``.
 
     Returns the new stagnation count.
     """
@@ -489,12 +596,14 @@ def increment_retry_count(
         existing = data.get(key, {})
         current = _extract_count(existing)
         total = max(0, int(existing.get("total_attempts", 0))) if isinstance(existing, dict) else 0
+        crash = max(0, int(existing.get("crash_count", 0))) if isinstance(existing, dict) else 0
         new_count = current + 1
         data[key] = {
             "count": new_count,
             "pattern_type": pattern_type,
             "sample_lines": pattern_excerpt[:500],
             "total_attempts": total + 1,
+            "crash_count": crash,
         }
         return new_count
 
@@ -506,43 +615,14 @@ def increment_retry_count(
         return 1
 
 
-def increment_total_attempts(instance_dir: str, mission_title: str) -> int:
-    """Increment the total_attempts counter without touching the stagnation count.
-
-    Called by crash-recovery (recover.py) when a mission is requeued after a
-    crash, so that the max_total_retries cap accounts for both stagnation and
-    crash-recovery retry cycles.
-
-    Returns the new total_attempts value.
-    """
-    path = _retry_tracker_path(instance_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    key = _mission_key(mission_title)
-
-    def _mutate(data: dict) -> int:
-        existing = data.get(key, {})
-        total = max(0, int(existing.get("total_attempts", 0))) if isinstance(existing, dict) else 0
-        new_total = total + 1
-        if isinstance(existing, dict):
-            data[key] = {**existing, "total_attempts": new_total}
-        else:
-            data[key] = {"count": _extract_count(existing), "total_attempts": new_total}
-        return new_total
-
-    try:
-        return locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
-    except OSError as e:
-        print(f"[stagnation_monitor] total_attempts save error: {e}", file=sys.stderr)
-        return 1
-
-
 def clear_retry_count(instance_dir: str, mission_title: str, *, clear_total: bool = True) -> None:
     """Drop the stagnation retry counter for *mission_title*.
 
     Args:
-        clear_total: When True (default), also resets total_attempts — use on
-            genuine mission success. When False, preserves total_attempts across
-            crash-recovery cycles so the cross-system cap remains effective.
+        clear_total: When True (default), also resets total_attempts and
+            crash_count — use on genuine mission success. When False, preserves
+            total_attempts and crash_count across crash-recovery cycles so the
+            cross-system cap remains effective.
     """
     path = _retry_tracker_path(instance_dir)
     if not path.exists():
@@ -558,8 +638,15 @@ def clear_retry_count(instance_dir: str, mission_title: str, *, clear_total: boo
                 data.pop(key, None)
                 return
             total = existing.get("total_attempts", 0)
+            crash = existing.get("crash_count", 0)
+            # Preserve total_attempts and crash_count, drop stagnation count
+            preserved: dict = {}
             if total:
-                data[key] = {"total_attempts": total}
+                preserved["total_attempts"] = total
+            if crash:
+                preserved["crash_count"] = crash
+            if preserved:
+                data[key] = preserved
             else:
                 data.pop(key, None)
 

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -425,23 +425,46 @@ def get_retry_count(instance_dir: str, mission_title: str) -> int:
     return _extract_count(data.get(_mission_key(mission_title), 0))
 
 
+def get_total_attempts(instance_dir: str, mission_title: str) -> int:
+    """Return total retry attempts across stagnation and crash-recovery for *mission_title*.
+
+    Unlike get_retry_count() which tracks stagnation-only retries (reset on any
+    non-stagnation exit), total_attempts accumulates across both stagnation requeues
+    and crash-recovery requeues, and is only cleared on genuine mission success.
+    Used by the max_total_retries cap.
+    """
+    path = _retry_tracker_path(instance_dir)
+    data = locked_json_read(path, default={})
+    if not isinstance(data, dict):
+        return 0
+    raw = data.get(_mission_key(mission_title), {})
+    if isinstance(raw, dict):
+        try:
+            return max(0, int(raw.get("total_attempts", 0)))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
 def get_retry_info(instance_dir: str, mission_title: str) -> dict:
     """Return full retry info for *mission_title* including pattern classification.
 
-    Returns a dict with keys ``count``, ``pattern_type``, ``sample_lines``.
+    Returns a dict with keys ``count``, ``pattern_type``, ``sample_lines``,
+    ``total_attempts``.
     """
     path = _retry_tracker_path(instance_dir)
     data = locked_json_read(path, default={})
     raw = data.get(_mission_key(mission_title), {}) if isinstance(data, dict) else {}
     if isinstance(raw, int):
-        return {"count": max(0, raw), "pattern_type": "", "sample_lines": ""}
+        return {"count": max(0, raw), "pattern_type": "", "sample_lines": "", "total_attempts": 0}
     if isinstance(raw, dict):
         return {
             "count": _extract_count(raw),
             "pattern_type": raw.get("pattern_type", ""),
             "sample_lines": raw.get("sample_lines", ""),
+            "total_attempts": max(0, int(raw.get("total_attempts", 0))),
         }
-    return {"count": 0, "pattern_type": "", "sample_lines": ""}
+    return {"count": 0, "pattern_type": "", "sample_lines": "", "total_attempts": 0}
 
 
 def increment_retry_count(
@@ -452,22 +475,26 @@ def increment_retry_count(
 ) -> int:
     """Increment and persist the stagnation retry counter for *mission_title*.
 
+    Also increments total_attempts (the combined cross-system cap counter).
     When *pattern_type* is provided, the tracker entry is upgraded to a dict
-    with ``count``, ``pattern_type``, and ``sample_lines`` fields.
+    with ``count``, ``pattern_type``, ``sample_lines``, and ``total_attempts``.
 
-    Returns the new count.
+    Returns the new stagnation count.
     """
     path = _retry_tracker_path(instance_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     key = _mission_key(mission_title)
 
     def _mutate(data: dict) -> int:
-        current = _extract_count(data.get(key, 0))
+        existing = data.get(key, {})
+        current = _extract_count(existing)
+        total = max(0, int(existing.get("total_attempts", 0))) if isinstance(existing, dict) else 0
         new_count = current + 1
         data[key] = {
             "count": new_count,
             "pattern_type": pattern_type,
             "sample_lines": pattern_excerpt[:500],
+            "total_attempts": total + 1,
         }
         return new_count
 
@@ -479,14 +506,61 @@ def increment_retry_count(
         return 1
 
 
-def clear_retry_count(instance_dir: str, mission_title: str) -> None:
-    """Drop the retry counter for *mission_title* (e.g. on completion)."""
+def increment_total_attempts(instance_dir: str, mission_title: str) -> int:
+    """Increment the total_attempts counter without touching the stagnation count.
+
+    Called by crash-recovery (recover.py) when a mission is requeued after a
+    crash, so that the max_total_retries cap accounts for both stagnation and
+    crash-recovery retry cycles.
+
+    Returns the new total_attempts value.
+    """
+    path = _retry_tracker_path(instance_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = _mission_key(mission_title)
+
+    def _mutate(data: dict) -> int:
+        existing = data.get(key, {})
+        total = max(0, int(existing.get("total_attempts", 0))) if isinstance(existing, dict) else 0
+        new_total = total + 1
+        if isinstance(existing, dict):
+            data[key] = {**existing, "total_attempts": new_total}
+        else:
+            data[key] = {"count": _extract_count(existing), "total_attempts": new_total}
+        return new_total
+
+    try:
+        return locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
+    except OSError as e:
+        print(f"[stagnation_monitor] total_attempts save error: {e}", file=sys.stderr)
+        return 1
+
+
+def clear_retry_count(instance_dir: str, mission_title: str, *, clear_total: bool = True) -> None:
+    """Drop the stagnation retry counter for *mission_title*.
+
+    Args:
+        clear_total: When True (default), also resets total_attempts — use on
+            genuine mission success. When False, preserves total_attempts across
+            crash-recovery cycles so the cross-system cap remains effective.
+    """
     path = _retry_tracker_path(instance_dir)
     if not path.exists():
         return
     key = _mission_key(mission_title)
 
     def _mutate(data: dict) -> None:
-        data.pop(key, None)
+        if clear_total:
+            data.pop(key, None)
+        else:
+            existing = data.get(key, {})
+            if not isinstance(existing, dict):
+                data.pop(key, None)
+                return
+            total = existing.get("total_attempts", 0)
+            if total:
+                data[key] = {"total_attempts": total}
+            else:
+                data.pop(key, None)
 
     locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)

--- a/koan/tests/test_recover.py
+++ b/koan/tests/test_recover.py
@@ -672,6 +672,62 @@ class TestRecoveryCounterIntegration:
         assert "[r:" not in between
 
 
+class TestDegradedTrackerFallback:
+    """When the stagnation tracker import fails, recovery must still escalate.
+
+    The tracker is the crash-count safety net. If it silently degrades to
+    crash_count=0 every cycle, a repeatedly crashing mission loops
+    Pending→crash→Pending forever. The fallback persists the count inline as
+    [r:N] so escalation still progresses.
+    """
+
+    @staticmethod
+    def _break_tracker_import(monkeypatch):
+        """Make `from app.stagnation_monitor import increment_crash_count` fail."""
+        import app.stagnation_monitor as sm
+        monkeypatch.delattr(sm, "increment_crash_count")
+
+    def test_degraded_recovery_persists_inline_counter(self, instance_dir, monkeypatch):
+        """Without the tracker, a recovered mission carries an inline [r:1]."""
+        self._break_tracker_import(monkeypatch)
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+
+        count, _ = recover_missions(str(instance_dir))
+        assert count == 1
+
+        content = missions.read_text()
+        # Count is persisted inline because the tracker is unavailable.
+        assert "[r:1]" in content
+
+    def test_degraded_recovery_increments_inline_counter(self, instance_dir, monkeypatch):
+        """A mission already at [r:1] is bumped to [r:2] on the next degraded cycle."""
+        self._break_tracker_import(monkeypatch)
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(in_progress="- Fix the bug [r:1]"))
+
+        count, _ = recover_missions(str(instance_dir))
+        assert count == 1
+
+        content = missions.read_text()
+        assert "[r:2]" in content
+        assert "[r:1]" not in content
+
+    def test_degraded_recovery_escalates_at_cap(self, instance_dir, monkeypatch):
+        """At the inline cap, a degraded mission escalates to Failed instead of looping."""
+        self._break_tracker_import(monkeypatch)
+        missions = instance_dir / "missions.md"
+        missions.write_text(
+            _missions_with_failed(in_progress=f"- Fix the bug [r:{_DEFAULT_MAX_CRASH_RETRIES}]")
+        )
+
+        count, _ = recover_missions(str(instance_dir))
+        assert count == 0  # not recovered to Pending
+
+        content = missions.read_text()
+        assert "needs_input" in content
+
+
 # ---------------------------------------------------------------------------
 # Unrecoverable escalation
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_recover.py
+++ b/koan/tests/test_recover.py
@@ -7,14 +7,16 @@ from unittest.mock import patch
 import pytest
 
 from app.recover import (
-    MAX_RECOVERY_ATTEMPTS,
-    _get_recovery_attempts,
-    _set_recovery_attempts,
     _strip_recovery_counter,
     check_pending_journal,
     classify_mission_state,
     recover_missions,
 )
+
+
+# Default max_crash_retries used in classify_mission_state.
+# Mirrors the default in recover.py / config.get_stagnation_config().
+_DEFAULT_MAX_CRASH_RETRIES = 3
 
 
 def _missions(pending="", in_progress="", done=""):
@@ -25,6 +27,28 @@ def _missions(pending="", in_progress="", done=""):
         f"## In Progress\n\n{in_progress}\n\n"
         f"## Done\n\n{done}\n"
     )
+
+
+def _write_crash_count(instance_dir, mission_title: str, crash_count: int) -> None:
+    """Write crash_count into .mission-retries.json so classify_mission_state sees it."""
+    from app.stagnation_monitor import _mission_key
+    key = _mission_key(mission_title)
+    tracker = Path(instance_dir) / ".mission-retries.json"
+    data = {}
+    if tracker.exists():
+        try:
+            data = json.loads(tracker.read_text())
+        except (json.JSONDecodeError, OSError):
+            data = {}
+    if not isinstance(data, dict):
+        data = {}
+    entry = data.get(key, {})
+    if not isinstance(entry, dict):
+        entry = {}
+    entry["crash_count"] = crash_count
+    entry["total_attempts"] = entry.get("total_attempts", 0) or crash_count
+    data[key] = entry
+    tracker.write_text(json.dumps(data))
 
 
 class TestRecoverMissions:
@@ -47,11 +71,9 @@ class TestRecoverMissions:
 
         assert count == 1
         content = missions.read_text()
-        # Should be in pending now
         lines = content.splitlines()
         pending_idx = next(i for i, l in enumerate(lines) if "pending" in l.lower())
         in_prog_idx = next(i for i, l in enumerate(lines) if "in progress" in l.lower())
-        # The mission should appear between pending header and in-progress header
         between = "\n".join(lines[pending_idx + 1 : in_prog_idx])
         assert "Fix the bug" in between
 
@@ -178,21 +200,14 @@ class TestRecoverMissions:
 
         content = missions.read_text()
         lines = content.splitlines()
-        # Use a regex-style check to find the ## Pending header line
         pending_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## pending"))
         in_prog_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## in progress"))
         pending_section = "\n".join(lines[pending_idx + 1 : in_prog_idx])
-        # Complex mission title recovered as - item (not ### block) so
-        # extract_next_pending() picks it up as a single mission, not fragments
         assert "- Complex Project" in pending_section
         assert "### Complex Project" not in pending_section
 
     def test_blank_line_ends_complex_block(self, instance_dir):
-        """A blank line after complex mission sub-items ends the complex block.
-
-        The complex block and the standalone mission after the blank line are
-        both recovered.
-        """
+        """A blank line after complex mission sub-items ends the complex block."""
         missions = instance_dir / "missions.md"
         missions.write_text(
             _missions(
@@ -214,12 +229,11 @@ class TestRecoverMissions:
         pending_idx = next(i for i, l in enumerate(lines) if "pending" in l.lower())
         in_prog_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## in progress"))
         pending_section = "\n".join(lines[pending_idx + 1 : in_prog_idx])
-        # Both the complex project and Step 3 should be in Pending
         assert "Complex Project" in pending_section
         assert "Step 3" in pending_section
 
     def test_two_complex_missions(self, instance_dir):
-        """Two consecutive complex missions both stay in-progress."""
+        """Two consecutive complex missions are both recovered."""
         missions = instance_dir / "missions.md"
         missions.write_text(
             _missions(
@@ -238,7 +252,6 @@ class TestRecoverMissions:
         assert count == 2
 
         content = missions.read_text()
-        # Both blocks should be in Pending now
         lines = content.splitlines()
         pending_idx = next(i for i, l in enumerate(lines) if "pending" in l.lower())
         in_prog_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## in progress"))
@@ -247,11 +260,7 @@ class TestRecoverMissions:
         assert "Another Complex" in pending_section
 
     def test_simple_mission_after_complex_recovered(self, instance_dir):
-        """A simple '- ' mission after a complex block (separated by blank line) IS recovered.
-
-        Blank lines end the complex mission block, so the complex block and
-        subsequent '- ' items are both recovered.
-        """
+        """A simple '- ' mission after a complex block (separated by blank line) IS recovered."""
         missions = instance_dir / "missions.md"
         missions.write_text(
             _missions(
@@ -273,7 +282,6 @@ class TestRecoverMissions:
         pending_idx = next(i for i, l in enumerate(lines) if "pending" in l.lower())
         in_prog_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## in progress"))
         pending_section = "\n".join(lines[pending_idx + 1 : in_prog_idx])
-        # Both the complex block and the simple orphan task are in Pending
         assert "Simple orphan task" in pending_section
         assert "Complex Project" in pending_section
 
@@ -352,9 +360,7 @@ class TestRecoverMissions:
         recover_missions(str(instance_dir))
         content = missions.read_text()
 
-        # "Existing task" must appear exactly once
         assert content.count("Existing task") == 1
-        # "Stale task" must appear exactly once (moved to pending)
         assert content.count("Stale task") == 1
 
     def test_no_section_headers_duplicated(self, instance_dir):
@@ -379,7 +385,6 @@ class TestRecoverAtomicity:
         missions.write_text(_missions(in_progress="- Stale task"))
 
         with patch("app.utils.modify_missions_file") as mock_modify:
-            # Make modify_missions_file actually call the transform so we get the count
             def _call_transform(path, transform):
                 content = path.read_text()
                 new_content = transform(content)
@@ -418,7 +423,6 @@ class TestRecoverCLI:
         import sys
 
         with patch.object(sys, "argv", ["app.recover.py", str(instance_dir)]):
-            # Can't easily test sys.exit, so just call the main block logic
             count, _ = recover_missions(str(instance_dir))
             if count > 0:
                 recover.format_and_send(
@@ -449,11 +453,8 @@ class TestCheckPendingJournal:
 
     def test_handles_file_deleted_between_check_and_read(self, tmp_path):
         """Regression: FileNotFoundError should be caught, not propagated."""
-        # The file doesn't exist at all — the new code uses try/except
-        # instead of exists() + read_text(), so this should just return False
         journal_dir = tmp_path / "journal"
         journal_dir.mkdir()
-        # No pending.md file — simulates the race where it was deleted
 
         result = check_pending_journal(str(tmp_path))
         assert result is False
@@ -503,25 +504,11 @@ class TestCheckPendingJournal:
 
 
 # ---------------------------------------------------------------------------
-# Recovery counter helpers
+# Recovery counter helpers (backward-compat strip only)
 # ---------------------------------------------------------------------------
 
 class TestRecoveryCounterHelpers:
-    """Unit tests for [r:N] counter parsing and manipulation."""
-
-    def test_get_attempts_absent(self):
-        assert _get_recovery_attempts("- Fix the bug") == 0
-
-    def test_get_attempts_present(self):
-        assert _get_recovery_attempts("- Fix the bug [r:2]") == 2
-
-    def test_set_attempts_on_fresh_line(self):
-        result = _set_recovery_attempts("- Fix the bug", 1)
-        assert result == "- Fix the bug [r:1]"
-
-    def test_set_attempts_replaces_existing(self):
-        result = _set_recovery_attempts("- Fix the bug [r:1]", 2)
-        assert result == "- Fix the bug [r:2]"
+    """Unit tests for [r:N] counter stripping (backward-compat cleanup)."""
 
     def test_strip_counter(self):
         result = _strip_recovery_counter("- Fix the bug [r:2]")
@@ -531,27 +518,10 @@ class TestRecoveryCounterHelpers:
         result = _strip_recovery_counter("- Fix the bug")
         assert result == "- Fix the bug"
 
-    def test_get_attempts_malformed_non_integer(self):
-        """Malformed [r:abc] defaults to 0 instead of raising ValueError."""
-        assert _get_recovery_attempts("- Fix the bug [r:abc]") == 0
-
-    def test_get_attempts_malformed_float(self):
-        """Malformed [r:3.5] defaults to 0."""
-        assert _get_recovery_attempts("- Fix the bug [r:3.5]") == 0
-
-    def test_get_attempts_malformed_empty(self):
-        """Malformed [r:] defaults to 0."""
-        assert _get_recovery_attempts("- Fix the bug [r:]") == 0
-
     def test_strip_malformed_counter(self):
         """Malformed [r:abc] is still stripped from the line."""
         result = _strip_recovery_counter("- Fix the bug [r:abc]")
         assert result == "- Fix the bug"
-
-    def test_set_replaces_malformed_counter(self):
-        """Malformed [r:abc] is replaced with a valid counter."""
-        result = _set_recovery_attempts("- Fix the bug [r:abc]", 1)
-        assert result == "- Fix the bug [r:1]"
 
 
 # ---------------------------------------------------------------------------
@@ -559,70 +529,123 @@ class TestRecoveryCounterHelpers:
 # ---------------------------------------------------------------------------
 
 class TestClassifyMissionState:
-    """Tests for classify_mission_state()."""
+    """Tests for classify_mission_state() — new signature: crash_count int."""
 
-    def test_dead_state_no_counter(self):
-        assert classify_mission_state("- Fix the bug") == "dead"
+    def test_dead_state_zero_crash_count(self):
+        """crash_count=0 with no journal -> dead."""
+        assert classify_mission_state(crash_count=0) == "dead"
 
-    def test_dead_state_low_counter(self):
-        assert classify_mission_state("- Fix the bug [r:1]") == "dead"
+    def test_dead_state_low_crash_count(self):
+        """crash_count below max_crash_retries -> dead."""
+        assert classify_mission_state(crash_count=1, max_crash_retries=3) == "dead"
 
     def test_partial_state_with_pending_journal(self):
-        assert classify_mission_state("- Fix the bug", has_pending_journal=True) == "partial"
+        """has_pending_journal=True -> partial when not exhausted."""
+        assert classify_mission_state(crash_count=0, has_pending_journal=True) == "partial"
 
     def test_unrecoverable_at_max_attempts(self):
-        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"
-        assert classify_mission_state(line) == "unrecoverable"
+        """crash_count == max_crash_retries -> unrecoverable."""
+        assert classify_mission_state(
+            crash_count=_DEFAULT_MAX_CRASH_RETRIES,
+            max_crash_retries=_DEFAULT_MAX_CRASH_RETRIES,
+        ) == "unrecoverable"
 
     def test_unrecoverable_above_max_attempts(self):
-        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS + 5}]"
-        assert classify_mission_state(line) == "unrecoverable"
+        """crash_count > max_crash_retries -> unrecoverable."""
+        assert classify_mission_state(
+            crash_count=_DEFAULT_MAX_CRASH_RETRIES + 5,
+            max_crash_retries=_DEFAULT_MAX_CRASH_RETRIES,
+        ) == "unrecoverable"
 
     def test_unrecoverable_overrides_pending_journal(self):
-        """Even with pending.md, too many attempts → unrecoverable."""
-        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"
-        assert classify_mission_state(line, has_pending_journal=True) == "unrecoverable"
+        """Even with pending.md, too many attempts -> unrecoverable."""
+        assert classify_mission_state(
+            crash_count=_DEFAULT_MAX_CRASH_RETRIES,
+            max_crash_retries=_DEFAULT_MAX_CRASH_RETRIES,
+            has_pending_journal=True,
+        ) == "unrecoverable"
 
     def test_just_below_max_is_dead(self):
-        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS - 1}]"
-        assert classify_mission_state(line) == "dead"
+        """crash_count == max_crash_retries - 1 -> dead (not unrecoverable yet)."""
+        assert classify_mission_state(
+            crash_count=_DEFAULT_MAX_CRASH_RETRIES - 1,
+            max_crash_retries=_DEFAULT_MAX_CRASH_RETRIES,
+        ) == "dead"
 
     def test_partial_state_with_checkpoint(self):
         """Mission with a checkpoint is classified as partial."""
-        assert classify_mission_state("- Fix the bug", has_checkpoint=True) == "partial"
+        assert classify_mission_state(crash_count=0, has_checkpoint=True) == "partial"
 
     def test_partial_state_checkpoint_and_pending(self):
-        """Both checkpoint and pending → still partial (not double-counted)."""
+        """Both checkpoint and pending -> still partial (not double-counted)."""
         assert classify_mission_state(
-            "- Fix the bug", has_pending_journal=True, has_checkpoint=True
+            crash_count=0, has_pending_journal=True, has_checkpoint=True
         ) == "partial"
 
     def test_unrecoverable_overrides_checkpoint(self):
-        """Even with a checkpoint, too many attempts → unrecoverable."""
-        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"
-        assert classify_mission_state(line, has_checkpoint=True) == "unrecoverable"
+        """Even with a checkpoint, too many attempts -> unrecoverable."""
+        assert classify_mission_state(
+            crash_count=_DEFAULT_MAX_CRASH_RETRIES,
+            max_crash_retries=_DEFAULT_MAX_CRASH_RETRIES,
+            has_checkpoint=True,
+        ) == "unrecoverable"
+
+    def test_total_attempts_cap_triggers_unrecoverable(self):
+        """total_attempts >= max_total_retries -> unrecoverable (when max_total_retries > 0)."""
+        assert classify_mission_state(
+            crash_count=0,
+            total_attempts=5,
+            max_total_retries=5,
+        ) == "unrecoverable"
+
+    def test_max_total_retries_zero_disables_cap(self):
+        """max_total_retries=0 disables the combined cap."""
+        assert classify_mission_state(
+            crash_count=0,
+            total_attempts=100,
+            max_total_retries=0,
+        ) == "dead"
 
 
 # ---------------------------------------------------------------------------
-# Recovery counter integration
+# Recovery counter integration -- tracker-based (no [r:N] tags in missions.md)
 # ---------------------------------------------------------------------------
 
 class TestRecoveryCounterIntegration:
-    """Integration tests: counter is incremented and tracked across recoveries."""
+    """Integration tests: crash counter is tracked in .mission-retries.json."""
 
-    def test_first_recovery_adds_counter(self, instance_dir):
-        """First recovery adds [r:1] to the mission line."""
+    def test_first_recovery_increments_tracker(self, instance_dir):
+        """First recovery increments crash_count in tracker (not written to missions.md)."""
         missions = instance_dir / "missions.md"
         missions.write_text(_missions(in_progress="- Fix the bug"))
 
         count, _ = recover_missions(str(instance_dir))
         assert count == 1
 
+        # No [r:N] tag in the missions file
         content = missions.read_text()
-        assert "[r:1]" in content
+        assert "[r:" not in content
 
-    def test_second_recovery_increments_counter(self, instance_dir):
-        """Second recovery changes [r:1] to [r:2]."""
+        # crash_count is tracked in the JSON file
+        from app.stagnation_monitor import get_crash_count
+        assert get_crash_count(str(instance_dir), "Fix the bug") == 1
+
+    def test_second_recovery_increments_tracker_again(self, instance_dir):
+        """Second recovery increments crash_count to 2."""
+        missions = instance_dir / "missions.md"
+
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        recover_missions(str(instance_dir))
+
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        count, _ = recover_missions(str(instance_dir))
+        assert count == 1
+
+        from app.stagnation_monitor import get_crash_count
+        assert get_crash_count(str(instance_dir), "Fix the bug") == 2
+
+    def test_legacy_r_tag_stripped_from_missions(self, instance_dir):
+        """A mission with a legacy [r:N] tag has it stripped on recovery."""
         missions = instance_dir / "missions.md"
         missions.write_text(_missions(in_progress="- Fix the bug [r:1]"))
 
@@ -630,23 +653,11 @@ class TestRecoveryCounterIntegration:
         assert count == 1
 
         content = missions.read_text()
-        assert "[r:2]" in content
-        assert "[r:1]" not in content
+        assert "[r:" not in content
+        assert "Fix the bug" in content
 
-    def test_malformed_counter_recovered_as_first_attempt(self, instance_dir):
-        """A mission with a malformed [r:abc] counter is treated as 0 attempts."""
-        missions = instance_dir / "missions.md"
-        missions.write_text(_missions(in_progress="- Fix the bug [r:abc]"))
-
-        count, _ = recover_missions(str(instance_dir))
-        assert count == 1
-
-        content = missions.read_text()
-        assert "[r:1]" in content
-        assert "[r:abc]" not in content
-
-    def test_counter_preserved_in_pending(self, instance_dir):
-        """The [r:N] tag is present in Pending after recovery."""
+    def test_recovered_mission_clean_in_pending(self, instance_dir):
+        """The recovered mission text in Pending has no [r:N] tag."""
         missions = instance_dir / "missions.md"
         missions.write_text(_missions(in_progress="- Fix the bug"))
 
@@ -658,7 +669,7 @@ class TestRecoveryCounterIntegration:
         in_prog_idx = next(i for i, l in enumerate(lines) if "in progress" in l.lower())
         between = "\n".join(lines[pending_idx + 1 : in_prog_idx])
         assert "Fix the bug" in between
-        assert "[r:" in between
+        assert "[r:" not in between
 
 
 # ---------------------------------------------------------------------------
@@ -679,16 +690,14 @@ def _missions_with_failed(pending="", in_progress="", done="", failed=""):
 class TestUnrecoverableEscalation:
     """Missions that have exhausted recovery attempts are escalated to Failed."""
 
-    def _stale_at_limit(self):
-        return f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"
-
     def test_unrecoverable_not_in_pending(self, instance_dir):
         """Unrecoverable missions are NOT moved to Pending."""
         missions = instance_dir / "missions.md"
-        missions.write_text(_missions(in_progress=self._stale_at_limit()))
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        _write_crash_count(instance_dir, "Fix the bug", _DEFAULT_MAX_CRASH_RETRIES)
 
         count, _ = recover_missions(str(instance_dir))
-        assert count == 0  # Not recovered to Pending
+        assert count == 0
 
         content = missions.read_text()
         lines = content.splitlines()
@@ -700,7 +709,8 @@ class TestUnrecoverableEscalation:
     def test_unrecoverable_moved_to_failed(self, instance_dir):
         """Unrecoverable missions appear in Failed section with needs_input tag."""
         missions = instance_dir / "missions.md"
-        missions.write_text(_missions_with_failed(in_progress=self._stale_at_limit()))
+        missions.write_text(_missions_with_failed(in_progress="- Fix the bug"))
+        _write_crash_count(instance_dir, "Fix the bug", _DEFAULT_MAX_CRASH_RETRIES)
 
         recover_missions(str(instance_dir))
 
@@ -711,8 +721,8 @@ class TestUnrecoverableEscalation:
     def test_unrecoverable_creates_failed_section_if_absent(self, instance_dir):
         """If no Failed section exists, one is created for escalated missions."""
         missions = instance_dir / "missions.md"
-        # Use _missions() which has no Failed section
-        missions.write_text(_missions(in_progress=self._stale_at_limit()))
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        _write_crash_count(instance_dir, "Fix the bug", _DEFAULT_MAX_CRASH_RETRIES)
 
         recover_missions(str(instance_dir))
 
@@ -724,20 +734,18 @@ class TestUnrecoverableEscalation:
     def test_mixed_recoverable_and_unrecoverable(self, instance_dir):
         """Recoverable missions go to Pending, unrecoverable go to Failed."""
         missions = instance_dir / "missions.md"
-        in_prog = f"- Normal task\n{self._stale_at_limit()}"
-        missions.write_text(_missions_with_failed(in_progress=in_prog))
+        missions.write_text(_missions_with_failed(in_progress="- Normal task\n- Fix the bug"))
+        _write_crash_count(instance_dir, "Fix the bug", _DEFAULT_MAX_CRASH_RETRIES)
 
         count, _ = recover_missions(str(instance_dir))
-        assert count == 1  # Only 1 recovered
+        assert count == 1
 
         content = missions.read_text()
-        # Normal task in Pending with counter
         lines = content.splitlines()
         pending_idx = next(i for i, l in enumerate(lines) if "pending" in l.lower())
         in_prog_idx = next(i for i, l in enumerate(lines) if "in progress" in l.lower())
         between = "\n".join(lines[pending_idx + 1 : in_prog_idx])
         assert "Normal task" in between
-        # Escalated in Failed
         assert "needs_input" in content
         assert "Fix the bug" in content
 
@@ -745,32 +753,48 @@ class TestUnrecoverableEscalation:
         """Unrecoverable complex ### block: header appears in Failed, sub-items preserved."""
         missions = instance_dir / "missions.md"
         in_prog = (
-            f"### Fix auth [r:{MAX_RECOVERY_ATTEMPTS}]\n"
+            "### Fix auth\n"
             "- ~~Step 1~~ done\n"
             "- Step 2 active\n"
         )
         missions.write_text(_missions(in_progress=in_prog))
+        _write_crash_count(instance_dir, "Fix auth", _DEFAULT_MAX_CRASH_RETRIES)
 
         count, escalated = recover_missions(str(instance_dir))
-        assert count == 0  # Not moved to Pending
+        assert count == 0
         assert len(escalated) == 1
 
         content = missions.read_text()
         assert "## Failed" in content
         assert "needs_input" in content
-        # Header appears without ### prefix
         assert "### Fix auth" not in content
         assert "Fix auth" in content
-        # Sub-items preserved in Failed
         assert "Step 1" in content
         assert "Step 2" in content
 
-        # In Progress should be empty now
         lines = content.splitlines()
         in_prog_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## in progress"))
         failed_idx = next(i for i, l in enumerate(lines) if l.strip().lower().startswith("## failed"))
         in_prog_section = "\n".join(lines[in_prog_idx + 1 : failed_idx])
         assert "Fix auth" not in in_prog_section
+
+    def test_legacy_r_tag_at_limit_triggers_unrecoverable(self, instance_dir):
+        """A mission with legacy [r:N] tag at or above limit is also escalated.
+
+        Backward-compat: if [r:N] value exceeds tracker crash_count,
+        the tag value is used for the cap check.
+        """
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(
+            in_progress=f"- Fix the bug [r:{_DEFAULT_MAX_CRASH_RETRIES}]"
+        ))
+
+        count, _ = recover_missions(str(instance_dir))
+        assert count == 0
+
+        content = missions.read_text()
+        assert "## Failed" in content
+        assert "Fix the bug" in content
 
 
 # ---------------------------------------------------------------------------
@@ -812,7 +836,8 @@ class TestRecoveryJSONLLog:
     def test_log_escalated_action(self, instance_dir):
         """Unrecoverable missions are logged with action=escalated."""
         missions = instance_dir / "missions.md"
-        missions.write_text(_missions(in_progress=f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"))
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        _write_crash_count(instance_dir, "Fix the bug", _DEFAULT_MAX_CRASH_RETRIES)
 
         recover_missions(str(instance_dir))
 
@@ -838,12 +863,10 @@ class TestRecoveryJSONLLog:
         """Multiple recovery runs append to the same log."""
         missions = instance_dir / "missions.md"
 
-        # First run
         missions.write_text(_missions(in_progress="- Task A"))
         recover_missions(str(instance_dir))
 
-        # Second run
-        missions.write_text(_missions(in_progress="- Task B [r:1]"))
+        missions.write_text(_missions(in_progress="- Task B"))
         recover_missions(str(instance_dir))
 
         log_path = instance_dir / "recovery.jsonl"
@@ -860,11 +883,7 @@ class TestRecoverPendingJournalTOCTOU:
 
     def test_pending_deleted_after_exists_check(self, instance_dir):
         """If pending.md is deleted between exists() and read_text(), recovery
-        should not raise FileNotFoundError — it should treat it as absent.
-
-        This is a benign race: the agent process deletes pending.md after
-        completing a mission, while recover.py is concurrently checking it.
-        """
+        should not raise FileNotFoundError."""
         missions = instance_dir / "missions.md"
         missions.write_text(_missions(in_progress="- Stale task"))
 
@@ -877,16 +896,13 @@ class TestRecoverPendingJournalTOCTOU:
         def _disappearing_read_text(self, *args, **kwargs):
             """Simulate the file vanishing between exists() and read_text()."""
             if self.name == "pending.md" and "journal" in str(self):
-                # Delete the file to simulate the race, then let read_text fail
                 self.unlink(missing_ok=True)
                 return original_read_text(self, *args, **kwargs)
             return original_read_text(self, *args, **kwargs)
 
         with patch.object(Path, "read_text", _disappearing_read_text):
-            # This must NOT raise FileNotFoundError
             count, _ = recover_missions(str(instance_dir))
 
-        # Mission should still be recovered (as "dead", not "partial")
         assert count == 1
 
 
@@ -905,15 +921,12 @@ class TestPendingJournalSingleUse:
         log_path = instance_dir / "recovery.jsonl"
         count, _ = recover_missions(str(instance_dir))
 
-        # Both missions should be recovered
         assert count == 2
 
-        # Read audit log to check states
         import json
         events = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
         by_mission = {e["mission"]: e["state"] for e in events}
 
-        # First mission claims the journal → partial; second is dead
         assert by_mission.get("- Task A") == "partial"
         assert by_mission.get("- Task B") == "dead"
 
@@ -930,7 +943,6 @@ class TestDryRun:
         count, _ = recover_missions(str(instance_dir), dry_run=True)
 
         assert count == 0
-        # File should not have been modified (no missions moved to Pending)
         content = missions.read_text()
         lines = content.splitlines()
         in_prog_idx = next(i for i, l in enumerate(lines) if "in progress" in l.lower())
@@ -993,7 +1005,6 @@ class TestCheckpointAwareRecovery:
         assert count == 1
 
         pending_path = instance_dir / "journal" / "pending.md"
-        # pending.md should not exist or should not contain checkpoint context
         if pending_path.exists():
             assert "Recovery Context" not in pending_path.read_text()
 
@@ -1014,91 +1025,3 @@ class TestCheckpointAwareRecovery:
         events = [json.loads(l) for l in log_path.read_text().splitlines() if l.strip()]
         assert len(events) >= 1
         assert events[0]["has_checkpoint"] is True
-
-
-class TestUnifiedRetryCap:
-    """Tests for B6 fix: max_total_retries combined cap across stagnation and crash-recovery."""
-
-    @pytest.fixture
-    def instance_dir(self, tmp_path):
-        (tmp_path / "journal").mkdir()
-        return tmp_path
-
-    def test_classify_unrecoverable_when_total_cap_hit(self):
-        """classify_mission_state returns unrecoverable when total_attempts >= max_total_retries."""
-        line = "- Fix the bug"
-        state = classify_mission_state(
-            line, total_attempts=5, max_total_retries=5,
-        )
-        assert state == "unrecoverable"
-
-    def test_classify_not_unrecoverable_when_total_under_cap(self):
-        """classify_mission_state does not escalate when total_attempts < max_total_retries."""
-        line = "- Fix the bug"
-        state = classify_mission_state(
-            line, total_attempts=4, max_total_retries=5,
-        )
-        assert state == "dead"
-
-    def test_classify_ignores_total_cap_when_zero(self):
-        """max_total_retries=0 disables the combined cap."""
-        line = "- Fix the bug"
-        state = classify_mission_state(
-            line, total_attempts=100, max_total_retries=0,
-        )
-        assert state in ("dead", "partial")
-
-    def test_r_counter_still_applies_independently(self):
-        """[r:N] >= MAX_RECOVERY_ATTEMPTS still escalates even if total cap not set."""
-        from app.recover import MAX_RECOVERY_ATTEMPTS
-        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"
-        state = classify_mission_state(line, total_attempts=0, max_total_retries=0)
-        assert state == "unrecoverable"
-
-    def test_recover_increments_total_attempts(self, instance_dir):
-        """recover_missions() increments total_attempts in stagnation tracker on requeue."""
-        from app.stagnation_monitor import get_total_attempts
-
-        missions = instance_dir / "missions.md"
-        missions.write_text(_missions(in_progress="- Fix the database"))
-
-        recover_missions(str(instance_dir))
-
-        total = get_total_attempts(str(instance_dir), "Fix the database")
-        assert total == 1
-
-    def test_recover_escalates_when_total_cap_hit(self, instance_dir):
-        """When max_total_retries is reached, recover_missions escalates instead of requeueing."""
-        from app.stagnation_monitor import increment_total_attempts
-
-        mission = "Fix the database"
-        # Pre-seed 5 total attempts so the next recovery hits the cap of 5
-        for _ in range(5):
-            increment_total_attempts(str(instance_dir), mission)
-
-        missions = instance_dir / "missions.md"
-        missions.write_text(_missions(in_progress=f"- {mission}"))
-
-        with patch(
-            "app.config.get_stagnation_config",
-            return_value={"max_total_retries": 5},
-        ):
-            count, escalated = recover_missions(str(instance_dir))
-
-        assert count == 0
-        assert len(escalated) == 1
-
-    def test_total_attempts_accumulates_across_crash_and_stagnation(self, instance_dir):
-        """total_attempts increments each crash recovery; stagnation tracker persists between runs."""
-        from app.stagnation_monitor import get_total_attempts, increment_total_attempts
-
-        mission = "Compile the project"
-        # Simulate 2 crash recoveries (recover.py increments total_attempts per requeue)
-        increment_total_attempts(str(instance_dir), mission)
-        increment_total_attempts(str(instance_dir), mission)
-        assert get_total_attempts(str(instance_dir), mission) == 2
-
-        # Simulate 1 stagnation requeue (increment_retry_count also bumps total_attempts)
-        from app.stagnation_monitor import increment_retry_count
-        increment_retry_count(str(instance_dir), mission)
-        assert get_total_attempts(str(instance_dir), mission) == 3

--- a/koan/tests/test_recover.py
+++ b/koan/tests/test_recover.py
@@ -1014,3 +1014,91 @@ class TestCheckpointAwareRecovery:
         events = [json.loads(l) for l in log_path.read_text().splitlines() if l.strip()]
         assert len(events) >= 1
         assert events[0]["has_checkpoint"] is True
+
+
+class TestUnifiedRetryCap:
+    """Tests for B6 fix: max_total_retries combined cap across stagnation and crash-recovery."""
+
+    @pytest.fixture
+    def instance_dir(self, tmp_path):
+        (tmp_path / "journal").mkdir()
+        return tmp_path
+
+    def test_classify_unrecoverable_when_total_cap_hit(self):
+        """classify_mission_state returns unrecoverable when total_attempts >= max_total_retries."""
+        line = "- Fix the bug"
+        state = classify_mission_state(
+            line, total_attempts=5, max_total_retries=5,
+        )
+        assert state == "unrecoverable"
+
+    def test_classify_not_unrecoverable_when_total_under_cap(self):
+        """classify_mission_state does not escalate when total_attempts < max_total_retries."""
+        line = "- Fix the bug"
+        state = classify_mission_state(
+            line, total_attempts=4, max_total_retries=5,
+        )
+        assert state == "dead"
+
+    def test_classify_ignores_total_cap_when_zero(self):
+        """max_total_retries=0 disables the combined cap."""
+        line = "- Fix the bug"
+        state = classify_mission_state(
+            line, total_attempts=100, max_total_retries=0,
+        )
+        assert state in ("dead", "partial")
+
+    def test_r_counter_still_applies_independently(self):
+        """[r:N] >= MAX_RECOVERY_ATTEMPTS still escalates even if total cap not set."""
+        from app.recover import MAX_RECOVERY_ATTEMPTS
+        line = f"- Fix the bug [r:{MAX_RECOVERY_ATTEMPTS}]"
+        state = classify_mission_state(line, total_attempts=0, max_total_retries=0)
+        assert state == "unrecoverable"
+
+    def test_recover_increments_total_attempts(self, instance_dir):
+        """recover_missions() increments total_attempts in stagnation tracker on requeue."""
+        from app.stagnation_monitor import get_total_attempts
+
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(in_progress="- Fix the database"))
+
+        recover_missions(str(instance_dir))
+
+        total = get_total_attempts(str(instance_dir), "Fix the database")
+        assert total == 1
+
+    def test_recover_escalates_when_total_cap_hit(self, instance_dir):
+        """When max_total_retries is reached, recover_missions escalates instead of requeueing."""
+        from app.stagnation_monitor import increment_total_attempts
+
+        mission = "Fix the database"
+        # Pre-seed 5 total attempts so the next recovery hits the cap of 5
+        for _ in range(5):
+            increment_total_attempts(str(instance_dir), mission)
+
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(in_progress=f"- {mission}"))
+
+        with patch(
+            "app.config.get_stagnation_config",
+            return_value={"max_total_retries": 5},
+        ):
+            count, escalated = recover_missions(str(instance_dir))
+
+        assert count == 0
+        assert len(escalated) == 1
+
+    def test_total_attempts_accumulates_across_crash_and_stagnation(self, instance_dir):
+        """total_attempts increments each crash recovery; stagnation tracker persists between runs."""
+        from app.stagnation_monitor import get_total_attempts, increment_total_attempts
+
+        mission = "Compile the project"
+        # Simulate 2 crash recoveries (recover.py increments total_attempts per requeue)
+        increment_total_attempts(str(instance_dir), mission)
+        increment_total_attempts(str(instance_dir), mission)
+        assert get_total_attempts(str(instance_dir), mission) == 2
+
+        # Simulate 1 stagnation requeue (increment_retry_count also bumps total_attempts)
+        from app.stagnation_monitor import increment_retry_count
+        increment_retry_count(str(instance_dir), mission)
+        assert get_total_attempts(str(instance_dir), mission) == 3

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -63,6 +63,66 @@ def projects(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Test: _clear_if_cap_hit — project-specific cap detection
+# ---------------------------------------------------------------------------
+
+class TestClearIfCapHit:
+    """The cap detection must read the SAME per-project config _finalize_mission
+    uses, otherwise a human retry on a project with tighter caps is silently
+    ignored (cleared against global defaults that never trip)."""
+
+    @staticmethod
+    def _fake_cfg_factory():
+        def fake_cfg(project_name=""):
+            cfg = {
+                "max_retry_on_stagnation": 3,
+                "max_total_retries": 0,
+                "max_crash_retries": 10,  # global: lenient
+            }
+            if project_name == "tight":
+                cfg = {**cfg, "max_crash_retries": 2}  # project: strict
+            return cfg
+        return fake_cfg
+
+    def test_global_cap_not_hit_leaves_counter(self, tmp_path):
+        from app import run
+        from app.stagnation_monitor import seed_crash_count, get_retry_info
+        seed_crash_count(str(tmp_path), "Fix bug", 2)
+
+        with patch("app.config.get_stagnation_config", side_effect=self._fake_cfg_factory()):
+            # crash_count=2 < global max_crash_retries=10 -> nothing to clear
+            assert run._clear_if_cap_hit(str(tmp_path), "Fix bug", "") is True
+        assert get_retry_info(str(tmp_path), "Fix bug")["crash_count"] == 2
+
+    def test_project_cap_hit_clears_counter(self, tmp_path):
+        from app import run
+        from app.stagnation_monitor import seed_crash_count, get_retry_info
+        seed_crash_count(str(tmp_path), "Fix bug", 2)
+
+        with patch("app.config.get_stagnation_config", side_effect=self._fake_cfg_factory()):
+            # crash_count=2 >= project "tight" max_crash_retries=2 -> clear
+            assert run._clear_if_cap_hit(str(tmp_path), "Fix bug", "tight") is True
+        assert get_retry_info(str(tmp_path), "Fix bug")["crash_count"] == 0
+
+    def test_no_counter_is_noop(self, tmp_path):
+        from app import run
+        with patch("app.config.get_stagnation_config", side_effect=self._fake_cfg_factory()) as m:
+            # Brand-new mission (no tracker entry) returns early before loading config
+            assert run._clear_if_cap_hit(str(tmp_path), "Never run", "tight") is True
+            m.assert_not_called()
+
+    def test_clear_failure_returns_false(self, tmp_path):
+        from app import run
+        from app.stagnation_monitor import seed_crash_count
+        seed_crash_count(str(tmp_path), "Fix bug", 5)
+
+        with patch("app.config.get_stagnation_config", side_effect=self._fake_cfg_factory()), \
+             patch("app.stagnation_monitor.clear_retry_count", side_effect=OSError("boom")):
+            # Cap hit but clear failed -> False so caller can warn prominently
+            assert run._clear_if_cap_hit(str(tmp_path), "Fix bug", "tight") is False
+
+
+# ---------------------------------------------------------------------------
 # Test: Colored logging
 # ---------------------------------------------------------------------------
 

--- a/koan/tests/test_stagnation_monitor.py
+++ b/koan/tests/test_stagnation_monitor.py
@@ -15,11 +15,12 @@ from app.stagnation_monitor import (
     _tail_hash,
     classify_stagnation,
     clear_retry_count,
+    get_crash_count,
     get_retry_count,
     get_retry_info,
     get_total_attempts,
+    increment_crash_count,
     increment_retry_count,
-    increment_total_attempts,
 )
 
 
@@ -581,7 +582,7 @@ class TestRetryTracker:
 
     def test_handles_corrupt_json_file(self, tmp_path):
         """Corrupt tracker file should be treated as empty."""
-        tracker = tmp_path / ".stagnation-retries.json"
+        tracker = tmp_path / ".mission-retries.json"
         tracker.write_text("not valid json {{{")
         assert get_retry_count(str(tmp_path), "mission X") == 0
         # Increment should overwrite the corrupt file.
@@ -589,21 +590,21 @@ class TestRetryTracker:
 
     def test_handles_non_dict_json(self, tmp_path):
         """JSON that is a list (not a dict) should be treated as empty."""
-        tracker = tmp_path / ".stagnation-retries.json"
+        tracker = tmp_path / ".mission-retries.json"
         tracker.write_text("[1, 2, 3]")
         assert get_retry_count(str(tmp_path), "any") == 0
 
     def test_handles_non_integer_value(self, tmp_path):
         """A stored value that isn't an int should default to 0."""
         key = _mission_key("broken")
-        tracker = tmp_path / ".stagnation-retries.json"
+        tracker = tmp_path / ".mission-retries.json"
         tracker.write_text(json.dumps({key: "not-a-number"}))
         assert get_retry_count(str(tmp_path), "broken") == 0
 
     def test_increment_handles_non_integer_stored_value(self, tmp_path):
         """increment on a corrupt stored value should treat it as 0 and return 1."""
         key = _mission_key("corrupt-entry")
-        tracker = tmp_path / ".stagnation-retries.json"
+        tracker = tmp_path / ".mission-retries.json"
         tracker.write_text(json.dumps({key: [1, 2]}))
         assert increment_retry_count(str(tmp_path), "corrupt-entry") == 1
 
@@ -615,26 +616,37 @@ class TestRetryTracker:
             increment_retry_count(d, "test mission")
 
     def test_clear_with_clear_total_false_preserves_total_attempts(self, tmp_path):
-        """clear_retry_count(clear_total=False) resets stagnation count but keeps total_attempts."""
+        """clear_retry_count(clear_total=False) resets stagnation count but keeps total_attempts and crash_count."""
         d = str(tmp_path)
         increment_retry_count(d, "mission X")
         increment_retry_count(d, "mission X")
+        increment_crash_count(d, "mission X")
         clear_retry_count(d, "mission X", clear_total=False)
         assert get_retry_count(d, "mission X") == 0
-        assert get_total_attempts(d, "mission X") == 2
+        assert get_total_attempts(d, "mission X") == 3  # 2 stagnation + 1 crash
+        assert get_crash_count(d, "mission X") == 1
 
     def test_clear_with_clear_total_true_resets_everything(self, tmp_path):
         """clear_retry_count() (default) removes the entry entirely including total_attempts."""
         d = str(tmp_path)
         increment_retry_count(d, "mission Y")
-        increment_total_attempts(d, "mission Y")
+        increment_crash_count(d, "mission Y")
         clear_retry_count(d, "mission Y")
         assert get_retry_count(d, "mission Y") == 0
         assert get_total_attempts(d, "mission Y") == 0
+        assert get_crash_count(d, "mission Y") == 0
+
+    def test_increment_retry_does_not_change_crash_count(self, tmp_path):
+        """increment_retry_count (stagnation) must not affect crash_count."""
+        d = str(tmp_path)
+        increment_retry_count(d, "stagnation mission")
+        increment_retry_count(d, "stagnation mission")
+        assert get_crash_count(d, "stagnation mission") == 0
+        assert get_retry_count(d, "stagnation mission") == 2
 
 
 class TestTotalAttempts:
-    """Tests for the cross-system total_attempts counter (B6 fix)."""
+    """Tests for the cross-system total_attempts counter."""
 
     def test_get_total_returns_zero_for_unknown_mission(self, tmp_path):
         assert get_total_attempts(str(tmp_path), "unseen") == 0
@@ -646,10 +658,10 @@ class TestTotalAttempts:
         assert get_total_attempts(d, "mission A") == 2
 
     def test_increment_total_without_stagnation(self, tmp_path):
-        """increment_total_attempts increments total_attempts without touching stagnation count."""
+        """increment_crash_count increments total_attempts without touching stagnation count."""
         d = str(tmp_path)
-        increment_total_attempts(d, "crash mission")
-        increment_total_attempts(d, "crash mission")
+        increment_crash_count(d, "crash mission")
+        increment_crash_count(d, "crash mission")
         assert get_total_attempts(d, "crash mission") == 2
         assert get_retry_count(d, "crash mission") == 0
 
@@ -657,7 +669,7 @@ class TestTotalAttempts:
         """total_attempts accumulates across both stagnation and crash-recovery increments."""
         d = str(tmp_path)
         increment_retry_count(d, "flaky mission")   # stagnation
-        increment_total_attempts(d, "flaky mission")  # crash-recovery
+        increment_crash_count(d, "flaky mission")   # crash-recovery
         increment_retry_count(d, "flaky mission")   # stagnation again
         assert get_retry_count(d, "flaky mission") == 2
         assert get_total_attempts(d, "flaky mission") == 3
@@ -666,7 +678,7 @@ class TestTotalAttempts:
         """Clearing the stagnation counter with clear_total=False leaves total_attempts intact."""
         d = str(tmp_path)
         increment_retry_count(d, "sticky mission")  # stagnation (total = 1)
-        increment_total_attempts(d, "sticky mission")  # crash (total = 2)
+        increment_crash_count(d, "sticky mission")  # crash (total = 2)
         clear_retry_count(d, "sticky mission", clear_total=False)
         assert get_retry_count(d, "sticky mission") == 0
         assert get_total_attempts(d, "sticky mission") == 2
@@ -675,7 +687,7 @@ class TestTotalAttempts:
         """Full clear (default) wipes total_attempts — used after genuine success."""
         d = str(tmp_path)
         increment_retry_count(d, "mission Z")
-        increment_total_attempts(d, "mission Z")
+        increment_crash_count(d, "mission Z")
         clear_retry_count(d, "mission Z")  # clear_total=True by default
         assert get_total_attempts(d, "mission Z") == 0
 
@@ -683,25 +695,68 @@ class TestTotalAttempts:
         """get_retry_info() includes total_attempts in its return dict."""
         d = str(tmp_path)
         increment_retry_count(d, "info mission")
-        increment_total_attempts(d, "info mission")
+        increment_crash_count(d, "info mission")
         info = get_retry_info(d, "info mission")
         assert info["count"] == 1
         assert info["total_attempts"] == 2
 
     def test_increment_total_handles_fresh_entry(self, tmp_path):
-        """increment_total_attempts creates a new entry when mission has no prior tracker data."""
+        """increment_crash_count creates a new entry when mission has no prior tracker data."""
         d = str(tmp_path)
-        result = increment_total_attempts(d, "brand new mission")
+        result = increment_crash_count(d, "brand new mission")
         assert result == 1
         assert get_total_attempts(d, "brand new mission") == 1
         assert get_retry_count(d, "brand new mission") == 0
+        assert get_crash_count(d, "brand new mission") == 1
 
     def test_key_stable_across_lifecycle_markers_for_total(self, tmp_path):
         """total_attempts key is stable regardless of [r:N] tags or timestamps."""
         d = str(tmp_path)
-        increment_total_attempts(d, "- Fix the tests [r:1]")
+        increment_crash_count(d, "- Fix the tests [r:1]")
         assert get_total_attempts(d, "- Fix the tests") == 1
         assert get_total_attempts(d, "- Fix the tests [r:2]") == 1
+
+
+class TestCrashCount:
+    """Tests for crash_count tracking — separate from stagnation requeue count."""
+
+    def test_get_crash_count_returns_zero_for_unknown(self, tmp_path):
+        assert get_crash_count(str(tmp_path), "unseen mission") == 0
+
+    def test_increment_crash_count_increments_both_crash_and_total(self, tmp_path):
+        d = str(tmp_path)
+        result = increment_crash_count(d, "crash mission")
+        assert result == 1
+        assert get_crash_count(d, "crash mission") == 1
+        assert get_total_attempts(d, "crash mission") == 1
+
+    def test_increment_crash_count_does_not_change_stagnation_count(self, tmp_path):
+        d = str(tmp_path)
+        increment_crash_count(d, "crash mission")
+        increment_crash_count(d, "crash mission")
+        assert get_retry_count(d, "crash mission") == 0
+        assert get_crash_count(d, "crash mission") == 2
+
+    def test_crash_count_key_stable_across_lifecycle_markers(self, tmp_path):
+        d = str(tmp_path)
+        increment_crash_count(d, "- Fix the bug [r:1]")
+        assert get_crash_count(d, "- Fix the bug") == 1
+        assert get_crash_count(d, "- Fix the bug [r:2]") == 1
+
+    def test_clear_full_also_removes_crash_count(self, tmp_path):
+        d = str(tmp_path)
+        increment_crash_count(d, "mission A")
+        clear_retry_count(d, "mission A")
+        assert get_crash_count(d, "mission A") == 0
+
+    def test_clear_preserve_total_also_preserves_crash_count(self, tmp_path):
+        d = str(tmp_path)
+        increment_crash_count(d, "mission B")
+        increment_crash_count(d, "mission B")
+        clear_retry_count(d, "mission B", clear_total=False)
+        # crash_count should be preserved
+        assert get_crash_count(d, "mission B") == 2
+        assert get_total_attempts(d, "mission B") == 2
 
 
 class TestClassifyStagnationEdgeCases:

--- a/koan/tests/test_stagnation_monitor.py
+++ b/koan/tests/test_stagnation_monitor.py
@@ -17,7 +17,9 @@ from app.stagnation_monitor import (
     clear_retry_count,
     get_retry_count,
     get_retry_info,
+    get_total_attempts,
     increment_retry_count,
+    increment_total_attempts,
 )
 
 
@@ -611,6 +613,95 @@ class TestRetryTracker:
         with patch("app.utils.atomic_write", side_effect=OSError("disk full")):
             # Should not raise — the OSError is caught and printed to stderr.
             increment_retry_count(d, "test mission")
+
+    def test_clear_with_clear_total_false_preserves_total_attempts(self, tmp_path):
+        """clear_retry_count(clear_total=False) resets stagnation count but keeps total_attempts."""
+        d = str(tmp_path)
+        increment_retry_count(d, "mission X")
+        increment_retry_count(d, "mission X")
+        clear_retry_count(d, "mission X", clear_total=False)
+        assert get_retry_count(d, "mission X") == 0
+        assert get_total_attempts(d, "mission X") == 2
+
+    def test_clear_with_clear_total_true_resets_everything(self, tmp_path):
+        """clear_retry_count() (default) removes the entry entirely including total_attempts."""
+        d = str(tmp_path)
+        increment_retry_count(d, "mission Y")
+        increment_total_attempts(d, "mission Y")
+        clear_retry_count(d, "mission Y")
+        assert get_retry_count(d, "mission Y") == 0
+        assert get_total_attempts(d, "mission Y") == 0
+
+
+class TestTotalAttempts:
+    """Tests for the cross-system total_attempts counter (B6 fix)."""
+
+    def test_get_total_returns_zero_for_unknown_mission(self, tmp_path):
+        assert get_total_attempts(str(tmp_path), "unseen") == 0
+
+    def test_increment_retry_also_increments_total(self, tmp_path):
+        d = str(tmp_path)
+        increment_retry_count(d, "mission A")
+        increment_retry_count(d, "mission A")
+        assert get_total_attempts(d, "mission A") == 2
+
+    def test_increment_total_without_stagnation(self, tmp_path):
+        """increment_total_attempts increments total_attempts without touching stagnation count."""
+        d = str(tmp_path)
+        increment_total_attempts(d, "crash mission")
+        increment_total_attempts(d, "crash mission")
+        assert get_total_attempts(d, "crash mission") == 2
+        assert get_retry_count(d, "crash mission") == 0
+
+    def test_combined_total_across_stagnation_and_crash(self, tmp_path):
+        """total_attempts accumulates across both stagnation and crash-recovery increments."""
+        d = str(tmp_path)
+        increment_retry_count(d, "flaky mission")   # stagnation
+        increment_total_attempts(d, "flaky mission")  # crash-recovery
+        increment_retry_count(d, "flaky mission")   # stagnation again
+        assert get_retry_count(d, "flaky mission") == 2
+        assert get_total_attempts(d, "flaky mission") == 3
+
+    def test_total_survives_stagnation_counter_clear(self, tmp_path):
+        """Clearing the stagnation counter with clear_total=False leaves total_attempts intact."""
+        d = str(tmp_path)
+        increment_retry_count(d, "sticky mission")  # stagnation (total = 1)
+        increment_total_attempts(d, "sticky mission")  # crash (total = 2)
+        clear_retry_count(d, "sticky mission", clear_total=False)
+        assert get_retry_count(d, "sticky mission") == 0
+        assert get_total_attempts(d, "sticky mission") == 2
+
+    def test_total_reset_on_success_clear(self, tmp_path):
+        """Full clear (default) wipes total_attempts — used after genuine success."""
+        d = str(tmp_path)
+        increment_retry_count(d, "mission Z")
+        increment_total_attempts(d, "mission Z")
+        clear_retry_count(d, "mission Z")  # clear_total=True by default
+        assert get_total_attempts(d, "mission Z") == 0
+
+    def test_get_retry_info_includes_total_attempts(self, tmp_path):
+        """get_retry_info() includes total_attempts in its return dict."""
+        d = str(tmp_path)
+        increment_retry_count(d, "info mission")
+        increment_total_attempts(d, "info mission")
+        info = get_retry_info(d, "info mission")
+        assert info["count"] == 1
+        assert info["total_attempts"] == 2
+
+    def test_increment_total_handles_fresh_entry(self, tmp_path):
+        """increment_total_attempts creates a new entry when mission has no prior tracker data."""
+        d = str(tmp_path)
+        result = increment_total_attempts(d, "brand new mission")
+        assert result == 1
+        assert get_total_attempts(d, "brand new mission") == 1
+        assert get_retry_count(d, "brand new mission") == 0
+
+    def test_key_stable_across_lifecycle_markers_for_total(self, tmp_path):
+        """total_attempts key is stable regardless of [r:N] tags or timestamps."""
+        d = str(tmp_path)
+        increment_total_attempts(d, "- Fix the tests [r:1]")
+        assert get_total_attempts(d, "- Fix the tests") == 1
+        assert get_total_attempts(d, "- Fix the tests [r:2]") == 1
 
 
 class TestClassifyStagnationEdgeCases:


### PR DESCRIPTION
## Problem

Two independent retry systems accumulated silently with no shared ceiling:
- `[r:N]` tags embedded in mission text (missions.md) for crash-recovery, hardcoded max 3
- `.stagnation-retries.json` for stagnation retries, max configurable

A mission could cycle between stagnating and crashing indefinitely because:
1. Neither counter knew about the other
2. Any non-stagnation exit cleared the stagnation counter, resetting cross-system progress
3. Counters were cleared immediately on escalation to Failed, so the human couldn't see why

## Changes

**Commit 1 — cross-system ceiling (`total_attempts`):**
- Add `total_attempts` field to tracker entries; incremented by both stagnation requeues and
  crash-recovery on requeue
- New `max_total_retries` config key (default 0 = disabled) in `get_stagnation_config()` —
  single operator knob across both systems
- `clear_retry_count(clear_total=False)` preserves `total_attempts` across crash cycles
- Both `classify_mission_state()` and `_finalize_mission` check combined cap

**Commit 2 — unified storage (remove `[r:N]` from missions.md):**
- Rename `.stagnation-retries.json` → `.mission-retries.json` with auto-migration
- Add `crash_count` field alongside existing stagnation `count`
- New `get_crash_count()` / `increment_crash_count()` API; `increment_crash_count()` also
  increments `total_attempts`
- New `max_crash_retries` config key (default 3) replaces hardcoded `MAX_RECOVERY_ATTEMPTS`
- `classify_mission_state()` takes `crash_count: int` instead of parsing `[r:N]` from text
- Remove `MAX_RECOVERY_ATTEMPTS`, `_get_recovery_attempts`, `_set_recovery_attempts` from
  `recover.py`; keep `_strip_recovery_counter()` for backward-compat cleanup of old tags
- Backward compat: legacy `[r:N]` tags in existing missions.md are read during recovery and,
  when higher than the tracker's `crash_count`, seeded into the tracker (via `seed_crash_count`)
  so the migrated count survives the recovery cycle; the tag itself is stripped on next write

**Commit 3 — counter lifetime (preserve in Failed; clear on human retry):**
- Counter is NOT cleared when stagnation cap is hit or mission escalated to Failed
- Counter is cleared only when `_start_mission_in_file()` detects a cap was previously hit
  (`stag_count >= max_retry` OR `crash_count >= max_crash_retries` OR `total >= max_total`),
  signalling a deliberate human retry
- Ongoing stagnation-retry requeus (count < cap) keep their counter intact
- New `_clear_if_cap_hit()` helper encapsulates the conditional clear logic

**Commit 4 — PR review fixes:**
- `_clear_if_cap_hit` reads the tracker once via `get_retry_info()` and bails early when the
  mission has no entry — avoids a config load + 3 reads on every new-mission start (hot path).
  Config keys are read directly (no `.get()` fallbacks that could drift from the centralized
  `get_stagnation_config()` defaults).
- `total_cap` cause tag now embeds the counts: `stagnation:{pattern}:total_cap({total}/{max_total})`,
  making the Failed entry self-documenting.
- `classify_mission_state()` is now keyword-only, closing the silent positional-breakage footgun
  introduced by the `str → int` first-argument change.
- Legacy `[r:N]` seeding (see Commit 2 backward-compat note above).
- Documented the intentional counter-preservation-in-Failed behaviour and its bounded
  orphan-entry limitation in the `.mission-retries.json` tracker module comment.

**Commit 5 — PR review fixes (round 2):**
- **Project-scoped cap detection.** `_clear_if_cap_hit` now reads the *per-project* stagnation
  config (`project_name` threaded through `_start_mission_in_file` → `_clear_if_cap_hit`).
  It previously used global defaults while `_finalize_mission` used the project's, so a human
  retry on a project with tighter caps was silently re-escalated to Failed.
- **Cap-clear failures surface instead of being swallowed.** `_clear_if_cap_hit` returns a
  bool and narrows its catch to `ImportError`; schema mismatches in `get_retry_info` /
  `get_stagnation_config` now propagate. A cap-hit clear failure produces a prominent caller
  warning ("mission may re-escalate to Failed on next finalize") rather than a buried log line.
  Because the In-Progress transition already succeeded before this runs, the caller guards the
  call so a failure cannot abort an already-started mission.
- **Tracker import failure no longer disables escalation.** `recover.py` splits config load
  (safe to fall back to defaults) from tracker-function imports (the escalation safety net).
  When the tracker is unavailable it falls back to the legacy inline `[r:N]` counter **and
  persists the incremented count** (new `_set_recovery_counter()` helper) in both the simple
  and complex-block paths — so a repeatedly crashing mission still escalates instead of looping
  Pending→crash→Pending forever with a count that resets to 0 each cycle.

## Counter lifetime

| Event | Counter action |
|---|---|
| Crash → Failed | preserve all |
| Stagnation cap hit → Failed | preserve all |
| Escalated unrecoverable → Failed | preserve all |
| Stagnation retry requeue (count < cap) | preserve (cap still needs to fire) |
| Mission success | full clear |
| `start_mission()` with cap-hit counter | full clear (human deliberate retry) |

## Test

Full suite passes (2 pre-existing environment failures on the base commit, unrelated to this
change: a `fake_stat()`/`follow_symlinks` mock bug in `test_awake.py` and a flaky timeout in
`test_private_security_audit.py`).

New/updated: `TestCrashCount`, `TestRetryTracker`, `TestTotalAttempts`, `TestUnifiedRetryCap`,
`TestClassifyMissionState`, `TestMigrationBackwardCompat`, plus `TestClearIfCapHit`
(project-scoped cap clearing, no-op early return, clear-failure → `False`) and
`TestDegradedTrackerFallback` (inline counter persist / increment / escalate-at-cap).

**Commit 6 — PR review fixes (round 3):**
- **Consistent direct config access.** `_finalize_mission` now reads
  `max_retry_on_stagnation` / `max_total_retries` via direct key access
  (`cfg["..."]`) instead of `cfg.get(..., 0)`, matching `_clear_if_cap_hit`.
  `get_stagnation_config()` guarantees every key, so a missing key is a real
  schema bug that should surface loudly rather than silently defaulting — and
  the `0` fallback on `max_retry_on_stagnation` was semantically wrong (0
  disables retries; the actual default is 3).
- **Cap-clear errors logged at error level.** The caller's guard around
  `_clear_if_cap_hit` now logs propagated schema errors at error level with a
  full `traceback.format_exc()` instead of a truncated warning, so genuine bugs
  (e.g. a missing `get_retry_info` key) are not easy to miss in production.
