### PR TITLE
fix(review): assign globally unique finding ids

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -4,7 +4,7 @@ title: "Skills Reference"
 description: "Complete reference for all Koan slash commands (mission management, code/PR operations, scheduling, status, configuration, and system commands) usable via Telegram, Slack, or GitHub @mentions."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-30
+updated: 2026-08-12
 ---
 
 # Skills Reference
@@ -104,6 +104,10 @@ detail, so reviewers can react or resolve in place. Cap the volume with
 `review_inline_comments.max_comments` (default 25). Re-running `/review` is
 idempotent (already-anchored findings are skipped); multi-line findings anchor
 to their full range; if all posts fail, you are notified. Disabled by default.
+
+Summary findings receive one sequence of IDs across Blocking, Important,
+Suggestions, and Silent Failure Analysis sections. Numbering never restarts at
+a section boundary, so follow-up requests can identify any finding by ID alone.
 
 **Verdict consistency:** A valid reflection pass is authoritative for the final
 finding list. Findings rejected below the configured threshold stay hidden;

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-30
+updated: 2026-08-12
 ---
 
 # Kōan User Manual
@@ -596,6 +596,8 @@ The debug loop enforces four steps:
   - `--bot-comments` — Triage inline comments from code-review bots (CodeRabbit, Copilot Review, Sourcery) and post replies to actionable findings
 - **Output:** Findings are grouped into severity buckets (🔴 Blocking /
   🟡 Important / 🟢 Suggestions), each folded into a collapsible section.
+  Finding IDs increment across all buckets and continue into Silent Failure
+  Analysis, so an ID uniquely identifies one finding within the review.
   Every finding's location is shown as a clickable link pinned to the reviewed
   commit. A valid second-pass reflection filters the final list authoritatively:
   rejected findings are not restored by their original checklist references or

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1740,7 +1740,7 @@ def _should_run_error_hunter(diff: str) -> bool:
 def _run_error_hunter(
     diff: str, project_path: str, skill_dir: Optional[Path],
     owner: str = "", repo: str = "", head_sha: str = "",
-    project_name: str = "",
+    project_name: str = "", start_id: int = 1,
 ) -> str:
     """Run the silent-failure-hunter pass and return formatted markdown section.
 
@@ -1768,7 +1768,7 @@ def _run_error_hunter(
         return ""
 
     return _format_error_hunter_findings(
-        findings, owner=owner, repo=repo, head_sha=head_sha,
+        findings, owner=owner, repo=repo, head_sha=head_sha, start_id=start_id,
     )
 
 
@@ -1810,13 +1810,14 @@ _ERROR_HUNTER_SEVERITY_EMOJI = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "�
 
 def _format_error_hunter_findings(
     findings: list, owner: str = "", repo: str = "", head_sha: str = "",
+    start_id: int = 1,
 ) -> str:
     """Format error-hunter findings as a markdown section with collapsible details."""
     severity_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2}
     findings = sorted(findings, key=lambda f: severity_order.get(f.get("severity", "MEDIUM"), 2))
 
     lines = ["## Silent Failure Analysis", ""]
-    for f in findings:
+    for finding_id, f in enumerate(findings, start_id):
         severity = f.get("severity", "?")
         emoji = _ERROR_HUNTER_SEVERITY_EMOJI.get(severity, "⚪")
         pattern = f.get("pattern", "unknown pattern")
@@ -1827,7 +1828,7 @@ def _format_error_hunter_findings(
         explanation = f.get("explanation", "")
         suggestion = f.get("suggestion", "")
 
-        title = f"{emoji} **{severity}** — {pattern}"
+        title = f"{emoji} **{finding_id}. {severity}** — {pattern}"
         # Link the location on its own line when line_hint is numeric and a
         # head-SHA permalink can be built; else keep the plain-text suffix.
         loc_line = ""
@@ -2518,24 +2519,24 @@ def _format_review_as_markdown(
 
     # Group comments by severity
     by_severity: dict = {"critical": [], "warning": [], "suggestion": []}
-    for c in comments:
+    for idx, c in enumerate(comments):
         sev = c.get("severity", "suggestion")
-        by_severity.setdefault(sev, []).append(c)
+        by_severity.setdefault(sev, []).append((idx, c))
 
     # Map each file_comments index to the label the renderer assigns it
-    # (e.g. "warning #2"). Numbering is per-severity, 1-based, in array order —
-    # identical to the section emission below — so checklist cross-references
-    # derived from these labels always match the rendered finding numbers.
+    # (e.g. "warning #3"). IDs are global across severity sections, 1-based,
+    # and follow rendered order so every finding in one review can be named
+    # unambiguously. Checklist cross-references use those same IDs.
     # Indices for severities that aren't rendered (anything outside the three
     # known levels) are intentionally omitted, so references to them get dropped.
     index_to_label: dict = {}
-    _sev_counters: dict = {"critical": 0, "warning": 0, "suggestion": 0}
-    for idx, c in enumerate(comments):
-        sev = c.get("severity", "suggestion")
-        if sev not in _sev_counters:
-            continue
-        _sev_counters[sev] += 1
-        index_to_label[idx] = f"{sev} #{_sev_counters[sev]}"
+    finding_id_by_index: dict = {}
+    next_finding_id = 1
+    for sev in ("critical", "warning", "suggestion"):
+        for idx, _item in by_severity.get(sev, []):
+            finding_id_by_index[idx] = next_finding_id
+            index_to_label[idx] = f"{sev} #{next_finding_id}"
+            next_finding_id += 1
 
     # Emit severity sections (skip empty ones)
     for sev in ("critical", "warning", "suggestion"):
@@ -2546,8 +2547,8 @@ def _format_review_as_markdown(
         heading = _SEVERITY_HEADING[sev]
         lines.append(f"### {emoji} {heading}")
         lines.append("")
-        for i, item in enumerate(items, 1):
-            title_line = f"<b>{i}. {item['title']}</b>"
+        for idx, item in items:
+            title_line = f"<b>{finding_id_by_index[idx]}. {item['title']}</b>"
             line_start = item.get("line_start") or 0
             line_end = item.get("line_end") or 0
             lines.append("<details>")
@@ -4263,6 +4264,11 @@ def run_review(
                 owner=owner, repo=repo,
                 head_sha=(current_shas[-1] if current_shas else ""),
                 project_name=project_name or "",
+                start_id=(
+                    len(review_data.get("file_comments", [])) + 1
+                    if isinstance(review_data, dict)
+                    else 1
+                ),
             )
             if error_section and posted:
                 _append_error_section_to_review(

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -1297,6 +1297,44 @@ class TestFormatReviewAsMarkdown:
         assert "### 🟢 Suggestions" in md
         assert "b.py:10-15" in md  # multi-line range
 
+    def test_finding_ids_increment_across_severity_sections(self):
+        """Finding IDs stay unique across every core-review severity bucket."""
+        data = {
+            "file_comments": [
+                {"file": "a.py", "line_start": 1, "line_end": 1,
+                 "severity": "warning", "title": "Warning", "comment": "x",
+                 "code_snippet": ""},
+                {"file": "b.py", "line_start": 2, "line_end": 2,
+                 "severity": "suggestion", "title": "Suggestion", "comment": "x",
+                 "code_snippet": ""},
+                {"file": "c.py", "line_start": 3, "line_end": 3,
+                 "severity": "critical", "title": "Critical", "comment": "x",
+                 "code_snippet": ""},
+                {"file": "d.py", "line_start": 4, "line_end": 4,
+                 "severity": "warning", "title": "Another warning", "comment": "x",
+                 "code_snippet": ""},
+            ],
+            "review_summary": {
+                "lgtm": False,
+                "summary": "Issues found.",
+                "checklist": [
+                    {"item": "Critical check", "passed": False, "finding_refs": [2]},
+                    {"item": "Warning check", "passed": False, "finding_refs": [0, 3]},
+                    {"item": "Suggestion check", "passed": False, "finding_refs": [1]},
+                ],
+            },
+        }
+
+        md = _format_review_as_markdown(data)
+
+        assert "<b>1. Critical</b>" in md
+        assert "<b>2. Warning</b>" in md
+        assert "<b>3. Another warning</b>" in md
+        assert "<b>4. Suggestion</b>" in md
+        assert "Critical check — critical ＃1" in md
+        assert "Warning check — warning ＃2, warning ＃3" in md
+        assert "Suggestion check — suggestion ＃4" in md
+
     def test_checklist_rendering(self):
         data = {
             "file_comments": [
@@ -1970,7 +2008,7 @@ class TestReviewPostsBeforeEnrichment:
     ):
         """The hunter's section goes through the append path, not the first post."""
         mock_fetch.return_value = pr_context
-        mock_claude.return_value = (json.dumps(LGTM_REVIEW_JSON), "")
+        mock_claude.return_value = (json.dumps(VALID_REVIEW_JSON), "")
 
         success, _summary, _rd = run_review(
             "owner", "repo", "42", "/tmp/project",
@@ -1983,6 +2021,8 @@ class TestReviewPostsBeforeEnrichment:
         # The section is routed to the append helper, carrying the hunter output.
         mock_append.assert_called_once()
         assert "swallowed exception at x" in mock_append.call_args.kwargs["error_section"]
+        # Core finding #1 already exists, so hunter IDs begin at #2.
+        assert _mock_hunter.call_args.kwargs["start_id"] == 2
         # And it is NOT baked into the initial posted comment body.
         posted = " ".join(str(c) for c in mock_gh.call_args_list)
         assert "swallowed exception at x" not in posted
@@ -6478,6 +6518,21 @@ class TestFormatErrorHunterFindings:
         high_pos = result.index("high issue")
         med_pos = result.index("medium issue")
         assert crit_pos < high_pos < med_pos
+
+    def test_ids_continue_after_core_review_findings(self):
+        from app.review_runner import _format_error_hunter_findings
+
+        findings = [
+            {"severity": "MEDIUM", "pattern": "medium issue", "file": "a.py"},
+            {"severity": "CRITICAL", "pattern": "critical issue", "file": "b.py"},
+            {"severity": "HIGH", "pattern": "high issue", "file": "c.py"},
+        ]
+
+        result = _format_error_hunter_findings(findings, start_id=5)
+
+        assert "**5. CRITICAL** — critical issue" in result
+        assert "**6. HIGH** — high issue" in result
+        assert "**7. MEDIUM** — medium issue" in result
 
     def test_emoji_per_severity(self):
         from app.review_runner import _format_error_hunter_findings

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -4,7 +4,7 @@ title: "Skill Spec — review"
 description: "Documents the `/review` skill that queues a code-review mission on PRs/issues, posting findings as a comment with severity-driven LGTM logic and re-review comment handling, covered by the eval harness."
 tags: [skill]
 created: 2026-06-27
-updated: 2026-07-30
+updated: 2026-08-12
 ---
 
 # Skill Spec — `review`
@@ -74,6 +74,11 @@ See `docs/users/skills.md` for the end-user `/review` reference and
 
 - Multi-URL queues preserve order via a single atomic locked insert.
 - Findings are advisory comments — `/review` never merges or pushes code.
+- **Finding IDs span the complete review.** Displayed IDs start at 1 and
+  increment through rendered severity order (Blocking, Important, Suggestions),
+  then continue through Silent Failure Analysis findings. IDs never restart at
+  a section boundary. Checklist references use these global IDs, letting a
+  requester identify any specific finding without also naming its section.
 - **Repo-level `always_check` pinning.** A target repo's optional
   `.koan/config.yaml` may set `review.always_check` to a list of file globs; any
   changed file whose path or basename matches is **pinned** so diff-size reduction


### PR DESCRIPTION
<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
