### PR TITLE
fix(slack): normalize inbound URL markup

### DIFF
--- a/docs/messaging/slack.md
+++ b/docs/messaging/slack.md
@@ -4,7 +4,7 @@ title: "Slack Setup Guide"
 description: "Step-by-step guide to configuring Kōan with Slack (Socket Mode app setup, scopes, env vars) plus Slack-specific behavior like threading, reactions, and the assistant \"thinking\" status."
 tags: [messaging]
 created: 2026-05-28
-updated: 2026-08-07
+updated: 2026-08-12
 ---
 
 # Slack Setup Guide
@@ -203,6 +203,8 @@ You should see in the logs:
   a letter (e.g. `/help`, `!status`) is treated as a command addressed to Kōan —
   exactly like `@Koan /help`. Slack normalizes `!command` to `/command` before
   handing it to the shared bridge, avoiding conflicts with Slack slash commands.
+  Slack's `<url>` and `<url|label>` link markup is also converted back to a
+  plain URL, so URL-based commands keep any context written after the link.
   It replies in a thread under the command, no @mention required. A leading
   prefix before a non-letter (`//` comments, `!!` punctuation,
   dotfile paths like `/.bashrc`, numeric/symbol prefixes) is ignored. This

--- a/koan/app/messaging/slack.py
+++ b/koan/app/messaging/slack.py
@@ -34,6 +34,12 @@ _MAX_ENGAGED_THREADS = 1000  # thread_ts the bot is participating in
 _MAX_SEEN_TS = 2000          # event ts already processed (dedup)
 _MAX_TS_TOKENS = 1000        # int token -> message ts, for reactions
 
+# Slack wraps links in mrkdwn as <url> or <url|label>. The second alternative
+# also accepts event text truncated immediately after the URL or separator.
+_SLACK_LINK_RE = re.compile(
+    r"<(https?://[^|>\s]+)(?:(?:\|[^>]*)?>|\|?(?=\s|$))"
+)
+
 # Unicode emoji -> Slack shortname (reactions.add wants a name, not the glyph).
 _SLACK_EMOJI_NAMES = {
     "✅": "white_check_mark",
@@ -461,6 +467,8 @@ class SlackProvider(MessagingProvider):
         # Strip @bot mentions from text.
         if self._bot_user_id:
             text = re.sub(rf"<@{re.escape(self._bot_user_id)}>\s*", "", text)
+
+        text = _SLACK_LINK_RE.sub(r"\1", text)
 
         text = text.strip()
         if re.match(r"![a-zA-Z]", text):

--- a/koan/tests/test_slack_provider.py
+++ b/koan/tests/test_slack_provider.py
@@ -200,6 +200,28 @@ class TestHandleSocketEvent:
         update = provider._message_queue.get_nowait()
         assert update.message.text == "/review changes"
 
+    @pytest.mark.parametrize("command", ["plan", "review", "fix", "rebase", "squash"])
+    def test_command_normalizes_slack_url_markup(self, provider, command):
+        url = "https://github.com/example/project/issues/19"
+        req = self._make_request(
+            "message",
+            "C123",
+            f"/{command} <{url}|github.com/example/project/issues/19> extra context",
+        )
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        assert update.message.text == f"/{command} {url} extra context"
+
+    @pytest.mark.parametrize("suffix", [">", "|", ""])
+    def test_command_normalizes_unlabelled_or_truncated_slack_url_markup(
+        self, provider, suffix,
+    ):
+        url = "https://github.com/example/project/pull/19"
+        req = self._make_request("message", "C123", f"/review <{url}{suffix}")
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        assert update.message.text == f"/review {url}"
+
     def test_slash_command_with_leading_whitespace_processed(self, provider):
         req = self._make_request("message", "C123", "  /status")
         provider._handle_socket_event(MagicMock(), req)

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -4,7 +4,7 @@ title: "Component Spec — Telegram Bridge"
 description: "Design contract for the Telegram bridge process that classifies human messages into chat vs. mission, dispatches commands/skills, and flushes the agent's outbox crash-safely."
 tags: [bridge]
 created: 2026-06-27
-updated: 2026-07-17
+updated: 2026-08-12
 ---
 
 # Component Spec — Telegram Bridge
@@ -82,6 +82,10 @@ awake.py (loop, ~3s poll)
   `/command` without a bot mention. Its provider normalizes the bang form to
   `/command` before the shared bridge dispatches it, keeping command handlers
   provider-agnostic and avoiding Slack slash-command conflicts.
+- **Slack URLs reach shared dispatch as plain URLs.** Slack's provider removes
+  mrkdwn link wrappers (`<url>` and `<url|label>`) before queueing inbound text.
+  It also repairs a wrapper truncated immediately after the URL or separator so
+  URL-driven skills receive clean targets while preserving trailing context.
 - **The chat ID is normalized at read time.** All reads of `KOAN_TELEGRAM_CHAT_ID` go
   through `utils.get_telegram_chat_id()`, which `.strip()`s stray whitespace/newlines
   (Railway/copy-paste inject a trailing newline that makes Telegram answer


### PR DESCRIPTION
<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
