### PR TITLE
fix(tests): keep the suite off live OAuth usage and CLI calls

### DIFF
--- a/koan/tests/conftest.py
+++ b/koan/tests/conftest.py
@@ -107,6 +107,30 @@ def _mock_fetch_pr_state():
 
 
 @pytest.fixture(autouse=True)
+def _no_live_oauth_usage(monkeypatch):
+    """Keep the suite off the live OAuth usage endpoint.
+
+    ``app.oauth_usage.fetch_usage()`` reads the operator's real Claude CLI
+    access token and performs an authenticated GET against the Anthropic
+    usage API, honoring Retry-After sleeps on 429 — so any test that reaches
+    a usage refresh (usage_estimator, quota, status, audit paths) silently
+    burns real rate limit and 10-90s of wall clock per test. With no token,
+    ``fetch_usage()`` is a documented graceful no-op, degrading to the local
+    heuristic these tests were written against.
+
+    test_oauth_usage.py is unaffected: its token-reading tests call their own
+    imported binding of ``read_access_token`` (not this patched attribute),
+    and its ``fetch_usage`` tests patch ``oauth_usage.read_access_token``
+    explicitly, overriding this default within their scope.
+    """
+    try:
+        import app.oauth_usage as oauth_usage
+        monkeypatch.setattr(oauth_usage, "read_access_token", lambda: None)
+    except ImportError:
+        pass
+
+
+@pytest.fixture(autouse=True)
 def isolate_env(monkeypatch):
     """Ensure tests don't touch real instance/ or send real Telegram messages."""
     monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "fake-token")

--- a/koan/tests/test_private_security_audit.py
+++ b/koan/tests/test_private_security_audit.py
@@ -218,6 +218,20 @@ AUDIT_SKILL_DIR = (
 
 
 class TestRunAuditJournalOnly:
+    @pytest.fixture(autouse=True)
+    def _no_learning_extraction(self):
+        """Keep run_audit's Step 7 off the real Claude CLI.
+
+        extract_security_learnings() invokes the CLI via run_cli_with_retry;
+        unmocked it burns ~7-17s and real quota per test on any machine with
+        an authenticated claude binary.
+        """
+        with patch(
+            "skills.core.audit.security_learnings.extract_security_learnings",
+            return_value=[],
+        ):
+            yield
+
     @patch("skills.core.audit.audit_runner._run_claude_audit")
     @patch("skills.core.audit.audit_runner.create_issues")
     def test_skips_create_issues(self, mock_create, mock_claude, tmp_path):


### PR DESCRIPTION
<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

On machines with an authenticated Claude CLI the test suite makes live network and CLI calls. Any test reaching a usage refresh calls `oauth_usage.fetch_usage()`, which sends the operator's real access token to the Anthropic usage API; under suite volume the endpoint returns 429 and `fetch_usage` honors Retry-After, so dozens of tests each sleep 10 to 90 seconds and burn real rate limit. The journal-only audit tests also left `extract_security_learnings` unmocked, spending 7 to 17 seconds per test in a real CLI invocation. CI never sees this because it has no token or authenticated binary; local runs were the ones crawling or timing out.

An autouse conftest fixture now patches `oauth_usage.read_access_token` to return `None`, making `fetch_usage()` its documented graceful no-op so usage tests exercise the local heuristic path they were written against; `test_oauth_usage.py` is unaffected since it patches the token reader explicitly. A class-scoped fixture in `TestRunAuditJournalOnly` stubs the learnings extraction; `test_security_learnings.py` still covers the real implementation.

## Testing

Baseline on an authenticated machine: 33 timeout failures, 19m30s serial. With the fixes: the 33 failures are gone, 19,609 passed in 14m32s serial with zero network sockets opened, and the journal-only audit tests dropped from 10 to 17 seconds each to under 3 seconds for the whole file. `test_oauth_usage.py` and `test_security_learnings.py` pass unchanged; ruff passes. One failure remains in `test_tui_dashboard.py::test_new_mission_queues_to_missions_md`, a Rich markup error that also fails on clean main, unrelated to this change.

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
