### PR TITLE
fix(review): do not resurrect findings rejected by reflection

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -4,7 +4,7 @@ title: "Skills Reference"
 description: "Complete reference for all Koan slash commands (mission management, code/PR operations, scheduling, status, configuration, and system commands) usable via Telegram, Slack, or GitHub @mentions."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-22
+updated: 2026-07-30
 ---
 
 # Skills Reference
@@ -105,11 +105,13 @@ detail, so reviewers can react or resolve in place. Cap the volume with
 idempotent (already-anchored findings are skipped); multi-line findings anchor
 to their full range; if all posts fail, you are notified. Disabled by default.
 
-**Verdict consistency:** The formal APPROVE / REQUEST_CHANGES state and its
-green/red/yellow alert are derived from the final bucketed findings. Reflection
-cannot leave a failed checklist item pointing at a hidden finding, and Kōan will
-not submit REQUEST_CHANGES unless the summary lists at least one 🔴 Blocking or
-🟡 Important finding.
+**Verdict consistency:** A valid reflection pass is authoritative for the final
+finding list. Findings rejected below the configured threshold stay hidden;
+checklist references are remapped, and a failed checklist entry is removed when
+all of its referenced findings were rejected. The formal APPROVE /
+REQUEST_CHANGES state and its green/red/yellow alert are then derived from the
+retained findings. If reflection returns malformed or inconsistent metadata,
+Kōan preserves the primary review unchanged.
 
 **Stale-HEAD alert:** the review comment's footer shows the commit it was run
 against (`HEAD=<short-sha>`). A review can take minutes, and you may push (or

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-18
+updated: 2026-07-30
 ---
 
 # Kōan User Manual
@@ -594,7 +594,15 @@ The debug loop enforces four steps:
   - `--errors` — Run an additional **silent-failure-hunter** pass that scans for swallowed exceptions, silent null returns, unhandled promises, and other silent error paths. Also auto-triggered when the diff contains error-handling patterns (`try/except`, `catch`, etc.)
   - `--comments` — Comment quality review (factual accuracy, completeness, stale TODOs, misleading language)
   - `--bot-comments` — Triage inline comments from code-review bots (CodeRabbit, Copilot Review, Sourcery) and post replies to actionable findings
-- **Output:** Findings are grouped into severity buckets (🔴 Blocking / 🟡 Important / 🟢 Suggestions), each folded into a collapsible section. Every finding's location is shown on its own line inside the summary as a **clickable link** that jumps straight to the exact file and lines on GitHub, pinned to the reviewed commit (so the link stays accurate even after the PR gets new commits). The request-changes verdict and its red/yellow alert are derived from this same final list, so a blocking verdict always names at least one categorized Blocking or Important finding.
+- **Output:** Findings are grouped into severity buckets (🔴 Blocking /
+  🟡 Important / 🟢 Suggestions), each folded into a collapsible section.
+  Every finding's location is shown as a clickable link pinned to the reviewed
+  commit. A valid second-pass reflection filters the final list authoritatively:
+  rejected findings are not restored by their original checklist references or
+  verdict, and failed checklist entries supported only by rejected findings are
+  removed. The request-changes verdict and its red/yellow alert are derived from
+  the retained findings. Malformed reflection metadata fails open to the complete
+  primary review.
 - **Project memory:** Reviews automatically inject the project's filtered learnings plus human-curated `context.md`/`priorities.md`, ranked against the PR's title, body, and diff via the SQLite FTS5 memory index. Set `review_memory.enabled: true` in `config.yaml` to *also* include recent typed project memory (decisions, observations) for extra reviewer context. Both apply to `/review` and the backend private review gate.
 - **Prior review context:** On a re-review, the bot's own most recent structured review is surfaced in a dedicated, head-preserving prompt slot so the new review builds on it (confirming whether prior findings are resolved) instead of losing it to the recency-truncated conversation thread. That prior review comment is also collapsed to a short "superseded" pointer so it doesn't echo or crowd out human feedback — set `review_history.preserve_previous: true` to keep it intact instead. Tune the prompt slot via `review_context` in `config.yaml` (`include_bot_feedback`, `prior_review_max_chars`).
 

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1258,13 +1258,25 @@ def _reconcile_review_after_reflection(
 
     checklist = summary.get("checklist")
     if not isinstance(checklist, list):
+        log(
+            "review",
+            "Malformed checklist metadata; preserving primary review",
+        )
         return review_data
 
     for entry in checklist:
         if not isinstance(entry, dict):
+            log(
+                "review",
+                "Malformed checklist entry; preserving primary review",
+            )
             return review_data
         refs = entry.get("finding_refs", [])
         if not isinstance(refs, list):
+            log(
+                "review",
+                "Malformed checklist finding_refs; preserving primary review",
+            )
             return review_data
 
     old_to_new = {

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1200,98 +1200,106 @@ def _reconcile_review_after_reflection(
     reflected_findings: list,
     retained_indices: list,
 ) -> dict:
-    """Finalize one coherent review after reflection filters findings.
+    """Finalize a coherent review after authoritative reflection filtering.
 
-    Reflection historically replaced only ``file_comments``. The summary,
-    checklist references, and model-supplied ``lgtm`` stayed tied to the
-    original array, which could produce a blocking review with no categorized
-    findings. Reconcile all index-bearing state here before any consumer sees
-    the result.
-
-    Failed checklist items represent findings the primary review explicitly
-    treated as unresolved, so their referenced findings are restored if the
-    reflection pass filtered them. If reflection otherwise removes every
-    blocker from a primary blocking review, all original blockers are restored.
-    This is the fail-safe policy: the primary blocker wins over a contradictory
-    reflection result.
+    A valid reflection result determines the final findings. Malformed or
+    inconsistent reflection metadata preserves the primary review unchanged.
     """
-    original_findings = review_data.get("file_comments") or []
-    if not isinstance(original_findings, list):
+    original_findings = review_data.get("file_comments")
+    summary = review_data.get("review_summary")
+    if not isinstance(original_findings, list) or not isinstance(summary, dict):
         return review_data
 
-    valid_retained = [
-        index for index in retained_indices
-        if isinstance(index, int)
-        and not isinstance(index, bool)
-        and 0 <= index < len(original_findings)
-    ]
-    if len(valid_retained) != len(reflected_findings):
+    if not isinstance(reflected_findings, list) or not isinstance(
+        retained_indices, list
+    ):
         log(
             "review",
-            "Reflection result/index mismatch; preserving original findings",
+            "Invalid reflection metadata types; preserving primary review",
         )
-        valid_retained = list(range(len(original_findings)))
+        return review_data
 
-    final_indices = set(valid_retained)
-    summary = review_data.get("review_summary") or {}
-    checklist = summary.get("checklist") or [] if isinstance(summary, dict) else []
+    if len(reflected_findings) != len(retained_indices):
+        log(
+            "review",
+            "Reflection result/index length mismatch; preserving primary review",
+        )
+        return review_data
 
-    # A failed check with an explicit finding reference is a known unresolved
-    # issue. Preserve that issue rather than leaving a dangling checklist item.
+    if any(
+        isinstance(index, bool)
+        or not isinstance(index, int)
+        or index < 0
+        or index >= len(original_findings)
+        for index in retained_indices
+    ):
+        log(
+            "review",
+            "Invalid retained finding index; preserving primary review",
+        )
+        return review_data
+
+    if len(set(retained_indices)) != len(retained_indices):
+        log(
+            "review",
+            "Duplicate retained finding index; preserving primary review",
+        )
+        return review_data
+
+    expected_findings = [
+        original_findings[index] for index in retained_indices
+    ]
+    if reflected_findings != expected_findings:
+        log(
+            "review",
+            "Reflection finding/index mismatch; preserving primary review",
+        )
+        return review_data
+
+    checklist = summary.get("checklist")
+    if not isinstance(checklist, list):
+        return review_data
+
     for entry in checklist:
-        if not isinstance(entry, dict) or entry.get("passed") is not False:
-            continue
-        refs = entry.get("finding_refs")
+        if not isinstance(entry, dict):
+            return review_data
+        refs = entry.get("finding_refs", [])
         if not isinstance(refs, list):
-            continue
-        final_indices.update(
-            ref for ref in refs
-            if isinstance(ref, int)
-            and not isinstance(ref, bool)
-            and 0 <= ref < len(original_findings)
-        )
+            return review_data
 
-    def _is_blocker(index: int) -> bool:
-        finding = original_findings[index]
-        return (
-            isinstance(finding, dict)
-            and finding.get("severity") in ("critical", "warning")
-        )
+    old_to_new = {
+        old_index: new_index
+        for new_index, old_index in enumerate(retained_indices)
+    }
+    reconciled_checklist = []
 
-    original_lgtm = summary.get("lgtm") if isinstance(summary, dict) else None
-    if original_lgtm is False and not any(_is_blocker(i) for i in final_indices):
-        final_indices.update(
-            i for i in range(len(original_findings)) if _is_blocker(i)
-        )
-
-    ordered_indices = sorted(final_indices)
-    old_to_new = {old: new for new, old in enumerate(ordered_indices)}
-    review_data["file_comments"] = [original_findings[i] for i in ordered_indices]
-
-    # Checklist references are defined against the original finding array.
-    # Rewrite them to the final array, dropping filtered/invalid references and
-    # preserving order without duplicates.
     for entry in checklist:
-        if not isinstance(entry, dict) or not isinstance(entry.get("finding_refs"), list):
-            continue
-        remapped: list = []
-        seen: set = set()
-        for old_index in entry["finding_refs"]:
+        refs = entry.get("finding_refs", [])
+        remapped_refs = []
+        seen = set()
+        for old_index in refs:
             if isinstance(old_index, bool) or not isinstance(old_index, int):
                 continue
             new_index = old_to_new.get(old_index)
             if new_index is not None and new_index not in seen:
                 seen.add(new_index)
-                remapped.append(new_index)
-        entry["finding_refs"] = remapped
+                remapped_refs.append(new_index)
 
-    # Severity is the sole source of truth for the formal verdict.
-    if isinstance(summary, dict):
-        summary["lgtm"] = not any(
-            isinstance(finding, dict)
-            and finding.get("severity") in ("critical", "warning")
-            for finding in review_data["file_comments"]
-        )
+        if entry.get("passed") is False and refs and not remapped_refs:
+            continue
+
+        reconciled_entry = dict(entry)
+        if "finding_refs" in entry:
+            reconciled_entry["finding_refs"] = remapped_refs
+        reconciled_checklist.append(reconciled_entry)
+
+    review_data["file_comments"] = expected_findings
+    summary["checklist"] = reconciled_checklist
+    summary["lgtm"] = not any(
+        isinstance(finding, dict)
+        and finding.get("severity") in ("critical", "warning")
+        for finding in expected_findings
+    )
 
     return review_data
 

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -5542,37 +5542,55 @@ class TestReconcileReviewAfterReflection:
             "code_snippet": "",
         }
 
-    def test_restores_filtered_findings_referenced_by_failed_checks(self):
-        """A blocking verdict must never render with an empty blocker list."""
+    def test_rejected_compile_finding_is_not_restored_by_failed_check(self):
         data = {
             "file_comments": [
-                self._finding("warning", "Preserve provisioning metadata"),
-                self._finding("warning", "Add regression coverage"),
+                self._finding("warning", "Remove unused storage import"),
             ],
             "review_summary": {
                 "lgtm": False,
-                "summary": "Two issues must be fixed.",
+                "summary": "The package does not compile.",
                 "checklist": [
-                    {"item": "Metadata preserved", "passed": False,
-                     "finding_refs": [0]},
-                    {"item": "Covered by tests", "passed": False,
-                     "finding_refs": [1]},
+                    {
+                        "item": "Package compiles",
+                        "passed": False,
+                        "finding_refs": [0],
+                    },
                 ],
             },
         }
 
         result = _reconcile_review_after_reflection(data, [], [])
 
-        assert [f["title"] for f in result["file_comments"]] == [
-            "Preserve provisioning metadata", "Add regression coverage",
-        ]
-        assert result["review_summary"]["lgtm"] is False
-        md = _format_review_as_markdown(result)
-        assert "### 🟡 Important" in md
-        assert "Preserve provisioning metadata" in md
-        assert "Add regression coverage" in md
+        assert result["file_comments"] == []
+        assert result["review_summary"]["checklist"] == []
+        assert result["review_summary"]["lgtm"] is True
 
-    def test_remaps_checklist_references_after_partial_filtering(self):
+    def test_does_not_restore_original_blocker_when_reflection_removes_it(self):
+        data = {
+            "file_comments": [
+                self._finding("critical", "Rejected blocker"),
+                self._finding("suggestion", "Retained cleanup"),
+            ],
+            "review_summary": {
+                "lgtm": False,
+                "summary": "Blocked.",
+                "checklist": [],
+            },
+        }
+
+        result = _reconcile_review_after_reflection(
+            data,
+            [data["file_comments"][1]],
+            [1],
+        )
+
+        assert [finding["title"] for finding in result["file_comments"]] == [
+            "Retained cleanup",
+        ]
+        assert result["review_summary"]["lgtm"] is True
+
+    def test_remaps_refs_and_keeps_failed_check_with_retained_evidence(self):
         data = {
             "file_comments": [
                 self._finding("suggestion", "Filtered nit"),
@@ -5583,10 +5601,16 @@ class TestReconcileReviewAfterReflection:
                 "lgtm": False,
                 "summary": "One blocker.",
                 "checklist": [
-                    {"item": "Blocker fixed", "passed": False,
-                     "finding_refs": [1]},
-                    {"item": "Optional cleanup", "passed": True,
-                     "finding_refs": [0, 2]},
+                    {
+                        "item": "Blocker fixed",
+                        "passed": False,
+                        "finding_refs": [0, 1],
+                    },
+                    {
+                        "item": "Optional cleanup",
+                        "passed": True,
+                        "finding_refs": [0, 2],
+                    },
                 ],
             },
         }
@@ -5600,26 +5624,101 @@ class TestReconcileReviewAfterReflection:
         ]
         assert result["review_summary"]["checklist"][0]["finding_refs"] == [0]
         assert result["review_summary"]["checklist"][1]["finding_refs"] == [1]
+        assert result["review_summary"]["lgtm"] is False
 
-    def test_restores_original_blockers_when_reflection_removes_them_all(self):
+    @pytest.mark.parametrize(
+        "bad_reflected_findings",
+        [None, True, {}, "finding", ()],
+    )
+    def test_non_list_reflected_metadata_preserves_primary_review(
+        self, bad_reflected_findings,
+    ):
         data = {
-            "file_comments": [
-                self._finding("critical", "Original blocker"),
-                self._finding("suggestion", "Optional cleanup"),
-            ],
+            "file_comments": [self._finding("warning", "Primary blocker")],
             "review_summary": {
-                "lgtm": False, "summary": "Blocked.", "checklist": [],
+                "lgtm": False,
+                "summary": "Blocked.",
+                "checklist": [],
             },
         }
+        original = copy.deepcopy(data)
 
         result = _reconcile_review_after_reflection(
-            data, [data["file_comments"][1]], [1],
+            data, bad_reflected_findings, [0],
         )
 
-        assert [f["title"] for f in result["file_comments"]] == [
-            "Original blocker", "Optional cleanup",
-        ]
-        assert result["review_summary"]["lgtm"] is False
+        assert result == original
+        assert data == original
+
+    @pytest.mark.parametrize(
+        "bad_retained_indices",
+        [
+            None,
+            True,
+            (0,),
+            {"index": 0},
+            [True],
+            ["0"],
+            [0.0],
+            [-1],
+            [1],
+            [0, 0],
+        ],
+    )
+    def test_invalid_retained_metadata_preserves_primary_review(
+        self, bad_retained_indices,
+    ):
+        data = {
+            "file_comments": [self._finding("warning", "Primary blocker")],
+            "review_summary": {
+                "lgtm": False,
+                "summary": "Blocked.",
+                "checklist": [],
+            },
+        }
+        original = copy.deepcopy(data)
+
+        result = _reconcile_review_after_reflection(
+            data,
+            [data["file_comments"][0]],
+            bad_retained_indices,
+        )
+
+        assert result == original
+        assert data == original
+
+    def test_mismatched_reflection_metadata_lengths_preserve_primary_review(self):
+        data = {
+            "file_comments": [self._finding("warning", "Primary blocker")],
+            "review_summary": {
+                "lgtm": False,
+                "summary": "Blocked.",
+                "checklist": [],
+            },
+        }
+        original = copy.deepcopy(data)
+
+        result = _reconcile_review_after_reflection(data, [], [0])
+
+        assert result == original
+        assert data == original
+
+    def test_mismatched_reflection_finding_preserves_primary_review(self):
+        data = {
+            "file_comments": [self._finding("warning", "Primary blocker")],
+            "review_summary": {
+                "lgtm": False,
+                "summary": "Blocked.",
+                "checklist": [],
+            },
+        }
+        original = copy.deepcopy(data)
+        inconsistent = [self._finding("warning", "Different finding")]
+
+        result = _reconcile_review_after_reflection(data, inconsistent, [0])
+
+        assert result == original
+        assert data == original
 
 
 # ---------------------------------------------------------------------------

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -4,7 +4,7 @@ title: "Skill Spec — review"
 description: "Documents the `/review` skill that queues a code-review mission on PRs/issues, posting findings as a comment with severity-driven LGTM logic and re-review comment handling, covered by the eval harness."
 tags: [skill]
 created: 2026-06-27
-updated: 2026-07-22
+updated: 2026-07-30
 ---
 
 # Skill Spec — `review`
@@ -98,19 +98,24 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   `suggestion`; promote it before blocking. Schema validation rejects a supplied
   verdict that contradicts the finding severities, and post-reflection
   finalization derives the verdict from the reconciled finding list again.
-- **Reflection preserves review consistency.** The reflection pass carries the
-  retained original finding indices into a final reconciliation step. Findings
-  referenced by failed checklist items are restored; if reflection would remove
-  every blocker from a primary blocking review, the original blockers are
-  restored. Checklist references are then remapped to the final finding array,
-  and `lgtm` is derived again from those final severities. Schema validation
-  rejects a contradictory verdict (REQUEST_CHANGES with no 🔴 Blocking / 🟡
-  Important finding, or APPROVE despite one) before anything is posted. As a
-  defensive backstop, the verdict body builder (`_build_verdict_body`) — which
-  runs *after* the review comment is already posted — never raises on such an
-  inconsistency: it logs and submits the verdict with an empty body, so a
-  broken invariant can never abort the run post-side-effect (and never renders
-  a blocker-less "issues found" alert).
+- **Valid reflection filtering is authoritative.** The reflection pass carries
+  retained original finding indices into final reconciliation. When both the
+  reflected finding array and retained-index array are valid and internally
+  consistent, reconciliation retains exactly those findings. It remaps checklist
+  references to the retained array, removes a failed checklist entry when all of
+  its referenced evidence was filtered, and derives `lgtm` from the retained
+  severities. It does not restore a rejected finding merely because the primary
+  checklist referenced it or because filtering changes a primary blocking verdict
+  to merge-ready.
+
+  Reconciliation remains fail-open when reflection metadata is malformed or
+  inconsistent. Both metadata values must be lists; every retained index must be
+  a unique, non-boolean integer in range; the arrays must have equal lengths; and
+  each reflected finding must match the original finding at its retained index.
+  If any check fails, the primary review is returned unchanged. Schema validation
+  continues to reject a contradictory verdict before anything is posted. As a
+  defensive backstop, `_build_verdict_body` logs an inconsistency and submits an
+  empty verdict body rather than failing after the review comment was posted.
 - **Verdict presentation is severity-graded, not the summary paragraph.** The
   formal APPROVE / request-changes verdict body (`_build_verdict_body`) is wrapped
   in a native GitHub alert whose color grades the outcome: `> [!TIP]` (green) when


### PR DESCRIPTION
## Summary

`_reconcile_review_after_reflection` no longer resurrects findings that
reflection rejected. A valid reflection pass (both metadata arrays are lists,
retained indices are unique in-range non-boolean integers, lengths match, and
each reflected finding matches the original at its retained index) is now
authoritative: reconciliation retains exactly those findings, remaps checklist
references, drops a failed checklist entry whose evidence was all filtered, and
derives `lgtm` from the retained severities. It no longer restores a finding
because a failed checklist referenced it or because filtering flipped a blocking
verdict to merge-ready. Malformed/inconsistent reflection metadata still
fails open to the unchanged primary review, and every fail-open branch (including
the three malformed-checklist guards) now logs.

## Testing

- `make lint`
- `make test` (review_runner suite)

## Declarations

- [x] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: reflection filtering is now authoritative; the
  primary-review restore fail-safe is removed (specs/skills/review.md).
