### PR TITLE
fix(github): allow dots in repo names when parsing GitHub remotes

### DIFF
--- a/koan/app/github_url_parser.py
+++ b/koan/app/github_url_parser.py
@@ -15,6 +15,12 @@ PR_OR_ISSUE_PATTERN = r'https?://[^/]*github[^/]*/([^/]+)/([^/]+)/(pull|issues)/
 # Jira URL pattern: https://org.atlassian.net/browse/PROJ-123
 JIRA_ISSUE_URL_PATTERN = r'https?://[^/]+\.atlassian\.net/browse/([A-Z][A-Z0-9]+-\d+)'
 
+# GitHub remote URL pattern (SSH and HTTPS), e.g. git@github.com:owner/repo.git
+# or https://github.com/owner/repo. The repo group must allow dots — repo names
+# can be domain-like (e.g. esphome/esphome.io) — while still stripping a
+# trailing .git suffix (GitHub forbids repo names ending in .git).
+GITHUB_REMOTE_RE = re.compile(r'github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?$')
+
 
 def _clean_url(url: str) -> str:
     """Clean a URL by removing fragments and whitespace.

--- a/koan/app/remote_rename_detector.py
+++ b/koan/app/remote_rename_detector.py
@@ -10,14 +10,12 @@ compares the canonical full_name against the local URL, and updates
 both .git/config and projects.yaml when a rename is detected.
 """
 
-import re
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 from app.git_utils import run_git
+from app.github_url_parser import GITHUB_REMOTE_RE as _GITHUB_REMOTE_RE
 from app.run_log import log
-
-_GITHUB_REMOTE_RE = re.compile(r'github\.com[:/]([^/]+)/([^/\s.]+?)(?:\.git)?$')
 
 
 def _extract_slug(url: str) -> Optional[str]:

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -282,8 +282,9 @@ def detect_project_from_text(text: str) -> Tuple[Optional[str], str]:
     return None, text
 
 
-# Pre-compiled regex for GitHub remote URL parsing (SSH and HTTPS)
-_GITHUB_REMOTE_RE = re.compile(r'github\.com[:/]([^/]+)/([^/\s.]+?)(?:\.git)?$')
+# Canonical GitHub remote URL regex — re-exported under the historical name
+# for existing importers (rebase_pr) and test patch targets.
+from app.github_url_parser import GITHUB_REMOTE_RE as _GITHUB_REMOTE_RE  # noqa: E402
 
 
 def get_github_remote(project_path: str) -> Optional[str]:

--- a/koan/tests/test_github_url_resolution.py
+++ b/koan/tests/test_github_url_resolution.py
@@ -66,6 +66,28 @@ class TestGetGithubRemote:
         with patch("app.utils.subprocess.run", return_value=result):
             assert get_github_remote(str(tmp_path)) == "garu/clone"
 
+    def test_dotted_repo_name(self, tmp_path):
+        """Parses repo names containing dots (e.g. esphome/esphome.io)."""
+        from app.utils import get_github_remote
+
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout="https://github.com/esphome/esphome.io\n"
+        )
+        with patch("app.utils.subprocess.run", return_value=result):
+            assert get_github_remote(str(tmp_path)) == "esphome/esphome.io"
+
+    def test_dotted_repo_name_with_git_suffix(self, tmp_path):
+        """Strips only the .git suffix from a dotted repo name."""
+        from app.utils import get_github_remote
+
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout="git@github.com:esphome/esphome.io.git\n"
+        )
+        with patch("app.utils.subprocess.run", return_value=result):
+            assert get_github_remote(str(tmp_path)) == "esphome/esphome.io"
+
     def test_non_github_remote(self, tmp_path):
         """Returns None for non-GitHub remotes."""
         from app.utils import get_github_remote

--- a/koan/tests/test_remote_rename_detector.py
+++ b/koan/tests/test_remote_rename_detector.py
@@ -27,6 +27,12 @@ class TestExtractSlug:
     def test_https_no_git_suffix(self):
         assert _extract_slug("https://github.com/Owner/Repo") == "owner/repo"
 
+    def test_dotted_repo_name(self):
+        assert _extract_slug("https://github.com/esphome/esphome.io") == "esphome/esphome.io"
+
+    def test_dotted_repo_name_with_git_suffix(self):
+        assert _extract_slug("git@github.com:esphome/esphome.io.git") == "esphome/esphome.io"
+
     def test_non_github_url(self):
         assert _extract_slug("git@gitlab.com:owner/repo.git") is None
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

Notifications from repos with a dot in the name (esphome/esphome.io, renamed from esphome-docs) were dropped with "GitHub: 1 @mention(s) dropped from unregistered repo(s)" even though the project was registered. The repo group in `_GITHUB_REMOTE_RE` excluded dots, so the remote URL never parsed and the slug never made it into the known repo set. The same pattern was duplicated in `utils.py` and `remote_rename_detector.py`; it is now hoisted to a single definition in `github_url_parser.py`, with the repo group fixed to allow dots while still stripping the `.git` suffix.

## Testing

Added failing tests first for dotted repo names in `test_github_url_resolution.py` and `test_remote_rename_detector.py`, then applied the fix; ran those files plus `test_rebase_pr.py`, `test_github_notifications.py`, `test_projects_merged.py`, `test_utils.py` (794 passed total), and ruff passes.

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
