### PR TITLE
feat(slack): accept bang-prefixed commands

### DIFF
--- a/docs/messaging/slack.md
+++ b/docs/messaging/slack.md
@@ -4,7 +4,7 @@ title: "Slack Setup Guide"
 description: "Step-by-step guide to configuring Kōan with Slack (Socket Mode app setup, scopes, env vars) plus Slack-specific behavior like threading, reactions, and the assistant \"thinking\" status."
 tags: [messaging]
 created: 2026-05-28
-updated: 2026-06-25
+updated: 2026-08-07
 ---
 
 # Slack Setup Guide
@@ -175,10 +175,10 @@ You should see in the logs:
   is not set — setting only the `KOAN_SLACK_*` tokens is not enough.
 - **You must @mention the bot.** Kōan ignores un-addressed channel chatter by
   design. Ping `@Koan ...` to start; after that you can keep replying in the
-  thread without re-mentioning. (Messages beginning with `/` followed by a
-  letter — e.g. `/help` — are an exception: they are treated as commands and
-  answered without a mention. A leading slash before a non-letter, like a
-  `//` comment or a `/.bashrc` dotfile path, stays ignored — but a
+  thread without re-mentioning. (Messages beginning with `/` or `!` followed by
+  a letter — e.g. `/help` or `!help` — are an exception: they are treated as
+  commands and answered without a mention. A leading prefix before a non-letter,
+  like a `//` comment, `!!` punctuation, or a `/.bashrc` dotfile path, stays ignored — but a
   letter-initial path such as `/Users/foo/log.txt` looks like a command and
   is answered.)
 
@@ -199,10 +199,12 @@ You should see in the logs:
 - **Mention to start**: In the configured channel, Kōan stays quiet until you
   @mention it (or it receives an `app_mention`). Ordinary channel chatter is
   ignored, so the bot is safe to drop into a shared channel.
-- **Commands need no mention**: A message beginning with `/` followed by a
-  letter (e.g. `/help`, `/status`) is treated as a command addressed to Kōan —
-  exactly like `@Koan /help`. It replies in a thread under the command, no
-  @mention required. A leading slash before a non-letter (`//` comments,
+- **Commands need no mention**: A message beginning with `/` or `!` followed by
+  a letter (e.g. `/help`, `!status`) is treated as a command addressed to Kōan —
+  exactly like `@Koan /help`. Slack normalizes `!command` to `/command` before
+  handing it to the shared bridge, avoiding conflicts with Slack slash commands.
+  It replies in a thread under the command, no @mention required. A leading
+  prefix before a non-letter (`//` comments, `!!` punctuation,
   dotfile paths like `/.bashrc`, numeric/symbol prefixes) is ignored. This
   heuristic cannot tell a command from a letter-initial path, so a pasted
   path like `/Users/foo/log.txt` at the start of a message *is* treated as a
@@ -223,7 +225,7 @@ You should see in the logs:
 
 ## Queued-mission acknowledgement
 
-When a slash command (`/fix`, `/rebase`, `/plan`, `/review`, …) or a plain
+When a command (`/fix`, `!rebase`, `/plan`, `!review`, …) or a plain
 mission is queued, Kōan acknowledges it with a ✅ **reaction** on the original
 message on platforms that support reactions. A brief "Queuing…" status is shown
 while the acknowledgement settles.

--- a/koan/app/messaging/slack.py
+++ b/koan/app/messaging/slack.py
@@ -381,11 +381,12 @@ class SlackProvider(MessagingProvider):
     def _is_addressed_to_bot(self, event: dict) -> bool:
         """Return True for app_mentions, direct @mentions, commands, or engaged threads.
 
-        A message whose text begins with ``/`` followed by a letter (e.g.
-        ``/help``) is treated as a command addressed to the bot, just like an
-        explicit ``@bot /help`` — no mention required. A leading slash followed
-        by a non-letter (``//`` comments, dotfile paths like ``/.bashrc``,
-        numeric/symbol prefixes) is ignored. Note that this heuristic cannot
+        A message whose text begins with ``/`` or ``!`` followed by a letter
+        (e.g. ``/help`` or ``!help``) is treated as a command addressed to the
+        bot, just like an explicit ``@bot /help`` — no mention required. A
+        leading prefix followed by a non-letter (``//`` comments, ``!!``
+        punctuation, dotfile paths like ``/.bashrc``, numeric/symbol prefixes)
+        is ignored. Note that this heuristic cannot
         distinguish a command from a letter-initial path: a pasted path like
         ``/Users/foo/log.txt`` at message start *is* treated as a command and
         falls through to an (unrecognized-command) help reply.
@@ -395,7 +396,7 @@ class SlackProvider(MessagingProvider):
         """
         text = event.get("text", "")
         mentioned = bool(self._bot_user_id) and f"<@{self._bot_user_id}>" in text
-        is_command = bool(re.match(r"/[a-zA-Z]", text.lstrip()))
+        is_command = bool(re.match(r"[!/][a-zA-Z]", text.lstrip()))
         # For a channel-root message Slack omits thread_ts; the message's own ts
         # is the root of the thread the bot will reply into.
         thread_root = event.get("thread_ts") or event.get("ts", "")
@@ -457,9 +458,13 @@ class SlackProvider(MessagingProvider):
         if not text:
             return ""
 
-        # Strip @bot mentions from text
+        # Strip @bot mentions from text.
         if self._bot_user_id:
-            text = re.sub(rf"<@{re.escape(self._bot_user_id)}>\s*", "", text).strip()
+            text = re.sub(rf"<@{re.escape(self._bot_user_id)}>\s*", "", text)
+
+        text = text.strip()
+        if re.match(r"![a-zA-Z]", text):
+            text = "/" + text[1:]
 
         return text
 

--- a/koan/tests/test_slack_provider.py
+++ b/koan/tests/test_slack_provider.py
@@ -188,6 +188,18 @@ class TestHandleSocketEvent:
         update = provider._message_queue.get_nowait()
         assert update.message.text == "/help"
 
+    def test_bang_command_without_mention_normalized(self, provider):
+        req = self._make_request("message", "C123", "!help")
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        assert update.message.text == "/help"
+
+    def test_bang_command_with_arguments_normalized(self, provider):
+        req = self._make_request("message", "C123", "  !review changes")
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        assert update.message.text == "/review changes"
+
     def test_slash_command_with_leading_whitespace_processed(self, provider):
         req = self._make_request("message", "C123", "  /status")
         provider._handle_socket_event(MagicMock(), req)
@@ -218,6 +230,12 @@ class TestHandleSocketEvent:
         # ignored. Note: letter-initial paths like /etc/hosts DO match /[a-zA-Z]
         # and are treated as commands, so they are not valid examples here.
         for text in ("//deploy note: ship it", "/.config/app.toml is the culprit"):
+            req = self._make_request("message", "C123", text)
+            provider._handle_socket_event(MagicMock(), req)
+            assert provider._message_queue.empty()
+
+    def test_leading_bang_non_letter_not_command(self, provider):
+        for text in ("!! deploy note", "!42 is surprising"):
             req = self._make_request("message", "C123", text)
             provider._handle_socket_event(MagicMock(), req)
             assert provider._message_queue.empty()

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -78,6 +78,10 @@ awake.py (loop, ~3s poll)
   *how* the agent behaves.
 - **Command parsing is hyphen-hostile.** Skill names/aliases use underscores; Telegram
   treats `-` as a word boundary and truncates the command.
+- **Slack accepts bang-prefixed commands.** Slack recognizes `!command` and
+  `/command` without a bot mention. Its provider normalizes the bang form to
+  `/command` before the shared bridge dispatches it, keeping command handlers
+  provider-agnostic and avoiding Slack slash-command conflicts.
 - **The chat ID is normalized at read time.** All reads of `KOAN_TELEGRAM_CHAT_ID` go
   through `utils.get_telegram_chat_id()`, which `.strip()`s stray whitespace/newlines
   (Railway/copy-paste inject a trailing newline that makes Telegram answer


### PR DESCRIPTION
<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
