### PR TITLE
feat(refactor): PR refactor skill + reusable pre-gate pass

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -88,8 +88,11 @@ proceeds. Toggle with `plan_review.assumptions_check` in `config.yaml` (default 
 `/fix`, `/implement`, and `/rebase` run an internal refactor pass right before
 the review gate: the same engine as `/refactor` cleans up the freshly produced
 code, makes one extra commit, runs the tests, and pushes — silently (no PR
-comment, since it is part of the larger workflow). This makes large implement
-missions land cleaner code before review.
+comment, since it is part of the larger workflow). If the tests stay red after a
+single fix attempt, the commit is kept local and **not** pushed. This makes
+large implement missions land cleaner code before review. It is on by default;
+disable it with `refactor_pass: { enabled: false }` in `config.yaml` to avoid
+the extra per-mission cost.
 
 The private post-PR review gate for `/fix`, `/implement`, and `/rebase` is
 backend-only: it reuses `/review` analysis, fixes Blocking/Important findings

--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -60,7 +60,7 @@ Complete reference for all Koan slash commands. Use these via Telegram, Slack, o
 | `/rebase [--fix] <PR> [focus area]` | `/rb` | Rebase a PR onto its base branch. **By default rebases only.** Add `--fix` to also address review feedback (implied when you add a focus area or severity keyword after the URL); trailing text is threaded into the mission as focus context | Yes |
 | `/squash <PR>` | `/sq` | Squash all PR commits into one clean commit | Yes |
 | `/recreate <PR>` | `/rc` | Re-implement a PR from scratch on a fresh branch | Yes |
-| `/refactor <desc>` | `/rf` | Targeted refactoring mission | Yes |
+| `/refactor <PR> [focus]` | `/rf` | Refactor a PR's changed code for clarity/simplicity (preserves behavior); one clean commit, push, and a summary comment. Trailing text is extra focus (e.g. "focus on the tests") | Yes |
 | `/check <url>` | `/inspect` | Run project health checks on a PR or issue (rebase, review, plan) | — |
 | `/check_need <url>` | `/need`, `/needs` | Analyze if a PR or issue is still needed vs. current main | — |
 | `/ci_check <PR>\|--enable\|--disable` | — | Check and fix CI failures on a PR (non-blocking, bounded, one attempt per mission); toggle CI system | — |
@@ -84,6 +84,12 @@ ones are folded into the plan's *Open Questions* section so you can resolve them
 the issue. When `/implement` runs, the same audit's findings are injected into the
 implementation context as "verify before coding" guidance — the mission always
 proceeds. Toggle with `plan_review.assumptions_check` in `config.yaml` (default on).
+
+`/fix`, `/implement`, and `/rebase` run an internal refactor pass right before
+the review gate: the same engine as `/refactor` cleans up the freshly produced
+code, makes one extra commit, runs the tests, and pushes — silently (no PR
+comment, since it is part of the larger workflow). This makes large implement
+missions land cleaner code before review.
 
 The private post-PR review gate for `/fix`, `/implement`, and `/rebase` is
 backend-only: it reuses `/review` analysis, fixes Blocking/Important findings

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -641,17 +641,29 @@ Produces a pedagogical walkthrough of the PR: what problem it solves (with examp
 - `/xp https://github.com/org/repo/pull/55` — Same thing, shorter
 </details>
 
-**`/refactor`** — Queue a targeted refactoring mission.
+**`/refactor`** — Refactor a PR's changed code for clarity and simplicity while
+preserving behavior, then commit, push, and comment on the PR.
 
-- **Usage:** `/refactor <github-url-or-path>`
+It refactors only the code this PR introduced (diff vs. the base branch),
+makes one clean convention-aware commit, runs the project's tests (with one fix
+attempt if they break), pushes to the PR branch, and posts a bullet-list summary
+comment explaining what changed. Trailing text after the URL becomes extra focus
+for the refactor.
+
+- **Usage:** `/refactor [--now] <github-pr-url> [focus area]`
 - **Aliases:** `/rf`
-- **GitHub @mention:** `@koan-bot /refactor` on a PR or issue
+- **GitHub @mention:** `@koan-bot /refactor` on a PR
+
+> The same engine runs **internally** at the end of `/implement`, `/rebase`, and
+> `/fix` — right before the private review gate — to clean up freshly produced
+> code (an extra commit, no PR comment).
 
 <details>
 <summary>Use cases</summary>
 
-- `/refactor https://github.com/org/repo/pull/60` — Refactor code in a PR
-- `/rf https://github.com/org/repo/issues/70` — Refactor based on an issue description
+- `/refactor https://github.com/org/repo/pull/60` — Clean up a PR's code
+- `/refactor https://github.com/org/repo/pull/60 focus on the tests` — Scope the refactor
+- `/rf --now https://github.com/org/repo/pull/60` — Run it at the top of the queue
 </details>
 
 ### PR Management
@@ -1811,7 +1823,7 @@ Ten skills can be triggered by commenting `@koan-bot <command>` on GitHub issues
 | `/reviewrebase` | `@koan-bot /rr` on a PR |
 | `/planimplement` | `@koan-bot /planit` on an issue |
 | `/recreate` | `@koan-bot /recreate` on a PR |
-| `/refactor` | `@koan-bot /refactor` on a PR or issue |
+| `/refactor` | `@koan-bot /refactor` on a PR |
 | `/plan` | `@koan-bot /plan <idea>` on an issue |
 | `/profile` | `@koan-bot /profile` on a PR or issue |
 
@@ -2397,7 +2409,7 @@ All commands at a glance. **Tier:** B = Beginner, I = Intermediate, P = Power Us
 | `/debug <issue>` | `/dbg` | I | Structured 4-step debug loop (reproduce → hypothesize → fix → verify) |
 | `/review <PR> [PR ...] [--architecture] [--errors] [--bot-comments]` | `/rv`, `/rereview`, `/re_review` | I | Review one or more pull requests |
 | `/explain <PR>` | `/xp` | I | Explain a PR in plain language with examples |
-| `/refactor <desc>` | `/rf` | I | Targeted refactoring mission |
+| `/refactor <PR> [focus]` | `/rf` | I | Refactor a PR's changed code (preserves behavior), commit, push & comment |
 | `/ask <comment-url>` | `/question` | I | Ask a question about a PR/issue — posts AI reply to GitHub |
 | `/rebase [--fix] <PR> [focus area]` | `/rb` | I | Rebase a PR onto its base branch (rebase-only by default); `--fix` (or trailing text) also addresses review feedback |
 | `/reviewrebase <PR>` | `/rr` | I | Review then rebase a PR (combo: /review → /rebase --fix) |

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -764,6 +764,14 @@ usage:
 #   dedup: true            # Skip re-reviewing the same clean PR head (default: true)
 #   tracker_max_age_days: 30  # Dedup tracker entry retention (default: 30)
 
+# Internal refactor pass — before the private review gate, /implement, /rebase
+# and /fix run a refactor pass on the freshly produced code (an extra commit,
+# pushed, no PR comment) so the gate reviews cleaner code. Set enabled: false to
+# skip it and avoid the extra per-mission cost. The standalone /refactor command
+# is unaffected.
+# refactor_pass:
+#   enabled: true          # Master switch (default: true)
+
 # Prompt injection guard — scans incoming missions for suspicious patterns
 # Detects instruction overrides, role confusion, secret extraction, shell injection.
 # Complements outbox_scanner (output defense) with input-side defense.

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -906,6 +906,21 @@ def is_session_resume_enabled() -> bool:
     return bool(config.get("session_resume_enabled", True))
 
 
+def is_internal_refactor_pass_enabled() -> bool:
+    """Check if the internal refactor pass runs before the review gate.
+
+    When True, ``/implement``, ``/rebase`` and ``/fix`` run a refactor pass on
+    the freshly produced code (an extra commit, pushed, no PR comment) right
+    before the private review gate. Default: True (opt-out via
+    ``refactor_pass: { enabled: false }`` to avoid the extra per-mission cost).
+    """
+    config = _load_config()
+    refactor_cfg = config.get("refactor_pass", {})
+    if isinstance(refactor_cfg, dict):
+        return bool(refactor_cfg.get("enabled", True))
+    return True
+
+
 def is_dashboard_enabled() -> bool:
     """Check if dashboard is enabled for managed startup.
 

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -57,6 +57,7 @@ from app.config import (
 from app.git_utils import ordered_remotes as _ordered_remotes
 from app.github import run_gh, sanitize_github_comment
 from app.prompts import load_prompt, load_prompt_or_skill, load_skill_prompt  # noqa: F401 — safety import
+from app.refactor_step import run_internal_refactor_pass
 from app.retry import retry_with_backoff
 from app.utils import (
     _GITHUB_REMOTE_RE,
@@ -1012,6 +1013,14 @@ def _run_rebase_impl(
             f"Actions completed:\n" +
             "\n".join(f"- {a}" for a in actions_log)
         )
+
+    # ── Step 6b: Internal refactor pass before the review gate ─────────
+    # Extra commit, pushed; best-effort, no PR comment (internal workflow).
+    run_internal_refactor_pass(
+        project_path,
+        base_branch=base,
+        notify_fn=notify_fn,
+    )
 
     # ── Step 7: Private review gate ────────────────────────────────────
     gate_result = _run_rebase_private_review_gate(

--- a/koan/app/refactor_pr.py
+++ b/koan/app/refactor_pr.py
@@ -1,0 +1,236 @@
+"""
+Kōan -- Pull Request refactor workflow.
+
+Refactors the code on a PR's branch for simplicity, reuse, and clarity while
+preserving behavior, commits the result, pushes to the existing PR branch, and
+posts a bullet-list summary comment on the PR.
+
+Pipeline:
+1. Resolve the PR location (cross-owner support) and fetch its metadata
+2. Checkout the PR branch locally
+3. Run the reusable refactor pass (refactor → commit → tests → push)
+4. Comment on the PR with a summary of what changed
+5. Restore the original branch
+
+The actual refactoring lives in :mod:`app.refactor_step` so the same pass can
+run internally inside /implement, /rebase and /fix before their review gate.
+"""
+
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+from app.claude_step import _get_current_branch, _safe_checkout, resolve_pr_location
+from app.github import run_gh, sanitize_github_comment
+from app.rebase_pr import _find_remote_for_repo, fetch_pr_context
+from app.refactor_step import RefactorResult, run_refactor_pass
+from app.squash_pr import _checkout_pr_branch
+
+_REFACTOR_SKILL_DIR = (
+    Path(__file__).resolve().parent.parent / "skills" / "core" / "refactor"
+)
+
+
+def run_refactor(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    project_path: str,
+    context: str = "",
+    notify_fn=None,
+    skill_dir: Optional[Path] = None,
+) -> Tuple[bool, str]:
+    """Execute the refactor pipeline for a pull request.
+
+    Returns:
+        (success, summary) tuple.
+    """
+    if notify_fn is None:
+        from app.notify import send_telegram
+        notify_fn = send_telegram
+    skill_dir = skill_dir or _REFACTOR_SKILL_DIR
+
+    # -- Step 0: Resolve actual PR location (cross-owner support) --
+    print(f"[refactor] Starting refactor for PR #{pr_number}", flush=True)
+    try:
+        owner, repo = resolve_pr_location(owner, repo, pr_number, project_path)
+    except RuntimeError as e:
+        return False, str(e)
+    full_repo = f"{owner}/{repo}"
+
+    # -- Step 1: Fetch PR context --
+    notify_fn(f"Reading PR #{pr_number}...")
+    try:
+        pr = fetch_pr_context(owner, repo, pr_number, project_path)
+    except Exception as e:
+        return False, f"Failed to fetch PR context: {e}"
+
+    pr_state = pr.get("state", "").upper()
+    if pr_state in ("MERGED", "CLOSED"):
+        msg = f"PR #{pr_number} is already {pr_state.lower()} — skipping refactor."
+        notify_fn(msg)
+        return True, msg
+
+    branch = pr.get("branch")
+    if not branch:
+        return False, "Could not determine PR branch name."
+    base = pr.get("base", "main")
+
+    head_owner = pr.get("head_owner", "")
+    head_remote = (
+        _find_remote_for_repo(head_owner, repo, project_path) if head_owner else None
+    )
+
+    # -- Step 2: Checkout PR branch --
+    notify_fn(f"Checking out `{branch}`...")
+    original_branch = _get_current_branch(project_path)
+    try:
+        _checkout_pr_branch(
+            branch, project_path,
+            head_remote=head_remote, head_owner=head_owner, repo=repo,
+        )
+    except Exception as e:
+        return False, f"Failed to checkout branch `{branch}`: {e}"
+
+    # -- Step 3: Refactor pass --
+    focus = f" (focus: {context})" if context else ""
+    notify_fn(f"Refactoring `{branch}`{focus}...")
+    try:
+        result = run_refactor_pass(
+            project_path,
+            context=context,
+            skill_dir=skill_dir,
+            base_branch=base,
+            branch=branch,
+            notify_fn=notify_fn,
+            run_tests=True,
+            push=True,
+        )
+    except Exception as e:
+        _safe_checkout(original_branch, project_path)
+        return False, f"Refactor failed: {e}"
+
+    # No changes needed — leave a short note and stop.
+    if not result.committed:
+        _safe_checkout(original_branch, project_path)
+        _comment_no_changes(pr_number, full_repo, notify_fn)
+        msg = f"PR #{pr_number}: no refactoring changes were needed."
+        notify_fn(msg)
+        return True, msg
+
+    if not result.pushed:
+        _safe_checkout(original_branch, project_path)
+        return False, (
+            f"Refactored `{branch}` but the push was rejected — the branch may "
+            "not be pushable from this instance."
+        )
+
+    # -- Step 4: Comment on the PR --
+    comment_body = _build_refactor_comment(branch, result)
+    commented = False
+    try:
+        run_gh(
+            "pr", "comment", pr_number,
+            "--repo", full_repo,
+            "--body", sanitize_github_comment(comment_body),
+        )
+        commented = True
+    except Exception as e:
+        notify_fn(f"Changes pushed but failed to comment on PR: {e}")
+
+    # -- Step 5: Restore original branch --
+    _safe_checkout(original_branch, project_path)
+
+    parts = [f"PR #{pr_number} refactored and pushed."]
+    parts.extend(f"- {b}" for b in result.bullets)
+    if result.tests:
+        parts.append(f"- Tests: {result.tests}")
+    if commented:
+        parts.append("- Commented on PR")
+    return True, "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_refactor_comment(branch: str, result: RefactorResult) -> str:
+    """Build a markdown comment summarizing the refactor."""
+    bullets = result.bullets or ["Simplified and cleaned up recent changes."]
+    changes_md = "\n".join(f"- {b}" for b in bullets)
+
+    parts = [
+        "## Refactor\n",
+        f"Branch `{branch}` was refactored for clarity and simplicity — "
+        "preserving behavior — then pushed.\n",
+        f"### What changed\n\n{changes_md}\n",
+    ]
+    if result.tests:
+        parts.append(f"### Tests\n\n{result.tests}\n")
+    parts.append("---\n_Automated by Kōan_")
+    return "\n".join(parts)
+
+
+def _comment_no_changes(pr_number: str, full_repo: str, notify_fn) -> None:
+    """Post a short best-effort note when no refactoring was needed."""
+    body = (
+        "## Refactor\n\nNo refactoring changes were needed — the code already "
+        "reads cleanly. ✅\n\n---\n_Automated by Kōan_"
+    )
+    try:
+        run_gh(
+            "pr", "comment", pr_number,
+            "--repo", full_repo,
+            "--body", sanitize_github_comment(body),
+        )
+    except Exception as e:
+        notify_fn(f"Could not comment on PR: {e}")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point -- python3 -m app.refactor_pr <url> --project-path <path>
+# ---------------------------------------------------------------------------
+
+
+def main(argv=None):
+    """CLI entry point for refactor_pr.
+
+    Returns exit code (0 = success, 1 = failure).
+    """
+    import argparse
+
+    from app.github_url_parser import parse_pr_url as _parse_url
+
+    parser = argparse.ArgumentParser(
+        description="Refactor a GitHub PR's code for clarity, then push & comment."
+    )
+    parser.add_argument("url", help="GitHub PR URL")
+    parser.add_argument(
+        "--project-path", required=True,
+        help="Local path to the project repository",
+    )
+    parser.add_argument(
+        "--context", default="",
+        help="Optional extra focus for the refactor (e.g. 'focus on the tests')",
+    )
+    cli_args = parser.parse_args(argv)
+
+    try:
+        owner, repo, pr_number = _parse_url(cli_args.url)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    success, summary = run_refactor(
+        owner, repo, pr_number, cli_args.project_path,
+        context=cli_args.context,
+        skill_dir=_REFACTOR_SKILL_DIR,
+    )
+
+    print(summary)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/koan/app/refactor_pr.py
+++ b/koan/app/refactor_pr.py
@@ -105,6 +105,7 @@ def run_refactor(
             notify_fn=notify_fn,
             run_tests=True,
             push=True,
+            head_remote=head_remote,
         )
     except Exception as e:
         _safe_checkout(original_branch, project_path)
@@ -117,6 +118,15 @@ def run_refactor(
         msg = f"PR #{pr_number}: no refactoring changes were needed."
         notify_fn(msg)
         return True, msg
+
+    # Tests stayed red after the one fix attempt — the commit was NOT pushed.
+    # Report failure and post no comment (don't advertise broken code).
+    if not result.tests_passed:
+        _safe_checkout(original_branch, project_path)
+        return False, (
+            f"Refactored `{branch}` but tests are still failing "
+            f"({result.tests}) — the commit was not pushed."
+        )
 
     if not result.pushed:
         _safe_checkout(original_branch, project_path)

--- a/koan/app/refactor_step.py
+++ b/koan/app/refactor_step.py
@@ -1,0 +1,289 @@
+"""
+Kōan -- Reusable refactor pass.
+
+Refactors the changed code on the current branch for simplicity, reuse, and
+clarity while preserving behavior, makes one clean convention-aware commit,
+optionally runs the test suite (with a single fix attempt), and optionally
+pushes the new commit to the branch's remote.
+
+This is the shared core used by:
+  - the standalone ``/refactor`` skill runner (``app.refactor_pr``), which wraps
+    it with PR checkout + a GitHub summary comment; and
+  - the ``/implement``, ``/rebase`` and ``/fix`` pipelines, which run it as an
+    internal quality pass immediately before the private review gate (no PR
+    comment).
+
+The pass never reaches outside the working tree on its own beyond a plain
+``git push`` of the new commit — it adds a commit on top of existing work, so a
+fast-forward push is always sufficient (no force, no rebase).
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Skill dir used to load the refactor prompt when a caller doesn't supply one.
+_REFACTOR_SKILL_DIR = (
+    Path(__file__).resolve().parent.parent / "skills" / "core" / "refactor"
+)
+
+# Markers the prompt emits around its human-readable change summary.
+_SUMMARY_START = "===REFACTOR_SUMMARY==="
+_SUMMARY_END = "===END==="
+
+# Commit message used when the prompt emits no COMMIT_SUBJECT line.
+_DEFAULT_COMMIT_MSG = "refactor: simplify and clean up recent changes"
+
+
+def _noop(_msg: str) -> None:
+    """No-op notifier used when a caller passes no notify_fn."""
+    return None
+
+
+class RefactorResult:
+    """Outcome of a single refactor pass."""
+
+    __slots__ = ("bullets", "committed", "pushed", "summary", "tests")
+
+    def __init__(
+        self,
+        committed: bool = False,
+        pushed: bool = False,
+        bullets: Optional[List[str]] = None,
+        tests: str = "",
+        summary: str = "",
+    ):
+        self.committed = committed
+        self.pushed = pushed
+        self.bullets = bullets or []
+        self.tests = tests
+        self.summary = summary
+
+    def __bool__(self) -> bool:
+        return self.committed
+
+
+def run_refactor_pass(
+    project_path: str,
+    *,
+    context: str = "",
+    skill_dir: Optional[Path] = None,
+    base_branch: Optional[str] = None,
+    branch: Optional[str] = None,
+    notify_fn=None,
+    run_tests: bool = True,
+    push: bool = True,
+    project_name: str = "",
+    instance_dir: str = "",
+) -> RefactorResult:
+    """Refactor the changed code on the current branch.
+
+    Args:
+        project_path: Local path to the project repository.
+        context: Optional extra focus for the refactor (e.g. "focus on the
+            tests"); flows into the prompt.
+        skill_dir: Path to the refactor skill dir for prompt loading.
+        base_branch: Branch the diff is computed against. Auto-resolved when
+            omitted.
+        branch: Branch being refactored. Defaults to the current branch.
+        notify_fn: Progress notifier. Defaults to a no-op.
+        run_tests: Run the project's tests after refactoring (single fix
+            attempt on failure).
+        push: Push the new commit to the branch's remote (plain fast-forward).
+        project_name: Project name (auto-resolved from the path when omitted).
+        instance_dir: Instance directory (reserved for future use).
+
+    Returns:
+        A :class:`RefactorResult`. ``committed`` is False when the refactor
+        produced no changes (a clean no-op) or the Claude step failed.
+    """
+    from app.claude_step import _get_current_branch, run_claude_step
+    from app.commit_conventions import get_project_commit_guidance
+    from app.config import get_skill_max_turns, get_skill_timeout
+    from app.projects_config import resolve_base_branch
+    from app.prompts import load_prompt_or_skill
+    from app.utils import project_name_for_path
+
+    notify = notify_fn or _noop
+    skill_dir = skill_dir or _REFACTOR_SKILL_DIR
+
+    branch = branch or _get_current_branch(project_path)
+    project_name = project_name or project_name_for_path(project_path)
+    base_branch = base_branch or resolve_base_branch(project_name, project_path)
+
+    commit_guidance = get_project_commit_guidance(project_path, base_branch)
+
+    prompt = load_prompt_or_skill(
+        skill_dir,
+        "refactor",
+        PROJECT_PATH=project_path,
+        BASE_BRANCH=base_branch,
+        BRANCH=branch,
+        CONTEXT=context or "",
+        COMMIT_GUIDANCE=commit_guidance,
+    )
+
+    actions_log: List[str] = []
+    step = run_claude_step(
+        prompt=prompt,
+        project_path=project_path,
+        commit_msg=_DEFAULT_COMMIT_MSG,
+        success_label="Applied refactoring",
+        failure_label="Refactor step failed",
+        actions_log=actions_log,
+        max_turns=get_skill_max_turns(),
+        timeout=get_skill_timeout(),
+        use_convention_subject=bool(commit_guidance),
+    )
+
+    if not step.committed:
+        return RefactorResult(
+            committed=False,
+            summary="No refactoring changes were needed.",
+        )
+
+    bullets = _parse_summary_bullets(step.output)
+
+    tests_status = ""
+    if run_tests:
+        tests_status = _run_tests_with_one_fix(project_path, notify)
+
+    pushed = _push_branch(branch, project_path) if push else False
+
+    summary = "Refactoring applied"
+    if bullets:
+        summary += f" ({len(bullets)} change(s))"
+    return RefactorResult(
+        committed=True,
+        pushed=pushed,
+        bullets=bullets,
+        tests=tests_status,
+        summary=summary,
+    )
+
+
+def run_internal_refactor_pass(
+    project_path: str,
+    *,
+    project_name: str = "",
+    instance_dir: str = "",
+    base_branch: Optional[str] = None,
+    notify_fn=None,
+) -> RefactorResult:
+    """Best-effort internal refactor pass for /implement, /rebase, /fix.
+
+    Runs immediately before the private review gate. Produces an extra commit
+    and pushes it, but never posts a PR comment (internal workflow) and never
+    raises — a refactor failure must not block the review gate.
+    """
+    notify = notify_fn or _noop
+    try:
+        result = run_refactor_pass(
+            project_path,
+            context="",
+            base_branch=base_branch,
+            notify_fn=notify,
+            run_tests=True,
+            push=True,
+            project_name=project_name,
+            instance_dir=instance_dir,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort, must not block the gate
+        logger.warning("[refactor] internal pass failed: %s", e)
+        return RefactorResult(committed=False, summary=f"refactor pass skipped: {e}")
+
+    if result.committed:
+        notify("🛠️ Refactor pass applied before review gate")
+    else:
+        notify("🛠️ Refactor pass: no changes needed")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_summary_bullets(output: str) -> List[str]:
+    """Extract bullet lines from the ===REFACTOR_SUMMARY===…===END=== block."""
+    if not output:
+        return []
+    start = output.find(_SUMMARY_START)
+    if start == -1:
+        return []
+    start += len(_SUMMARY_START)
+    end = output.find(_SUMMARY_END, start)
+    block = output[start:] if end == -1 else output[start:end]
+
+    bullets: List[str] = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("-", "*")):
+            text = stripped[1:].strip()
+            if text:
+                bullets.append(text)
+    return bullets
+
+
+def _run_tests_with_one_fix(project_path: str, notify) -> str:
+    """Run the test suite; on failure, attempt one Claude fix and re-run.
+
+    Returns a short human-readable status string.
+    """
+    from app.claude_step import run_claude_step, run_project_tests
+    from app.config import get_skill_max_turns
+    from app.pr_review import detect_test_command
+
+    test_cmd = detect_test_command(project_path)
+    if not test_cmd:
+        return "skipped (no test command detected)"
+
+    notify("Running tests after refactor...")
+    result = run_project_tests(project_path, test_cmd=test_cmd)
+    if result.get("passed"):
+        return f"passing ({result.get('details', 'OK')})"
+
+    notify("Tests failing after refactor — attempting one fix...")
+    fix_prompt = (
+        "The test suite is failing after a refactoring pass. "
+        f"Test command: `{test_cmd}`\n\n"
+        f"Test output:\n```\n{result.get('output', '')[:3000]}\n```\n\n"
+        "Fix the failures by correcting the refactoring — preserve the original "
+        "behavior. Only modify what is necessary."
+    )
+    run_claude_step(
+        prompt=fix_prompt,
+        project_path=project_path,
+        commit_msg="fix: repair tests after refactoring",
+        success_label="",
+        failure_label="",
+        actions_log=[],
+        max_turns=get_skill_max_turns(),
+        timeout=600,
+    )
+
+    retest = run_project_tests(project_path, test_cmd=test_cmd)
+    if retest.get("passed"):
+        return "fixed and passing"
+    return f"still failing ({retest.get('details', 'unknown')})"
+
+
+def _push_branch(branch: str, project_path: str) -> bool:
+    """Plain (non-force) push of *branch*, trying each remote in order.
+
+    Returns True on the first successful push, False if all remotes reject it.
+    Never raises — a push failure is reported to the caller, not fatal.
+    """
+    from app.claude_step import _run_git
+    from app.git_utils import ordered_remotes
+
+    for remote in ordered_remotes(None, cwd=project_path):
+        try:
+            _run_git(["git", "push", remote, branch], cwd=project_path)
+            return True
+        except Exception as e:  # noqa: BLE001 — try the next remote
+            logger.warning("[refactor] push to %s failed: %s", remote, e)
+            continue
+    return False

--- a/koan/app/refactor_step.py
+++ b/koan/app/refactor_step.py
@@ -45,7 +45,7 @@ def _noop(_msg: str) -> None:
 class RefactorResult:
     """Outcome of a single refactor pass."""
 
-    __slots__ = ("bullets", "committed", "pushed", "summary", "tests")
+    __slots__ = ("bullets", "committed", "pushed", "summary", "tests", "tests_passed")
 
     def __init__(
         self,
@@ -54,11 +54,14 @@ class RefactorResult:
         bullets: Optional[List[str]] = None,
         tests: str = "",
         summary: str = "",
+        tests_passed: bool = True,
     ):
         self.committed = committed
         self.pushed = pushed
         self.bullets = bullets or []
         self.tests = tests
+        # True unless the suite ran and stayed red after the one fix attempt.
+        self.tests_passed = tests_passed
         self.summary = summary
 
     def __bool__(self) -> bool:
@@ -77,6 +80,7 @@ def run_refactor_pass(
     push: bool = True,
     project_name: str = "",
     instance_dir: str = "",
+    head_remote: Optional[str] = None,
 ) -> RefactorResult:
     """Refactor the changed code on the current branch.
 
@@ -94,10 +98,15 @@ def run_refactor_pass(
         push: Push the new commit to the branch's remote (plain fast-forward).
         project_name: Project name (auto-resolved from the path when omitted).
         instance_dir: Instance directory (reserved for future use).
+        head_remote: Preferred remote to push to (the PR's head remote for
+            fork PRs); tried first before the default remote ordering.
 
     Returns:
         A :class:`RefactorResult`. ``committed`` is False when the refactor
-        produced no changes (a clean no-op) or the Claude step failed.
+        produced no changes (a clean no-op) or the Claude step failed. When the
+        suite stays red after the one fix attempt, the commit is kept locally
+        but NOT pushed (``pushed`` False, ``tests_passed`` False) — broken code
+        never reaches the remote branch.
     """
     from app.claude_step import _get_current_branch, run_claude_step
     from app.commit_conventions import get_project_commit_guidance
@@ -147,10 +156,17 @@ def run_refactor_pass(
     bullets = _parse_summary_bullets(step.output)
 
     tests_status = ""
+    tests_passed = True
     if run_tests:
-        tests_status = _run_tests_with_one_fix(project_path, notify)
+        tests_status, tests_passed = _run_tests_with_one_fix(project_path, notify)
 
-    pushed = _push_branch(branch, project_path) if push else False
+    # Never push code that leaves the suite red — keep the commit local.
+    pushed = False
+    if push:
+        if tests_passed:
+            pushed = _push_branch(branch, project_path, preferred=head_remote)
+        else:
+            notify("Tests still failing after refactor — not pushing.")
 
     summary = "Refactoring applied"
     if bullets:
@@ -160,6 +176,7 @@ def run_refactor_pass(
         pushed=pushed,
         bullets=bullets,
         tests=tests_status,
+        tests_passed=tests_passed,
         summary=summary,
     )
 
@@ -177,8 +194,15 @@ def run_internal_refactor_pass(
     Runs immediately before the private review gate. Produces an extra commit
     and pushes it, but never posts a PR comment (internal workflow) and never
     raises — a refactor failure must not block the review gate.
+
+    Opt-out via ``refactor_pass: { enabled: false }`` in ``config.yaml`` to skip
+    the extra per-mission cost.
     """
+    from app.config import is_internal_refactor_pass_enabled
+
     notify = notify_fn or _noop
+    if not is_internal_refactor_pass_enabled():
+        return RefactorResult(committed=False, summary="refactor pass disabled by config")
     try:
         result = run_refactor_pass(
             project_path,
@@ -227,31 +251,33 @@ def _parse_summary_bullets(output: str) -> List[str]:
     return bullets
 
 
-def _run_tests_with_one_fix(project_path: str, notify) -> str:
+def _run_tests_with_one_fix(project_path: str, notify) -> tuple[str, bool]:
     """Run the test suite; on failure, attempt one Claude fix and re-run.
 
-    Returns a short human-readable status string.
+    Returns:
+        ``(status, passed)`` — a short human-readable status string and whether
+        the suite is green. ``passed`` is True when tests pass, are fixed, or
+        no test command exists (no red signal to block a push).
     """
     from app.claude_step import run_claude_step, run_project_tests
     from app.config import get_skill_max_turns
     from app.pr_review import detect_test_command
+    from app.prompts import load_prompt
 
     test_cmd = detect_test_command(project_path)
     if not test_cmd:
-        return "skipped (no test command detected)"
+        return "skipped (no test command detected)", True
 
     notify("Running tests after refactor...")
     result = run_project_tests(project_path, test_cmd=test_cmd)
     if result.get("passed"):
-        return f"passing ({result.get('details', 'OK')})"
+        return f"passing ({result.get('details', 'OK')})", True
 
     notify("Tests failing after refactor — attempting one fix...")
-    fix_prompt = (
-        "The test suite is failing after a refactoring pass. "
-        f"Test command: `{test_cmd}`\n\n"
-        f"Test output:\n```\n{result.get('output', '')[:3000]}\n```\n\n"
-        "Fix the failures by correcting the refactoring — preserve the original "
-        "behavior. Only modify what is necessary."
+    fix_prompt = load_prompt(
+        "refactor_test_fix",
+        TEST_CMD=test_cmd,
+        TEST_OUTPUT=result.get("output", "")[:3000],
     )
     run_claude_step(
         prompt=fix_prompt,
@@ -266,12 +292,17 @@ def _run_tests_with_one_fix(project_path: str, notify) -> str:
 
     retest = run_project_tests(project_path, test_cmd=test_cmd)
     if retest.get("passed"):
-        return "fixed and passing"
-    return f"still failing ({retest.get('details', 'unknown')})"
+        return "fixed and passing", True
+    return f"still failing ({retest.get('details', 'unknown')})", False
 
 
-def _push_branch(branch: str, project_path: str) -> bool:
+def _push_branch(
+    branch: str, project_path: str, preferred: Optional[str] = None
+) -> bool:
     """Plain (non-force) push of *branch*, trying each remote in order.
+
+    ``preferred`` (the PR's head remote) is tried first so fork PRs push to the
+    fork rather than ``origin``.
 
     Returns True on the first successful push, False if all remotes reject it.
     Never raises — a push failure is reported to the caller, not fatal.
@@ -279,7 +310,7 @@ def _push_branch(branch: str, project_path: str) -> bool:
     from app.claude_step import _run_git
     from app.git_utils import ordered_remotes
 
-    for remote in ordered_remotes(None, cwd=project_path):
+    for remote in ordered_remotes(preferred, cwd=project_path):
         try:
             _run_git(["git", "push", remote, branch], cwd=project_path)
             return True

--- a/koan/app/skill_dispatch.py
+++ b/koan/app/skill_dispatch.py
@@ -74,6 +74,7 @@ _CANONICAL_RUNNERS = {
     "rebase": "app.rebase_pr",
     "recreate": "app.recreate_pr",
     "squash": "app.squash_pr",
+    "refactor": "app.refactor_pr",
     "review": "app.review_runner",
     "ultrareview": "app.review_runner",
     "ai": "app.ai_runner",
@@ -451,6 +452,7 @@ def build_skill_command(
         "rebase": lambda: _build_rebase_cmd(base_cmd, args, project_path),
         "recreate": lambda: _build_pr_url_cmd(base_cmd, args, project_path),
         "squash": lambda: _build_pr_url_cmd(base_cmd, args, project_path),
+        "refactor": lambda: _build_refactor_cmd(base_cmd, args, project_path),
         "review": lambda: _build_review_cmd(base_cmd, args, project_path, project_name),
         "ultrareview": lambda: _build_review_cmd(
             base_cmd, args, project_path, project_name, ultra=True,
@@ -702,6 +704,24 @@ def _build_pr_url_cmd(
     if not url_match:
         return None
     return base_cmd + [url_match.group(0), "--project-path", project_path]
+
+
+def _build_refactor_cmd(
+    base_cmd: List[str], args: str, project_path: str,
+) -> Optional[List[str]]:
+    """Build refactor command: PR URL + optional trailing focus context.
+
+        /refactor <url>                       → refactor the changed code
+        /refactor <url> focus on the tests    → --context "focus on the tests"
+    """
+    url_match = _PR_URL_RE.search(args)
+    if not url_match:
+        return None
+    cmd = base_cmd + [url_match.group(0), "--project-path", project_path]
+    remainder = args[url_match.end():].strip()
+    if remainder:
+        cmd.extend(["--context", remainder])
+    return cmd
 
 
 # Regex to extract a severity keyword from rebase args.
@@ -1098,7 +1118,7 @@ def validate_skill_args(command: str, args: str) -> Optional[str]:
     canonical = _resolve_canonical(command)
 
     # Validation rules use canonical names — aliases inherit automatically.
-    if canonical in ("rebase", "recreate", "review", "ultrareview", "squash", "ci_check", "explain"):
+    if canonical in ("rebase", "recreate", "review", "ultrareview", "squash", "ci_check", "explain", "refactor"):
         if not _PR_URL_RE.search(args):
             return (
                 f"/{command} requires a PR URL "

--- a/koan/skills/core/fix/fix_runner.py
+++ b/koan/skills/core/fix/fix_runner.py
@@ -31,6 +31,7 @@ from app.pr_submit import (
 from app.prompts import load_prompt_or_skill
 from app.github_url_parser import parse_pr_url
 from app.private_review_gate import format_gate_note, run_gate_for_skill
+from app.refactor_step import run_internal_refactor_pass
 
 logger = logging.getLogger(__name__)
 
@@ -251,6 +252,17 @@ def run_fix(
 
     # Build notification and summary
     branch = get_current_branch(project_path)
+
+    # Internal refactor pass before the review gate (extra commit, pushed).
+    # Best-effort, no PR comment. Only when work landed on a feature branch.
+    if branch not in (effective_base_branch, "main", "master"):
+        run_internal_refactor_pass(
+            project_path,
+            project_name=project_name,
+            instance_dir=instance_dir,
+            base_branch=effective_base_branch,
+            notify_fn=notify_fn,
+        )
 
     # In-place fix: the PR already exists, just report the branch.
     if existing_branch:

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -35,6 +35,7 @@ from app.pr_submit import (
 )
 from app.prompts import load_prompt_or_skill
 from app.private_review_gate import format_gate_note, run_gate_for_skill
+from app.refactor_step import run_internal_refactor_pass
 
 logger = logging.getLogger(__name__)
 
@@ -309,6 +310,19 @@ def run_implement(
     # Build notification and summary
     branch = get_current_branch(project_path)
     on_base_branch = branch in (effective_base_branch, "main", "master")
+
+    # Internal refactor pass: clean up the implementation (extra commit, pushed)
+    # before the review gate. Best-effort, no PR comment. Only when work landed
+    # on a feature branch.
+    if not on_base_branch:
+        run_internal_refactor_pass(
+            project_path,
+            project_name=project_name,
+            instance_dir=instance_dir,
+            base_branch=effective_base_branch,
+            notify_fn=notify_fn,
+        )
+
     gate_result = run_gate_for_skill(
         project_path=project_path,
         project_name=project_name,

--- a/koan/skills/core/refactor/SKILL.md
+++ b/koan/skills/core/refactor/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: refactor
 scope: core
-group: code
+group: pr
 emoji: 🛠️
-description: "Queue a refactoring mission (ex: /refactor https://github.com/owner/repo/pull/42)"
-version: 1.0.0
+description: "Queue a PR refactor mission (ex: /refactor https://github.com/owner/repo/pull/42)"
+version: 2.0.0
 audience: hybrid
+caveman: true
+model_key: mission
 github_enabled: true
 github_context_aware: true
 commands:
   - name: refactor
-    description: "Queue a refactoring mission for a PR, issue, or file"
-    usage: "/refactor <github-url-or-path>"
+    description: "Refactor a PR's code for clarity, then push & comment (ex: /refactor <pr-url> [focus]). Use --now to queue at the top."
     aliases: [rf]
 handler: handler.py
 ---

--- a/koan/skills/core/refactor/handler.py
+++ b/koan/skills/core/refactor/handler.py
@@ -1,44 +1,65 @@
-"""Kōan refactor skill -- queue a refactoring mission."""
+"""Kōan refactor skill -- queue a PR refactor mission."""
 
-from app.github_url_parser import parse_github_url
-from app.github_skill_helpers import extract_github_url, handle_github_skill
+from app.github_url_parser import parse_pr_url
+from app.missions import extract_now_flag
+import app.github_skill_helpers as _gh_helpers
 
 
 def handle(ctx):
-    """Handle /refactor command -- queue a refactoring mission.
+    """Handle /refactor command -- queue a refactor mission for a PR.
 
     Usage:
-        /refactor https://github.com/owner/repo/pull/42
-        /refactor https://github.com/owner/repo/issues/42
-        /refactor src/utils.py
+        /refactor https://github.com/owner/repo/pull/123
+        /refactor --now https://github.com/owner/repo/pull/123
+        /refactor https://github.com/owner/repo/pull/123 focus on the tests
+
+    Queues a mission that refactors the PR branch's changed code for
+    simplicity and clarity (preserving behavior), makes one clean commit,
+    pushes to the existing PR branch, and comments on the PR. Any text after
+    the URL becomes extra focus for the refactor. Use --now to queue at the
+    top of the mission queue.
     """
-    args = ctx.args.strip()
+    args = ctx.args.strip() if ctx.args else ""
+
+    # Extract --now flag for priority queuing
+    urgent, args = extract_now_flag(args)
 
     if not args:
         return (
-            "Usage: /refactor <github-url-or-path>\n"
+            "Usage: /refactor [--now] <github-pr-url> [focus area]\n"
             "Ex: /refactor https://github.com/sukria/koan/pull/42\n"
-            "Ex: /refactor src/utils.py\n\n"
-            "Queues a refactoring mission."
+            "Ex: /refactor --now https://github.com/sukria/koan/pull/42\n"
+            "Ex: /refactor https://github.com/sukria/koan/pull/42 focus on the tests\n\n"
+            "Refactors the PR's changed code for clarity (preserving behavior), "
+            "commits, pushes, and comments on the PR.\n"
+            "Use --now to queue at the top of the mission queue."
         )
 
-    # Try to extract a GitHub URL first
-    result = extract_github_url(args, url_type="pr-or-issue")
-    if result:
-        return handle_github_skill(
-            ctx,
-            command="refactor",
-            url_type="pr-or-issue",
-            parse_func=parse_github_url,
-            success_prefix="Refactor queued",
+    result = _gh_helpers.extract_github_url(args, url_type="pr")
+    if not result:
+        return (
+            "❌ No valid GitHub PR URL found.\n"
+            "Ex: /refactor https://github.com/owner/repo/pull/123\n"
+            "Use --now to queue at the top: /refactor --now <url>"
         )
 
-    # No URL found - treat as a file path
-    from app.utils import insert_pending_mission
+    pr_url, context = result
 
-    file_path = args.strip()
-    mission_entry = f"- /refactor {file_path}"
-    missions_path = ctx.instance_dir / "missions.md"
-    insert_pending_mission(missions_path, mission_entry)
+    try:
+        owner, repo, pr_number = parse_pr_url(pr_url)
+    except ValueError as e:
+        return f"❌ {e}"
 
-    return f"Refactor queued for {file_path}"
+    project_path, project_name = _gh_helpers.resolve_project_for_repo(repo, owner=owner)
+    if not project_path:
+        return _gh_helpers.format_project_not_found_error(repo, owner=owner)
+
+    duplicate = _gh_helpers.queue_github_mission_once(
+        ctx, "refactor", pr_url, project_name, context, urgent=urgent,
+        type_label="PR", number=pr_number, owner=owner, repo=repo,
+    )
+    if duplicate:
+        return duplicate
+
+    priority = " (priority)" if urgent else ""
+    return f"Refactor queued{priority} for {_gh_helpers.format_success_message('PR', pr_number, owner, repo)}"

--- a/koan/skills/core/refactor/prompts/refactor.md
+++ b/koan/skills/core/refactor/prompts/refactor.md
@@ -1,0 +1,119 @@
+# Refactor Pass — Code Quality
+
+You are an expert software engineer acting as a code-quality and refactoring
+agent on a pull request branch.
+
+Working directory: `{PROJECT_PATH}`
+Current branch: `{BRANCH}`
+Base branch: `{BASE_BRANCH}`
+
+Your mission is to refactor, simplify, and normalize the code **introduced by
+this branch** while strictly **preserving behavior and public APIs**. Prefer
+simple, explicit, boring code that the next engineer will immediately
+understand over clever or over-abstracted solutions.
+
+## Scope
+
+1. Run `git diff {BASE_BRANCH}...HEAD --name-only` to list the files this branch
+   changed.
+2. Refactor **only** that changed/new code — do **not** touch unrelated code,
+   except a small surrounding cleanup when it clearly and directly improves the
+   changed code's clarity.
+3. Do **not** change behavior, public interfaces, or test expectations. Do not
+   add features.
+
+## Context (mandatory)
+
+Before editing, read `CLAUDE.md` (if present) and respect the project's naming
+conventions, folder structure, architectural boundaries, and existing helper
+utilities.
+
+## Extra focus
+
+{CONTEXT}
+
+(If the focus above is empty, apply the general refactoring rules below.)
+
+## Refactoring Guidelines
+
+Refactor the code while preserving behavior. Favor readability,
+maintainability, and consistency with the existing codebase.
+
+### Principles
+
+- **Simplicity first** — reduce nesting and branching, prefer early returns and
+  small focused functions over large ones, and prefer readability over
+  micro-optimization. Keep diffs minimal and focused: do not reformat untouched
+  regions or introduce new patterns unless they clearly improve the code.
+- **Function design** — each function should do one thing, have an
+  intention-revealing name, take simple explicit parameters, and return early
+  instead of nesting. Avoid long parameter lists, behavior-changing boolean
+  flags, hidden dependencies, and mixed concerns.
+- **No boilerplate or duplication** — do not introduce copy-pasted logic,
+  over-defensive code, redundant checks, dead code, or unused imports. If
+  similar patterns emerge, extract them into reusable helpers.
+- **Reuse before creating** — prefer existing helpers over new ones; search the
+  codebase for a utility that already solves the problem before writing logic.
+- **Extend before duplicating** — if an existing helper is close but not quite
+  sufficient, extend or generalize it instead of creating a parallel helper.
+- **Create new helpers only when justified** — only when no suitable existing
+  abstraction exists. Keep helper APIs focused, reusable, and consistent with
+  existing naming and design conventions. Avoid unnecessary abstractions; every
+  helper must solve a real reuse or readability problem.
+
+### Testing
+
+- Ensure any new or modified helper has tests covering its behavior.
+- Update existing tests when extending a helper's behavior.
+- Add regression tests for refactored logic whose behavior could
+  unintentionally change.
+- Never reduce the overall quality or coverage of the test suite. Keep test
+  changes proportional — do not sweep in unrelated coverage.
+
+### Process
+
+1. **Audit** the changed files for complexity, duplication, inconsistency, and
+   anti-patterns, and for logic that duplicates an existing helper.
+2. **Apply** focused refactors with the smallest reasonable diffs, reusing or
+   extending helpers in preference to adding new ones.
+3. **Cover** any new or modified helper, and any refactor that could shift
+   behavior, with tests.
+
+### Code Quality Checklist
+
+When you have made changes, verify before finishing:
+
+- No behavior changed (unless the focus above explicitly asked for it).
+- Boilerplate and duplication minimized; existing helpers reused wherever
+  possible.
+- New helpers introduced only when justified, and kept small and cohesive.
+- New or modified helpers are covered by tests; affected paths remain covered.
+- The resulting code is simpler than the original.
+
+## Important — do NOT touch git
+
+Make your edits with the Read/Edit/Write tools only. **Do not run
+`git add`, `git commit`, `git push`, or switch branches** — the surrounding
+automation stages, commits (with a convention-aware message), and pushes your
+changes for you. If you made no worthwhile improvement, make no edits.
+
+{COMMIT_GUIDANCE}
+
+## Output (required)
+
+End your response with **exactly** these two sections:
+
+```
+COMMIT_SUBJECT: <one concise, conventional commit subject for the refactor>
+```
+
+```
+===REFACTOR_SUMMARY===
+- <short bullet describing a change you made>
+- <short bullet describing another change>
+===END===
+```
+
+If you made no changes, still emit the summary block with a single bullet
+`- No refactoring was necessary; the code already reads cleanly.` and use
+`COMMIT_SUBJECT: refactor: no changes needed`.

--- a/koan/system-prompts/refactor_test_fix.md
+++ b/koan/system-prompts/refactor_test_fix.md
@@ -1,0 +1,8 @@
+The test suite is failing after a refactoring pass. Test command: `{TEST_CMD}`
+
+Test output:
+```
+{TEST_OUTPUT}
+```
+
+Fix the failures by correcting the refactoring — preserve the original behavior. Only modify what is necessary.

--- a/koan/tests/test_fix_runner.py
+++ b/koan/tests/test_fix_runner.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from skills.core.fix.fix_runner import (
     run_fix,
     _build_issue_body,
@@ -31,6 +33,18 @@ from app.pr_submit import (
 _FIX_MODULE = "skills.core.fix.fix_runner"
 _DIAG_MODULE = "skills.core.fix.fix_diagnose"
 _PR_MODULE = "app.pr_submit"
+
+
+@pytest.fixture(autouse=True)
+def _noop_internal_refactor():
+    """Stub the pre-gate internal refactor pass so runner tests never invoke
+    Claude. Individual tests can re-patch it to assert it is called."""
+    from app.refactor_step import RefactorResult
+    with patch(
+        f"{_FIX_MODULE}.run_internal_refactor_pass",
+        return_value=RefactorResult(committed=False),
+    ) as m:
+        yield m
 
 _MOCK_DIAGNOSTIC = {
     "confidence": "HIGH", "hypothesis": "Test hypothesis",

--- a/koan/tests/test_implement_runner.py
+++ b/koan/tests/test_implement_runner.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from app.github import fetch_issue_with_comments, detect_parent_repo
 from app.issue_tracker.types import IssueContent, IssueRef
 from app.issue_tracker import UnresolvedJiraProjectError
@@ -41,6 +43,18 @@ from app.pr_submit import (
 
 _IMPL_MODULE = "skills.core.implement.implement_runner"
 _PR_MODULE = "app.pr_submit"
+
+
+@pytest.fixture(autouse=True)
+def _noop_internal_refactor():
+    """Stub the pre-gate internal refactor pass so runner tests never invoke
+    Claude. Individual tests can re-patch it to assert it is called."""
+    from app.refactor_step import RefactorResult
+    with patch(
+        f"{_IMPL_MODULE}.run_internal_refactor_pass",
+        return_value=RefactorResult(committed=False),
+    ) as m:
+        yield m
 
 
 def _github_issue(title="Title", body="Body", comments=None, key="42", repo="o/r"):
@@ -1596,6 +1610,33 @@ class TestRunImplementWithPR:
             assert mock_gate.call_args.kwargs["pr_url"] == "https://github.com/o/r/pull/99"
             assert mock_gate.call_args.kwargs["plan_url"] == "https://github.com/o/r/issues/42"
             assert mock_gate.call_args.kwargs["skill_origin"] == "implement"
+
+    def test_internal_refactor_runs_before_gate(self, tmp_path, _noop_internal_refactor):
+        notify = MagicMock()
+        body = "### Summary\nPlan\n#### Phase 1: Do it"
+        gate_result = SimpleNamespace(ran=True, summary="gate ok")
+        with patch(f"{_IMPL_MODULE}.fetch_issue",
+                    return_value=_github_issue(title="Title", body=body)), \
+             patch(f"{_IMPL_MODULE}._run_plan_review_gate", return_value=None), \
+             patch(f"{_IMPL_MODULE}._execute_implementation", return_value="Done"), \
+             patch(f"{_IMPL_MODULE}.get_commit_subjects",
+                    return_value=["feat: implement plan"]), \
+             patch(f"{_IMPL_MODULE}.get_current_branch", return_value="koan/feat"), \
+             patch(f"{_IMPL_MODULE}._submit_implement_pr",
+                    return_value="https://github.com/o/r/pull/99"), \
+             patch(f"{_IMPL_MODULE}.run_gate_for_skill",
+                   return_value=gate_result) as mock_gate:
+            ok, _msg = run_implement(
+                str(tmp_path),
+                "https://github.com/o/r/issues/42",
+                notify_fn=notify,
+                project_name="app",
+            )
+
+        assert ok
+        # the internal refactor pass ran (feature branch) and the gate still ran
+        _noop_internal_refactor.assert_called_once()
+        mock_gate.assert_called_once()
 
     def test_private_gate_failure_does_not_fail_implementation(self, tmp_path):
         notify = MagicMock()

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -48,6 +48,18 @@ from app.rebase_pr import (
 from app.claude_step import _is_permission_error, check_existing_ci, wait_for_ci
 
 
+@pytest.fixture(autouse=True)
+def _noop_internal_refactor():
+    """Stub the pre-gate internal refactor pass so rebase tests never invoke
+    Claude. Individual tests can re-patch it to assert it is called."""
+    from app.refactor_step import RefactorResult
+    with patch(
+        "app.rebase_pr.run_internal_refactor_pass",
+        return_value=RefactorResult(committed=False),
+    ) as m:
+        yield m
+
+
 # ---------------------------------------------------------------------------
 # parse_pr_url (from pr_review)
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_refactor_pr.py
+++ b/koan/tests/test_refactor_pr.py
@@ -1,0 +1,135 @@
+"""Tests for app.refactor_pr — the standalone /refactor PR runner."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.refactor_pr import _build_refactor_comment, main, run_refactor
+from app.refactor_step import RefactorResult
+
+
+_PR_CONTEXT = {
+    "title": "Add feature",
+    "body": "",
+    "branch": "koan/feature",
+    "base": "main",
+    "state": "OPEN",
+    "head_owner": "sukria",
+}
+
+
+def _run(context=None, refactor_result=None, gh_ok=True):
+    """Invoke run_refactor with the external boundaries mocked."""
+    ctx = dict(_PR_CONTEXT)
+    if context:
+        ctx.update(context)
+    result = refactor_result if refactor_result is not None else RefactorResult(
+        committed=True, pushed=True,
+        bullets=["Simplified X"], tests="passing (OK)",
+    )
+    notify = MagicMock()
+    run_gh = MagicMock() if gh_ok else MagicMock(side_effect=RuntimeError("no comment"))
+
+    with patch("app.refactor_pr.resolve_pr_location", return_value=("owner", "repo")), \
+         patch("app.refactor_pr.fetch_pr_context", return_value=ctx), \
+         patch("app.refactor_pr._find_remote_for_repo", return_value="origin"), \
+         patch("app.refactor_pr._get_current_branch", return_value="main"), \
+         patch("app.refactor_pr._checkout_pr_branch", return_value="origin"), \
+         patch("app.refactor_pr._safe_checkout"), \
+         patch("app.refactor_pr.run_refactor_pass", return_value=result) as mock_pass, \
+         patch("app.refactor_pr.run_gh", run_gh):
+        success, summary = run_refactor(
+            "owner", "repo", "42", "/proj", context="", notify_fn=notify,
+        )
+    return success, summary, run_gh, mock_pass
+
+
+class TestRunRefactor:
+    def test_success_posts_comment(self):
+        success, summary, run_gh, _ = _run()
+        assert success is True
+        # a PR comment was posted
+        comment_calls = [c for c in run_gh.call_args_list if c.args[:2] == ("pr", "comment")]
+        assert len(comment_calls) == 1
+        body = comment_calls[0].kwargs.get("body") or comment_calls[0].args[-1]
+        assert "Refactor" in body
+
+    def test_merged_pr_short_circuits(self):
+        success, summary, run_gh, mock_pass = _run(context={"state": "MERGED"})
+        assert success is True
+        assert "merged" in summary.lower()
+        mock_pass.assert_not_called()
+
+    def test_no_changes_posts_short_note(self):
+        success, summary, run_gh, _ = _run(
+            refactor_result=RefactorResult(committed=False),
+        )
+        assert success is True
+        assert "no refactoring" in summary.lower()
+        # the "no changes" note is still posted
+        assert any(c.args[:2] == ("pr", "comment") for c in run_gh.call_args_list)
+
+    def test_push_rejected_fails(self):
+        success, summary, _, _ = _run(
+            refactor_result=RefactorResult(committed=True, pushed=False),
+        )
+        assert success is False
+        assert "push" in summary.lower()
+
+    def test_missing_branch_fails(self):
+        success, summary, _, mock_pass = _run(context={"branch": ""})
+        assert success is False
+        mock_pass.assert_not_called()
+
+    def test_comment_failure_is_nonfatal(self):
+        success, summary, _, _ = _run(gh_ok=False)
+        assert success is True
+
+    def test_context_forwarded_to_pass(self):
+        notify = MagicMock()
+        with patch("app.refactor_pr.resolve_pr_location", return_value=("owner", "repo")), \
+             patch("app.refactor_pr.fetch_pr_context", return_value=dict(_PR_CONTEXT)), \
+             patch("app.refactor_pr._find_remote_for_repo", return_value="origin"), \
+             patch("app.refactor_pr._get_current_branch", return_value="main"), \
+             patch("app.refactor_pr._checkout_pr_branch", return_value="origin"), \
+             patch("app.refactor_pr._safe_checkout"), \
+             patch("app.refactor_pr.run_gh"), \
+             patch("app.refactor_pr.run_refactor_pass",
+                   return_value=RefactorResult(committed=True, pushed=True)) as mock_pass:
+            run_refactor("owner", "repo", "42", "/proj",
+                         context="focus on the tests", notify_fn=notify)
+
+        assert mock_pass.call_args.kwargs["context"] == "focus on the tests"
+
+
+class TestBuildRefactorComment:
+    def test_includes_bullets_and_tests(self):
+        result = RefactorResult(
+            committed=True, pushed=True,
+            bullets=["a", "b"], tests="passing",
+        )
+        body = _build_refactor_comment("koan/x", result)
+        assert "- a" in body and "- b" in body
+        assert "passing" in body
+        assert "Kōan" in body
+
+    def test_falls_back_when_no_bullets(self):
+        body = _build_refactor_comment("koan/x", RefactorResult(committed=True))
+        assert "What changed" in body
+
+
+class TestMain:
+    def test_invalid_url_returns_1(self, capsys):
+        rc = main(["not-a-url", "--project-path", "/proj"])
+        assert rc == 1
+
+    def test_valid_url_dispatches(self):
+        with patch("app.refactor_pr.run_refactor",
+                   return_value=(True, "done")) as mock_run:
+            rc = main([
+                "https://github.com/owner/repo/pull/42",
+                "--project-path", "/proj",
+                "--context", "focus on tests",
+            ])
+        assert rc == 0
+        assert mock_run.call_args.kwargs["context"] == "focus on tests"

--- a/koan/tests/test_refactor_step.py
+++ b/koan/tests/test_refactor_step.py
@@ -1,0 +1,169 @@
+"""Tests for app.refactor_step — the reusable refactor pass."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.refactor_step import (
+    RefactorResult,
+    _parse_summary_bullets,
+    run_internal_refactor_pass,
+    run_refactor_pass,
+)
+
+
+_OUTPUT_WITH_SUMMARY = (
+    "Did some work.\n"
+    "COMMIT_SUBJECT: refactor: simplify auth\n"
+    "===REFACTOR_SUMMARY===\n"
+    "- Extracted a shared helper\n"
+    "- Removed dead code\n"
+    "===END===\n"
+)
+
+
+def _step(committed=True, output=_OUTPUT_WITH_SUMMARY):
+    return MagicMock(committed=committed, output=output)
+
+
+def _patch_common():
+    """Patch the lazily-imported dependencies of run_refactor_pass."""
+    return [
+        patch("app.claude_step._get_current_branch", return_value="koan/feature"),
+        patch("app.projects_config.resolve_base_branch", return_value="main"),
+        patch("app.prompts.load_prompt_or_skill", return_value="PROMPT"),
+        patch("app.commit_conventions.get_project_commit_guidance", return_value=""),
+        patch("app.utils.project_name_for_path", return_value="repo"),
+    ]
+
+
+class TestParseSummaryBullets:
+    def test_extracts_bullets(self):
+        assert _parse_summary_bullets(_OUTPUT_WITH_SUMMARY) == [
+            "Extracted a shared helper",
+            "Removed dead code",
+        ]
+
+    def test_no_block_returns_empty(self):
+        assert _parse_summary_bullets("no markers here") == []
+
+    def test_empty_output(self):
+        assert _parse_summary_bullets("") == []
+
+
+class TestRunRefactorPass:
+    def test_commits_parses_and_pushes(self):
+        patches = _patch_common()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("app.claude_step.run_claude_step", return_value=_step()), \
+             patch("app.pr_review.detect_test_command", return_value=None), \
+             patch("app.git_utils.ordered_remotes", return_value=["origin"]), \
+             patch("app.claude_step._run_git") as mock_git:
+            result = run_refactor_pass("/proj")
+
+        assert result.committed is True
+        assert result.pushed is True
+        assert result.bullets == ["Extracted a shared helper", "Removed dead code"]
+        mock_git.assert_called_once()
+        # plain push, never force
+        pushed_args = mock_git.call_args.args[0]
+        assert "--force" not in pushed_args
+        assert "--force-with-lease" not in pushed_args
+
+    def test_no_changes_is_noop(self):
+        patches = _patch_common()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("app.claude_step.run_claude_step", return_value=_step(committed=False)), \
+             patch("app.git_utils.ordered_remotes", return_value=["origin"]), \
+             patch("app.claude_step._run_git") as mock_git:
+            result = run_refactor_pass("/proj")
+
+        assert result.committed is False
+        assert result.pushed is False
+        mock_git.assert_not_called()
+
+    def test_push_false_skips_push(self):
+        patches = _patch_common()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("app.claude_step.run_claude_step", return_value=_step()), \
+             patch("app.pr_review.detect_test_command", return_value=None), \
+             patch("app.claude_step._run_git") as mock_git:
+            result = run_refactor_pass("/proj", push=False, run_tests=False)
+
+        assert result.committed is True
+        assert result.pushed is False
+        mock_git.assert_not_called()
+
+    def test_run_tests_false_skips_detection(self):
+        patches = _patch_common()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("app.claude_step.run_claude_step", return_value=_step()), \
+             patch("app.pr_review.detect_test_command") as mock_detect, \
+             patch("app.git_utils.ordered_remotes", return_value=["origin"]), \
+             patch("app.claude_step._run_git"):
+            run_refactor_pass("/proj", run_tests=False)
+
+        mock_detect.assert_not_called()
+
+    def test_tests_fixed_after_one_attempt(self):
+        patches = _patch_common()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("app.claude_step.run_claude_step", return_value=_step()) as mock_step, \
+             patch("app.pr_review.detect_test_command", return_value="make test"), \
+             patch("app.claude_step.run_project_tests",
+                   side_effect=[{"passed": False, "output": "boom", "details": "1 failed"},
+                                {"passed": True, "details": "ok"}]), \
+             patch("app.git_utils.ordered_remotes", return_value=["origin"]), \
+             patch("app.claude_step._run_git"):
+            result = run_refactor_pass("/proj")
+
+        assert result.tests == "fixed and passing"
+        # one refactor step + one fix step
+        assert mock_step.call_count == 2
+
+    def test_uses_convention_subject_when_guidance_present(self):
+        with patch("app.claude_step._get_current_branch", return_value="koan/x"), \
+             patch("app.projects_config.resolve_base_branch", return_value="main"), \
+             patch("app.prompts.load_prompt_or_skill", return_value="PROMPT"), \
+             patch("app.commit_conventions.get_project_commit_guidance",
+                   return_value="Use conventional commits"), \
+             patch("app.utils.project_name_for_path", return_value="repo"), \
+             patch("app.claude_step.run_claude_step", return_value=_step()) as mock_step, \
+             patch("app.pr_review.detect_test_command", return_value=None), \
+             patch("app.git_utils.ordered_remotes", return_value=["origin"]), \
+             patch("app.claude_step._run_git"):
+            run_refactor_pass("/proj")
+
+        assert mock_step.call_args.kwargs["use_convention_subject"] is True
+
+    def test_push_failure_reported(self):
+        patches = _patch_common()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("app.claude_step.run_claude_step", return_value=_step()), \
+             patch("app.pr_review.detect_test_command", return_value=None), \
+             patch("app.git_utils.ordered_remotes", return_value=["origin", "upstream"]), \
+             patch("app.claude_step._run_git", side_effect=RuntimeError("rejected")):
+            result = run_refactor_pass("/proj")
+
+        assert result.committed is True
+        assert result.pushed is False
+
+
+class TestRunInternalRefactorPass:
+    def test_swallows_exceptions(self):
+        notify = MagicMock()
+        with patch("app.refactor_step.run_refactor_pass",
+                   side_effect=RuntimeError("kaboom")):
+            result = run_internal_refactor_pass("/proj", notify_fn=notify)
+
+        assert isinstance(result, RefactorResult)
+        assert result.committed is False
+
+    def test_notifies_on_commit(self):
+        notify = MagicMock()
+        with patch("app.refactor_step.run_refactor_pass",
+                   return_value=RefactorResult(committed=True, pushed=True)):
+            run_internal_refactor_pass("/proj", notify_fn=notify)
+
+        assert notify.called
+        assert "Refactor pass" in notify.call_args.args[0]

--- a/koan/tests/test_skill_dispatch.py
+++ b/koan/tests/test_skill_dispatch.py
@@ -294,6 +294,27 @@ class TestBuildSkillCommand:
         cmd = self._build("recreate", "no url here")
         assert cmd is None
 
+    def test_refactor(self):
+        url = "https://github.com/sukria/koan/pull/42"
+        cmd = self._build("refactor", url)
+        assert cmd is not None
+        assert "app.refactor_pr" in cmd
+        assert url in cmd
+        assert "--project-path" in cmd
+        assert "--context" not in cmd
+
+    def test_refactor_with_context(self):
+        url = "https://github.com/sukria/koan/pull/42"
+        cmd = self._build("refactor", f"{url} focus on the tests")
+        assert cmd is not None
+        assert "app.refactor_pr" in cmd
+        assert "--context" in cmd
+        assert cmd[cmd.index("--context") + 1] == "focus on the tests"
+
+    def test_refactor_no_url(self):
+        cmd = self._build("refactor", "no url here")
+        assert cmd is None
+
     def test_ci_check(self):
         url = "https://github.com/sukria/koan/pull/42"
         cmd = self._build("ci_check", url)

--- a/koan/tests/test_skill_handlers_untested.py
+++ b/koan/tests/test_skill_handlers_untested.py
@@ -168,6 +168,9 @@ MISSIONS_TEMPLATE = (
 )
 
 
+_PR_URL = "https://github.com/owner/repo/pull/42"
+
+
 class TestRefactorHandler:
     def test_no_args_returns_usage(self, tmp_path):
         from skills.core.refactor.handler import handle
@@ -177,62 +180,113 @@ class TestRefactorHandler:
         assert "Usage:" in result
         assert "/refactor" in result
 
-    def test_github_url_delegates_to_handle_github_skill(self, tmp_path):
-        from skills.core.refactor.handler import handle
-
-        with patch("skills.core.refactor.handler.extract_github_url",
-                    return_value=("owner", "repo", "42")), \
-             patch("skills.core.refactor.handler.handle_github_skill",
-                    return_value="Refactor queued for #42") as mock_skill:
-            ctx = _make_ctx(
-                tmp_path, command_name="refactor",
-                args="https://github.com/owner/repo/pull/42",
-            )
-            result = handle(ctx)
-
-        mock_skill.assert_called_once()
-        assert result == "Refactor queued for #42"
-
-    def test_file_path_inserts_mission(self, tmp_path):
-        from skills.core.refactor.handler import handle
-
-        ctx = _make_ctx(
-            tmp_path, command_name="refactor",
-            args="src/utils.py",
-            missions_content=MISSIONS_TEMPLATE,
-        )
-        with patch("skills.core.refactor.handler.extract_github_url",
-                    return_value=None):
-            with patch("app.utils.insert_pending_mission") as mock_insert:
-                result = handle(ctx)
-
-        mock_insert.assert_called_once()
-        call_args = mock_insert.call_args[0]
-        assert "refactor" in call_args[1]
-        assert "src/utils.py" in call_args[1]
-        assert "src/utils.py" in result
-
-    def test_non_url_treated_as_file_path(self, tmp_path):
-        from skills.core.refactor.handler import handle
-
-        ctx = _make_ctx(
-            tmp_path, command_name="refactor",
-            args="koan/app/run.py",
-            missions_content=MISSIONS_TEMPLATE,
-        )
-        with patch("skills.core.refactor.handler.extract_github_url",
-                    return_value=None):
-            with patch("app.utils.insert_pending_mission"):
-                result = handle(ctx)
-
-        assert "koan/app/run.py" in result
-
     def test_whitespace_only_returns_usage(self, tmp_path):
         from skills.core.refactor.handler import handle
 
         ctx = _make_ctx(tmp_path, command_name="refactor", args="   ")
         result = handle(ctx)
         assert "Usage:" in result
+
+    def test_non_pr_url_returns_error(self, tmp_path):
+        from skills.core.refactor.handler import handle
+
+        ctx = _make_ctx(
+            tmp_path, command_name="refactor", args="src/utils.py",
+        )
+        result = handle(ctx)
+        assert "No valid GitHub PR URL" in result
+
+    def test_valid_pr_url_queues_mission(self, tmp_path):
+        from skills.core.refactor.handler import handle
+
+        ctx = _make_ctx(
+            tmp_path, command_name="refactor", args=_PR_URL,
+            missions_content=MISSIONS_TEMPLATE,
+        )
+        with patch(
+            "app.github_skill_helpers.resolve_project_for_repo",
+            return_value=("/path/to/repo", "repo"),
+        ), patch(
+            "app.github_skill_helpers.queue_github_mission_once",
+            return_value=None,
+        ) as mock_queue:
+            result = handle(ctx)
+
+        mock_queue.assert_called_once()
+        kwargs = mock_queue.call_args.kwargs
+        args = mock_queue.call_args.args
+        # positional: ctx, command, url, project_name, context
+        assert args[1] == "refactor"
+        assert args[2] == _PR_URL
+        assert kwargs.get("urgent") is False
+        assert "Refactor queued" in result
+
+    def test_context_passed_through(self, tmp_path):
+        from skills.core.refactor.handler import handle
+
+        ctx = _make_ctx(
+            tmp_path, command_name="refactor",
+            args=f"{_PR_URL} focus on the tests",
+            missions_content=MISSIONS_TEMPLATE,
+        )
+        with patch(
+            "app.github_skill_helpers.resolve_project_for_repo",
+            return_value=("/path/to/repo", "repo"),
+        ), patch(
+            "app.github_skill_helpers.queue_github_mission_once",
+            return_value=None,
+        ) as mock_queue:
+            handle(ctx)
+
+        # context is the 5th positional arg
+        assert mock_queue.call_args.args[4] == "focus on the tests"
+
+    def test_now_flag_sets_urgent(self, tmp_path):
+        from skills.core.refactor.handler import handle
+
+        ctx = _make_ctx(
+            tmp_path, command_name="refactor", args=f"--now {_PR_URL}",
+            missions_content=MISSIONS_TEMPLATE,
+        )
+        with patch(
+            "app.github_skill_helpers.resolve_project_for_repo",
+            return_value=("/path/to/repo", "repo"),
+        ), patch(
+            "app.github_skill_helpers.queue_github_mission_once",
+            return_value=None,
+        ) as mock_queue:
+            result = handle(ctx)
+
+        assert mock_queue.call_args.kwargs.get("urgent") is True
+        assert "priority" in result
+
+    def test_project_not_found(self, tmp_path):
+        from skills.core.refactor.handler import handle
+
+        ctx = _make_ctx(tmp_path, command_name="refactor", args=_PR_URL)
+        with patch(
+            "app.github_skill_helpers.resolve_project_for_repo",
+            return_value=(None, None),
+        ):
+            result = handle(ctx)
+        assert "repo" in result.lower()
+
+    def test_duplicate_returns_warning(self, tmp_path):
+        from skills.core.refactor.handler import handle
+
+        ctx = _make_ctx(
+            tmp_path, command_name="refactor", args=_PR_URL,
+            missions_content=MISSIONS_TEMPLATE,
+        )
+        with patch(
+            "app.github_skill_helpers.resolve_project_for_repo",
+            return_value=("/path/to/repo", "repo"),
+        ), patch(
+            "app.github_skill_helpers.queue_github_mission_once",
+            return_value="⚠️ Duplicate ignored",
+        ):
+            result = handle(ctx)
+        assert "Duplicate" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Turn the stub /refactor core skill into a runner-backed PR command,
modelled on /rebase and /squash: it auto-detects the project from the PR
URL, queues a mission, and the run loop dispatches a Python runner that
refactors the PR's changed code for clarity while preserving behavior,
makes one clean convention-aware commit, runs the tests (with a single
fix attempt), pushes, and posts a bullet-list summary comment. Trailing
text after the URL becomes extra focus (e.g. "focus on the tests").

Factor the refactoring itself into app/refactor_step.run_refactor_pass so
the same engine runs internally at the end of /implement, /rebase and
/fix, immediately before the private review gate. The internal pass adds
an extra commit and pushes it but posts no PR comment, leaving cleaner
code for the gate to review. The step lives in its own light module so
the gate-bearing runners can import it without a circular dependency.

The self-contained refactor prompt enforces simplicity-first,
reuse-before-create and behavior preservation, scoped to the branch diff,
and emits COMMIT_SUBJECT plus a parsed summary block for the comment.

Behavior change: /refactor is now PR-only (was a generic file/issue
mission that fell through to the agent) and moves to the pr help group.

Changelog: Add /refactor PR command and run an automatic refactor pass
 before the review gate in /implement, /rebase and /fix

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
