### PR TITLE
feat(context): one deduped steering summary before each Claude call

### DIFF
--- a/docs/users/koan-md.md
+++ b/docs/users/koan-md.md
@@ -4,7 +4,7 @@ title: "KOAN.md — koan-only project instructions"
 description: "Documents the optional project-root KOAN.md file and the .koan/ directory (a second .koan/KOAN.md, per-skill .koan/skills/<skill>/*.md hooks, and a structured .koan/config.yaml with review.always_check): koan-only steering injected into the autonomous agent's system prompt but never loaded by interactive Claude Code sessions, with precedence rules, the 16k-char cap, and this repo's dogfood layout."
 tags: [users]
 created: 2026-07-09
-updated: 2026-07-26
+updated: 2026-07-28
 ---
 
 # KOAN.md — koan-only project instructions
@@ -80,19 +80,26 @@ the mission text instead.
 
 ### Seeing what got loaded (`make logs`)
 
-Every steering file koan folds into a prompt is announced on the run log, so you
-can confirm the context is actually in play. Watch `make logs` for lines like:
+Every steering file koan folds into a prompt is announced on the run log as a
+single summary before Claude Code runs, so you can confirm the context is
+actually in play. Watch `make logs` for a block like:
 
 ```
-[context] Detected KOAN.md, loaded 1240 chars (~ 354 tokens)
-[context] Detected .koan/skills/plan, loaded 380 chars (~ 108 tokens)
-[context] Detected CLAUDE.md (auto-loaded by CLI), loaded 8900 chars (~ 2542 tokens)
+[context] Steering loaded before Claude (3 file(s), ~ 3004 tokens total):
+[context]   • CLAUDE.md (auto-loaded by CLI): 8900 chars (~ 2542 tokens)
+[context]   • KOAN.md: 1240 chars (~ 354 tokens)
+[context]   • .koan/skills/plan: 380 chars (~ 108 tokens)
 ```
 
-`KOAN.md` and `.koan/skills/<skill>` lines mean koan injected that content;
-the `CLAUDE.md` line is **detection-only** — Claude Code loads `CLAUDE.md` from
+`KOAN.md` and `.koan/skills/<skill>` entries mean koan injected that content;
+the `CLAUDE.md` entry is **detection-only** — Claude Code loads `CLAUDE.md` from
 the working directory itself, koan just reports its size so you can see the full
 steering context at a glance. Token counts are a `chars/3.5` estimate.
+
+The block appears once per mission: skills that call the CLI several times (like
+`plan`) rebuild the prompt for each call, and a repeat of the same steering set
+is suppressed rather than re-printed. A new mission always re-announces, even
+when the files have not changed.
 
 ## The `.koan/config.yaml` file
 

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -701,6 +701,11 @@ def _run_iteration(
 
     run_num = count + 1
 
+    # Fresh steering-summary scope per mission: a new mission re-announces its
+    # loaded .md context even when byte-identical to the previous mission's.
+    from app.project_koan import reset_context_load_log
+    reset_context_load_log()
+
     # --- Parallel session reap (Phase 1) ---
     # Poll any active parallel sessions and process completions before planning
     # the next iteration.  Skipped when max_parallel_sessions == 1 (default) so

--- a/koan/app/project_koan.py
+++ b/koan/app/project_koan.py
@@ -32,29 +32,87 @@ _MAX_HOOK_CMD_LEN = 1000
 _HOOK_PHASES = {"pre": "pre_hooks", "post": "post_hooks"}
 
 
-def log_context_load(label: str, content: str) -> None:
-    """Announce a steering file koan just loaded into a prompt, for ``make logs``.
+# --- Steering-context load accumulation (per prompt build) -------------------
+# Each prompt build records the steering files it folds in via
+# record_context_load(); flush_context_summary() emits ONE consolidated block and
+# clears the batch. A summary identical to the previous one is suppressed, so a
+# multi-CLI-call skill (plan builds 3 prompts per mission) announces its steering
+# context once, not once per CLI call. reset_context_load_log() clears the dedup
+# memory per mission so a fresh mission re-announces byte-identical context.
+_pending_loads: list = []   # [(label, chars, tokens), ...] for the current build
+_last_summary_sig = None    # signature of the last-emitted summary
 
-    Emits ``Detected <label>, loaded N chars (~ M tokens)`` on **stderr** so it
-    lands in ``logs/run.log`` (visible via ``make logs``) without ever
-    corrupting the JSON some skill runners write to stdout. The ``logging``
-    module has no stdout/stderr handler wired in the run loop, so ``logger.info``
-    alone would be invisible there — hence the direct ``print``.
 
-    Best-effort: a broken stream (or a missing ``estimate_tokens``) must never
-    break prompt assembly, so every failure is swallowed — logged at debug so it
-    stays visible without ever raising.
-    """
+def _estimate_tokens(content: str) -> int:
     try:
         from app.diff_compressor import estimate_tokens
-        print(
-            f"[context] Detected {label}, loaded {len(content)} chars "
-            f"(~ {estimate_tokens(content)} tokens)",
-            file=sys.stderr,
-            flush=True,
-        )
+        return estimate_tokens(content)
+    except Exception:
+        return 0
+
+
+def record_context_load(label: str, content: str) -> None:
+    """Silently record a steering file folded into the prompt about to be sent.
+
+    Accumulates ``(label, chars, tokens)`` into the current build's batch, deduped
+    by ``label`` (a re-read of the same file updates in place). The consolidated
+    line is emitted later by :func:`flush_context_summary`. Best-effort: never
+    raises — a broken estimator must not break prompt assembly.
+    """
+    try:
+        entry = (label, len(content), _estimate_tokens(content))
+        for i, (lbl, _chars, _tokens) in enumerate(_pending_loads):
+            if lbl == label:
+                _pending_loads[i] = entry
+                return
+        _pending_loads.append(entry)
     except Exception as e:
-        logger.debug("log_context_load failed for %s: %s", label, e)
+        logger.debug("record_context_load failed for %s: %s", label, e)
+
+
+def flush_context_summary() -> None:
+    """Emit one consolidated steering-context summary for the current build.
+
+    Prints on **stderr** (→ ``logs/run.log``, visible via ``make logs``) a block
+    listing every steering file recorded since the last flush, with per-file and
+    total token estimates, then clears the batch. stderr keeps the block away from
+    the JSON some skill runners write to stdout; ``logging`` has no handler wired
+    in the run loop, so a direct ``print`` is the only thing operators would see.
+    Suppresses a summary identical to the previous one (same files + sizes) so
+    repeated prompt builds within a single mission announce once. No-op on an
+    empty batch. Best-effort: never raises.
+    """
+    global _last_summary_sig
+    try:
+        if not _pending_loads:
+            return
+        sig = tuple(_pending_loads)
+        batch = _pending_loads.copy()
+        _pending_loads.clear()
+        if sig == _last_summary_sig:
+            return
+        _last_summary_sig = sig
+        total = sum(tokens for _lbl, _chars, tokens in batch)
+        lines = [
+            f"[context] Steering loaded before Claude "
+            f"({len(batch)} file(s), ~ {total} tokens total):"
+        ]
+        for lbl, chars, tokens in batch:
+            lines.append(f"[context]   • {lbl}: {chars} chars (~ {tokens} tokens)")
+        print("\n".join(lines), file=sys.stderr, flush=True)
+    except Exception as e:
+        logger.debug("flush_context_summary failed: %s", e)
+
+
+def reset_context_load_log() -> None:
+    """Reset per-mission steering-summary state.
+
+    Called once per mission iteration so each mission re-emits its steering
+    summary even when the files are byte-identical to the previous mission's.
+    """
+    global _last_summary_sig
+    _pending_loads.clear()
+    _last_summary_sig = None
 
 
 def _read_or_empty(path: Path) -> str:

--- a/koan/app/project_koan.py
+++ b/koan/app/project_koan.py
@@ -39,15 +39,23 @@ _HOOK_PHASES = {"pre": "pre_hooks", "post": "post_hooks"}
 # multi-CLI-call skill (plan builds 3 prompts per mission) announces its steering
 # context once, not once per CLI call. reset_context_load_log() clears the dedup
 # memory per mission so a fresh mission re-announces byte-identical context.
+#
+# NOT thread-safe: both globals assume a single builder at a time (default
+# max_parallel_sessions == 1). With concurrent prompt builds, one build's flush
+# can emit another build's records or empty its batch. Only the log line is
+# affected — never what Claude receives. Move to threading.local() if parallel
+# sessions become the default.
 _pending_loads: list = []   # [(label, chars, tokens), ...] for the current build
 _last_summary_sig = None    # signature of the last-emitted summary
 
 
 def _estimate_tokens(content: str) -> int:
+    """Best-effort token estimate; 0 (with a debug trace) when unavailable."""
     try:
         from app.diff_compressor import estimate_tokens
         return estimate_tokens(content)
-    except Exception:
+    except Exception as e:
+        logger.debug("estimate_tokens failed (reporting 0 tokens): %s", e)
         return 0
 
 

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -328,12 +328,12 @@ def _get_koan_md_section(project_path: str) -> str:
     """
     if not project_path:
         return ""
-    from app.project_koan import log_context_load, read_general_koan_md
+    from app.project_koan import read_general_koan_md, record_context_load
     content = read_general_koan_md(project_path)
     if not content:
         return ""
 
-    log_context_load("KOAN.md", content)
+    record_context_load("KOAN.md", content)
 
     from app.prompts import load_prompt
     return load_prompt("koan-md", KOAN_MD_CONTENT=content)
@@ -355,8 +355,8 @@ def _log_claude_md_detected(project_path: str) -> None:
         if not claude_md.is_file():
             return
         content = claude_md.read_text(errors="replace")
-        from app.project_koan import log_context_load
-        log_context_load("CLAUDE.md (auto-loaded by CLI)", content)
+        from app.project_koan import record_context_load
+        record_context_load("CLAUDE.md (auto-loaded by CLI)", content)
     except Exception as e:
         logger.debug("CLAUDE.md detection failed for %s: %s", project_path, e)
 
@@ -929,6 +929,10 @@ def build_agent_prompt(
     # Append language preference (overrides soul.md default)
     prompt += _get_language_section()
 
+    # One consolidated steering summary right before the CLI call.
+    from app.project_koan import flush_context_summary
+    flush_context_summary()
+
     return prompt
 
 
@@ -1021,6 +1025,11 @@ def build_agent_prompt_parts(
     sys_parts.append(_get_merge_policy(project_name))
     sys_parts.append(_get_submit_pr_section(project_path))
 
+    # Surface the project's CLAUDE.md for `make logs` (detection-only; the CLI
+    # auto-loads it via cwd — koan never injects it). Recorded before KOAN.md so
+    # the summary order matches build_agent_prompt's.
+    _log_claude_md_detected(host_project_path or project_path)
+
     # Project-local koan-only instructions (KOAN.md). Read from the HOST path
     # (host_project_path) because in devcontainer mode project_path is the
     # container-side workspace, while the file lives on the host disk.
@@ -1072,6 +1081,10 @@ def build_agent_prompt_parts(
         sys_parts.append(security)
 
     system_prompt = "\n\n".join(part for part in sys_parts if part)
+
+    # One consolidated steering summary right before the CLI call.
+    from app.project_koan import flush_context_summary
+    flush_context_summary()
 
     return system_prompt, user_prompt
 

--- a/koan/app/prompts.py
+++ b/koan/app/prompts.py
@@ -219,7 +219,13 @@ def load_skill_prompt(
     prompt = _maybe_append_project_skill_instructions(prompt, skill_dir, project_path)
     # General KOAN.md rides BELOW the per-skill block: precedence is
     # `.koan/skills/<skill>/* > KOAN.md` (see specs/components/skills.md).
-    return _maybe_append_general_koan_md(prompt, skill_dir, project_path)
+    result = _maybe_append_general_koan_md(prompt, skill_dir, project_path)
+
+    # One consolidated steering summary right before the CLI call.
+    from app.project_koan import flush_context_summary
+    flush_context_summary()
+
+    return result
 
 
 def load_prompt_or_skill(
@@ -306,11 +312,11 @@ def _maybe_append_project_skill_instructions(
     try:
         if not project_path or not (skill_dir / "SKILL.md").is_file():
             return prompt
-        from app.project_koan import log_context_load, read_skill_instructions
+        from app.project_koan import read_skill_instructions, record_context_load
         content = read_skill_instructions(project_path, skill_dir.name)
         if not content:
             return prompt
-        log_context_load(f".koan/skills/{skill_dir.name}", content)
+        record_context_load(f".koan/skills/{skill_dir.name}", content)
         block = load_prompt(
             "koan-skill",
             SKILL_NAME=skill_dir.name,
@@ -334,9 +340,10 @@ def _maybe_append_general_koan_md(
     shared ``koan-md`` template — the same framing the agent loop uses in
     ``prompt_builder._get_koan_md_section`` — and appended AFTER the
     ``.koan/skills/<name>/`` block so the precedence reads
-    ``.koan/skills/<skill>/* > KOAN.md``. A successful injection is announced via
-    ``project_koan.log_context_load`` (stderr → ``logs/run.log``) so ``make logs``
-    shows the load.
+    ``.koan/skills/<skill>/* > KOAN.md``. A successful injection is recorded via
+    ``project_koan.record_context_load``; :func:`load_skill_prompt` flushes the
+    whole build's steering summary once (stderr → ``logs/run.log``) so
+    ``make logs`` shows the load.
 
     Failures are swallowed (additive guidance, not a correctness feature); they
     surface via the module logger so silent regressions stay visible in the log.
@@ -344,11 +351,11 @@ def _maybe_append_general_koan_md(
     try:
         if not project_path or not (skill_dir / "SKILL.md").is_file():
             return prompt
-        from app.project_koan import log_context_load, read_general_koan_md
+        from app.project_koan import read_general_koan_md, record_context_load
         content = read_general_koan_md(project_path)
         if not content:
             return prompt
-        log_context_load("KOAN.md", content)
+        record_context_load("KOAN.md", content)
         block = load_prompt("koan-md", KOAN_MD_CONTENT=content)
         return f"{prompt}\n\n{block}"
     except Exception as e:

--- a/koan/tests/conftest.py
+++ b/koan/tests/conftest.py
@@ -128,6 +128,28 @@ def isolate_env(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _reset_steering_context_log():
+    """Clear the module-global steering-summary batch between tests.
+
+    ``project_koan`` accumulates loaded steering files per prompt build and
+    suppresses a summary identical to the previous one. Without a reset, a
+    leftover batch or dedup signature from a prior test silently changes what a
+    later test sees on stderr.
+    """
+    try:
+        import app.project_koan as pk
+        pk.reset_context_load_log()
+    except Exception:
+        pass
+    yield
+    try:
+        import app.project_koan as pk
+        pk.reset_context_load_log()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def _reset_reply_breaker():
     """Clear per-thread reply circuit-breaker state between tests.
 

--- a/koan/tests/test_project_koan.py
+++ b/koan/tests/test_project_koan.py
@@ -1,6 +1,16 @@
 from pathlib import Path
 
+import pytest
+
 import app.project_koan as pk
+
+
+@pytest.fixture(autouse=True)
+def _reset_context_log():
+    # Module-global batch/signature state: isolate every test from its neighbors.
+    pk.reset_context_load_log()
+    yield
+    pk.reset_context_load_log()
 
 
 def test_general_absent_returns_empty(tmp_path):
@@ -95,15 +105,62 @@ def test_skill_cap(tmp_path, monkeypatch):
     assert "truncated" in out
 
 
-def test_log_context_load_emits_chars_and_tokens(capsys):
-    pk.log_context_load("KOAN.md", "x" * 35)
+def test_record_is_silent_flush_emits_summary(capsys):
+    pk.record_context_load("KOAN.md", "x" * 35)
+    pk.record_context_load("CLAUDE.md (auto-loaded by CLI)", "y" * 70)
+    assert capsys.readouterr().err == ""  # recording is silent
+    pk.flush_context_summary()
     err = capsys.readouterr().err
-    assert "Detected KOAN.md" in err
-    assert "35 chars" in err
+    assert "Steering loaded before Claude (2 file(s)" in err
+    assert "KOAN.md: 35 chars" in err
+    assert "CLAUDE.md (auto-loaded by CLI): 70 chars" in err
     assert "tokens" in err  # ~ 10 tokens at chars/3.5
 
 
-def test_log_context_load_never_raises(capsys, monkeypatch):
+def test_flush_empty_batch_is_noop(capsys):
+    pk.flush_context_summary()
+    assert capsys.readouterr().err == ""
+
+
+def test_record_dedups_same_label_within_build(capsys):
+    pk.record_context_load("KOAN.md", "a" * 10)
+    pk.record_context_load("KOAN.md", "a" * 10)
+    pk.flush_context_summary()
+    err = capsys.readouterr().err
+    assert err.count("KOAN.md:") == 1
+    assert "(1 file(s)" in err
+
+
+def test_consecutive_identical_summary_suppressed(capsys):
+    pk.record_context_load("KOAN.md", "z" * 20)
+    pk.flush_context_summary()
+    assert "Steering loaded" in capsys.readouterr().err
+    pk.record_context_load("KOAN.md", "z" * 20)  # same set + sizes
+    pk.flush_context_summary()
+    assert capsys.readouterr().err == ""  # deduped
+
+
+def test_changed_steering_set_re_emits(capsys):
+    pk.record_context_load("KOAN.md", "z" * 20)
+    pk.flush_context_summary()
+    capsys.readouterr()
+    pk.record_context_load("KOAN.md", "z" * 20)
+    pk.record_context_load(".koan/skills/plan", "q" * 30)
+    pk.flush_context_summary()
+    assert "(2 file(s)" in capsys.readouterr().err
+
+
+def test_reset_lets_next_mission_re_emit(capsys):
+    pk.record_context_load("KOAN.md", "z" * 20)
+    pk.flush_context_summary()
+    capsys.readouterr()
+    pk.reset_context_load_log()  # new mission
+    pk.record_context_load("KOAN.md", "z" * 20)
+    pk.flush_context_summary()
+    assert "Steering loaded" in capsys.readouterr().err
+
+
+def test_record_never_raises(monkeypatch):
     # A broken token estimator must not break prompt assembly.
     import app.diff_compressor as dc
 
@@ -111,7 +168,8 @@ def test_log_context_load_never_raises(capsys, monkeypatch):
         raise RuntimeError("estimator down")
 
     monkeypatch.setattr(dc, "estimate_tokens", _boom)
-    pk.log_context_load("KOAN.md", "content")  # must not raise
+    pk.record_context_load("KOAN.md", "content")  # must not raise
+    pk.flush_context_summary()  # must not raise
 
 
 # --- read_repo_convention_docs ---

--- a/koan/tests/test_prompt_builder.py
+++ b/koan/tests/test_prompt_builder.py
@@ -2597,32 +2597,41 @@ class TestKoanMdSection:
         assert _get_koan_md_section(str(tmp_path)) == ""
 
     def test_koan_md_section_logs_load(self, tmp_path, capsys):
+        # _get_koan_md_section only records; the builders flush the summary.
+        from app.project_koan import flush_context_summary
         from app.prompt_builder import _get_koan_md_section
         (tmp_path / "KOAN.md").write_text("Always run make lint before pushing.")
         _get_koan_md_section(str(tmp_path))
+        flush_context_summary()
         err = capsys.readouterr().err
-        assert "Detected KOAN.md" in err and "tokens" in err
+        assert "KOAN.md:" in err and "tokens" in err
 
 
 class TestClaudeMdDetection:
     """_log_claude_md_detected surfaces CLAUDE.md in make logs (detection-only)."""
 
     def test_logs_when_present(self, tmp_path, capsys):
+        from app.project_koan import flush_context_summary
         from app.prompt_builder import _log_claude_md_detected
         (tmp_path / "CLAUDE.md").write_text("Project rules here.")
         _log_claude_md_detected(str(tmp_path))
+        flush_context_summary()
         err = capsys.readouterr().err
-        assert "Detected CLAUDE.md" in err
-        assert "auto-loaded by CLI" in err
+        assert "CLAUDE.md (auto-loaded by CLI):" in err
+        assert "Steering loaded before Claude" in err
 
     def test_silent_when_absent(self, tmp_path, capsys):
+        from app.project_koan import flush_context_summary
         from app.prompt_builder import _log_claude_md_detected
         _log_claude_md_detected(str(tmp_path))
+        flush_context_summary()
         assert "CLAUDE.md" not in capsys.readouterr().err
 
     def test_silent_when_empty_path(self, capsys):
+        from app.project_koan import flush_context_summary
         from app.prompt_builder import _log_claude_md_detected
         _log_claude_md_detected("")
+        flush_context_summary()
         assert capsys.readouterr().err == ""
 
 

--- a/koan/tests/test_prompt_builder.py
+++ b/koan/tests/test_prompt_builder.py
@@ -1616,6 +1616,16 @@ class TestBuildAgentPromptParts:
         assert "Mission Spec" in user_prompt
         assert "Do the thing" in user_prompt
 
+    def test_steering_summary_lists_claude_md_then_koan_md(self, prompt_env, capsys):
+        """The split builder surfaces CLAUDE.md (detection-only) and KOAN.md."""
+        project = Path(prompt_env["project_path"])
+        (project / "CLAUDE.md").write_text("Project rules here.")
+        (project / "KOAN.md").write_text("Always run make lint before pushing.")
+        self._build(prompt_env)
+        err = capsys.readouterr().err
+        assert "Steering loaded before Claude" in err
+        assert err.index("CLAUDE.md (auto-loaded by CLI):") < err.index("KOAN.md:")
+
     def test_language_preference_in_system_prompt(self, prompt_env):
         """Language preference appears in system prompt when set."""
         with patch(

--- a/koan/tests/test_prompts.py
+++ b/koan/tests/test_prompts.py
@@ -951,7 +951,8 @@ class TestMaybeAppendProjectSkillInstructions:
         load_skill_prompt(sd, "review", project_path=str(proj))
         # Surfaced on stderr so `make logs` (logs/run.log) shows the load.
         err = capsys.readouterr().err
-        assert "Detected .koan/skills/review" in err
+        assert "Steering loaded before Claude" in err
+        assert ".koan/skills/review:" in err
         assert "chars" in err and "tokens" in err
 
 
@@ -1045,5 +1046,6 @@ class TestMaybeAppendGeneralKoanMd:
 
         # Surfaced on stderr so `make logs` (logs/run.log) shows the load.
         err = capsys.readouterr().err
-        assert "Detected KOAN.md" in err
+        assert "Steering loaded before Claude" in err
+        assert "KOAN.md:" in err
         assert "chars" in err and "tokens" in err

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -83,12 +83,23 @@ Code auto-loads `CLAUDE.md` but never `KOAN.md`, so interactive sessions never
 see it.
 
 **Steering-context visibility (`make logs`).** Every steering file that shapes a
-mission prompt is announced on stderr (→ `logs/run.log`) as `Detected <label>,
-loaded N chars (~ M tokens)` via `project_koan.log_context_load`. The agent loop
-surfaces `KOAN.md` when `_get_koan_md_section` reads it, and — detection-only —
-`CLAUDE.md (auto-loaded by CLI)` via `_log_claude_md_detected(project_path)`,
-which reads the project-root `CLAUDE.md` solely to report its size (koan never
-injects it; the CLI loads it from `cwd`). Best-effort: any read/stream failure is
+mission prompt is folded in silently via `project_koan.record_context_load(label,
+content)` and then announced **once per prompt build** as a single consolidated
+block on stderr (→ `logs/run.log`) by `project_koan.flush_context_summary()`,
+called at the end of each prompt builder (`build_agent_prompt`,
+`build_agent_prompt_parts`, and `prompts.load_skill_prompt`). The block reads
+`Steering loaded before Claude (N file(s), ~ T tokens total):` followed by one
+`• <label>: C chars (~ M tokens)` line per file. The agent loop records `KOAN.md`
+(`_get_koan_md_section`) and — detection-only — `CLAUDE.md (auto-loaded by CLI)`
+(`_log_claude_md_detected`, wired into both `build_agent_prompt` and the split
+`build_agent_prompt_parts`), which reads the project-root `CLAUDE.md` solely to
+report its size (koan never injects it; the CLI loads it from `cwd`). A summary
+identical to the previous one (same files and sizes) is suppressed, so a skill
+that rebuilds the prompt several times per mission (e.g. `plan`) announces its
+steering context once, not once per CLI call.
+`mission_executor._run_iteration` calls `reset_context_load_log()` at the top of
+each iteration so a new mission re-announces even when the files are
+byte-identical to the previous mission's. Best-effort: any read/stream failure is
 swallowed and never blocks prompt assembly.
 
 ### Mission hooks (`mission_hooks`) — repo-config-driven shell around missions

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -4,7 +4,7 @@ title: "Component Spec — Agent Loop Pipeline"
 description: "Design contract for the core mission pipeline (iteration manager, mission executor/runner, quota handling, stagnation monitor) that pulls missions, invokes the CLI provider, and finalizes lifecycle state."
 tags: [agent-loop]
 created: 2026-06-27
-updated: 2026-07-26
+updated: 2026-07-28
 ---
 
 # Component Spec — Agent Loop Pipeline

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -4,7 +4,7 @@ title: "Component Spec — Skills System"
 description: "Documents the skills system that discovers, routes, and executes `/command` skills (SKILL.md contract, dispatch, the new-skill checklist, and the eval harness)."
 tags: [skills]
 created: 2026-06-27
-updated: 2026-07-26
+updated: 2026-07-28
 ---
 
 # Component Spec — Skills System

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -230,12 +230,17 @@ a large root `KOAN.md` and large per-skill instructions). Prompt-only skills
 (`_execute_prompt` returns raw `prompt_body`) run without a resolved project in
 scope, so they receive no project-scoped injection — by design, not a gap.
 
-Every actual injection is announced on **stderr** (so it lands in `logs/run.log`
-and is visible via `make logs`) through `project_koan.log_context_load(label,
-content)`, which emits `Detected <label>, loaded N chars (~ M tokens)` — `label`
-is `KOAN.md` for the general block and `.koan/skills/<skill>` for the per-skill
-block. `logging.getLogger` output alone is invisible in the run loop (no
-stream handler wired), so the load line is a direct `print`, not `logger.info`.
+Every actual injection is folded in silently via
+`project_koan.record_context_load(label, content)` — `label` is `KOAN.md` for the
+general block and `.koan/skills/<skill>` for the per-skill block.
+`prompts.load_skill_prompt` then calls `project_koan.flush_context_summary()`
+once, at the end of the build, which emits a single `Steering loaded before
+Claude (…)` block on **stderr** (so it lands in `logs/run.log` and is visible via
+`make logs`) listing every recorded file with per-file and total token estimates.
+`logging.getLogger` output alone is invisible in the run loop (no stream handler
+wired), so the summary is a direct `print`, not `logger.info`. Repeated builds
+within one mission that carry the same steering set are deduped (see
+`specs/components/agent-loop.md` § "Steering-context visibility").
 
 ### Repo config file (`.koan/config.yaml`)
 


### PR DESCRIPTION
## Summary

`/plan` and other multi-CLI-call skills rebuild their prompt several times per mission,
and every rebuild re-announced the same steering file — so `make logs` showed
`Detected KOAN.md` two or three times for a single mission. This replaces the per-file
`Detected …` lines with an **accumulate-then-summarize** model: each prompt build
silently records the steering files it folds in, then emits **one** consolidated summary
right before the CLI is invoked. Repeats within a mission are suppressed; each new
mission re-announces.

Before:

```
[context] Detected KOAN.md, loaded 1240 chars (~ 354 tokens)
[context] Detected KOAN.md, loaded 1240 chars (~ 354 tokens)
[context] Detected .koan/skills/plan, loaded 380 chars (~ 108 tokens)
```

After:

```
[context] Steering loaded before Claude (3 file(s), ~ 3004 tokens total):
[context]   • CLAUDE.md (auto-loaded by CLI): 8900 chars (~ 2542 tokens)
[context]   • KOAN.md: 1240 chars (~ 354 tokens)
[context]   • .koan/skills/plan: 380 chars (~ 108 tokens)
```

Closes https://github.com/Anantys-oss/koan/issues/2469

## Changes

- `project_koan.py`: `log_context_load` replaced by `record_context_load` (silent
  accumulate, deduped by label), `flush_context_summary` (emits one block, suppresses a
  summary identical to the previous one, clears the batch) and `reset_context_load_log`
  (per-mission reset). Every path stays best-effort and never raises.
- `prompt_builder.py` / `prompts.py`: the four call-sites now record; `build_agent_prompt`,
  `build_agent_prompt_parts` and `load_skill_prompt` flush once at the end of the build,
  immediately before the CLI call.
- **Gap closed**: `build_agent_prompt_parts` (the split builder the agent loop actually
  uses) never ran `_log_claude_md_detected`, so `CLAUDE.md` was invisible on that path. It
  is now recorded there too — the summary really covers *all* local `.md` files.
- `mission_executor._run_iteration` calls `reset_context_load_log()` so a fresh mission
  re-announces byte-identical steering context.
- Specs updated **contract-first** (`specs/components/agent-loop.md`,
  `specs/components/skills.md`), then the code made to conform. `docs/users/koan-md.md`
  shows the new block.

Out of scope per the issue thread: thread-local batching for parallel sessions, and
wrapping contemplative sessions in the per-mission reset.

## Test plan

- New unit matrix in `koan/tests/test_project_koan.py`: record is silent → flush emits;
  empty batch is a no-op; per-label dedup within a build; consecutive identical summary
  suppressed; a changed steering set re-emits; reset lets the next mission re-emit; a
  broken token estimator never raises.
- `test_prompts.py` / `test_prompt_builder.py` updated to assert the summary through the
  real flush points.
- Autouse conftest fixture resets the module-global batch so the dedup signature cannot
  bleed between tests.
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_project_koan.py
  koan/tests/test_prompts.py koan/tests/test_prompt_builder.py` → 319 passed.
- `make lint` → clean. `scripts/wiki_check.py` → no gaps.
- One pre-existing failure on `main` is unrelated and untouched
  (`test_messaging_level.py::test_notify_outcome_always_logs_and_sends`).

## Declarations

- [x] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/agent-loop.md`, `specs/components/skills.md`). The new architecture
  needs review before approval. Rationale: the steering-visibility contract changes from
  "announce each file at read time" to "record silently, flush one deduped summary per
  prompt build, reset per mission".

---
_Generated by [Kōan](https://koan.anantys.com)_
