### PR TITLE
fix(providers): honor a binary path in the global cli_provider

### DIFF
--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -204,6 +204,14 @@ same as `models:`: `mission`, `chat`, `lightweight`, `review_mode`, `reflect`.
 role selects `claude` without an explicit path, and `cli_provider` /
 `KOAN_CLI_PROVIDER` remain the global default provider.
 
+`cli_provider` additionally accepts the same `flavor:path` grammar as `cli:`, so
+`cli_provider: "claude:/root/.local/bin/lmpanel-claude"` makes **every**
+un-overridden role spawn that wrapper instead of bare `claude` — including the
+paths that do not resolve a role (chat, rituals, outbox formatting). A path here
+wins over `KOAN_CLAUDE_CLI_PATH`, matching how a per-role `claude:path` behaves.
+`KOAN_CLI_PROVIDER` stays flavor-only; use `KOAN_CLAUDE_CLI_PATH` to pin a binary
+from the environment.
+
 > Tip: the ready-made wrappers in `bin/` (`zai-claude`, `oc-claude`,
 > `ollama-claude`) make good `claude:path` targets when you want a role to run a
 > Claude-compatible backend.

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -458,7 +458,14 @@ tools:
 # Options: "claude" (default), "codex" (OpenAI Codex CLI), "copilot" (GitHub Copilot CLI),
 #          "haze", "grok" (xAI Grok Build CLI), "ollama-launch" (Ollama-managed Claude CLI)
 #          ("local" was removed — use ollama-launch)
-# Can also be set via KOAN_CLI_PROVIDER env var (overrides this)
+# Accepts "flavor" OR "flavor:path" — the same grammar as the per-role `cli:`
+# section below. A path pins the binary for the GLOBAL provider, e.g.
+#   cli_provider: "claude:/root/.local/bin/lmpanel-claude"
+# (absolute as-is; bare name resolved on PATH; relative rooted at KOAN_ROOT).
+# Every role that does not override it under `cli:` inherits that binary.
+# Can also be set via KOAN_CLI_PROVIDER env var (overrides this). The env var
+# is flavor-only — use KOAN_CLAUDE_CLI_PATH to pin a binary from the
+# environment.
 cli_provider: "claude"
 
 # Skip permission prompts/sandboxing for CLI providers.

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -528,6 +528,10 @@ def handle_chat(text: str):
 
     chat_tools_list = get_chat_tools().split(",")
     models = get_model_config()
+    # Chat already runs on the `chat` MODEL; take the `chat` CLI too so a
+    # `cli:` binary override applies. Resolved once here rather than per retry.
+    from app.provider import get_provider_for_role
+    chat_provider = get_provider_for_role("chat")
 
     # Run chat from KOAN_ROOT so paths line up with the rest of the system
     # (reflection, agent loop). Chat only needs to read state under
@@ -575,6 +579,7 @@ def handle_chat(text: str):
                 fallback=models["fallback"],
                 max_turns=5,
                 project_context=False,
+                provider=chat_provider,
             )
 
             try:
@@ -585,6 +590,7 @@ def handle_chat(text: str):
                         cmd,
                         capture_output=True, text=True, timeout=timeout,
                         cwd=chat_cwd,
+                        provider=chat_provider,
                     )
             except subprocess.TimeoutExpired:
                 # Timeout is a retryable contention symptom.

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -527,11 +527,16 @@ def handle_chat(text: str):
             quarantine_mission(text, guard_result.reason, source="telegram-chat")
 
     chat_tools_list = get_chat_tools().split(",")
-    models = get_model_config()
-    # Chat already runs on the `chat` MODEL; take the `chat` CLI too so a
-    # `cli:` binary override applies. Resolved once here rather than per retry.
+    # Take the `chat` CLI so a `cli:` binary override applies (resolved once
+    # here, not per retry), and resolve the model against THAT provider's
+    # section so a cross-flavor role override (e.g. chat→codex) gets codex's
+    # model, not the global provider's — a provider spawned with a foreign
+    # model fails.
     from app.provider import get_provider_for_role
     chat_provider = get_provider_for_role("chat")
+    models = get_model_config(
+        role_providers={"chat": chat_provider.name, "fallback": chat_provider.name},
+    )
 
     # Run chat from KOAN_ROOT so paths line up with the rest of the system
     # (reflection, agent loop). Chat only needs to read state under

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -383,7 +383,7 @@ def get_model_config(
 _CLI_ROLES = ("mission", "chat", "lightweight", "review_mode", "reflect")
 
 
-def _parse_cli_value(raw: str) -> Tuple[str, str]:
+def _parse_cli_value(raw: str, warn: bool = True) -> Tuple[str, str]:
     """Parse a ``cli:`` value (``flavor`` or ``flavor:path``) into ``(flavor, path)``.
 
     Splits on the FIRST colon so absolute paths containing extra colons survive.
@@ -392,6 +392,10 @@ def _parse_cli_value(raw: str) -> Tuple[str, str]:
     global provider (a typo must never crash the agent loop). The path is
     returned RAW — the provider resolves it (absolute / KOAN_ROOT-relative /
     bare) in ``binary()`` via the shared ``_resolve_binary_path`` helper.
+
+    Set ``warn=False`` when a caller re-parses a value it has already reported
+    on, so a bad setting is logged once per resolution instead of once per
+    lookup.
     """
     raw = str(raw or "").strip()
     if not raw:
@@ -402,13 +406,36 @@ def _parse_cli_value(raw: str) -> Tuple[str, str]:
     from app.provider import is_known_provider
 
     if not is_known_provider(flavor):
-        print(
-            f"[config] cli: unknown provider flavor {flavor!r} (value {raw!r}); "
-            "ignoring and using the global provider",
-            file=sys.stderr,
-        )
+        if warn:
+            print(
+                f"[config] cli: unknown provider flavor {flavor!r} (value {raw!r}); "
+                "ignoring and using the global provider",
+                file=sys.stderr,
+            )
         return ("", "")
     return (flavor, path)
+
+
+def get_global_cli_spec(warn: bool = True) -> Tuple[str, str]:
+    """Resolve the global ``cli_provider`` key into ``(flavor, path)``.
+
+    ``cli_provider`` accepts the same ``flavor`` / ``flavor:path`` grammar as the
+    per-role ``cli:`` entries, so a deployment that routes Claude Code through a
+    wrapper binary can set it once globally instead of repeating the path for
+    every role. Parsing goes through :func:`_parse_cli_value`, so an unknown
+    flavor warns and yields ``("", "")`` — the caller then falls back to the
+    built-in default rather than crashing.
+
+    Returns ``("", "")`` when unset or unparseable. The env var
+    (``KOAN_CLI_PROVIDER``) is deliberately NOT handled here: it stays
+    flavor-only, because ``KOAN_CLAUDE_CLI_PATH`` already covers "custom binary
+    from the environment" and a second spelling would only invite drift.
+
+    A config-loading failure PROPAGATES — ``provider.get_provider_name`` owns
+    that error path and logs it, so catching it here would only swallow the
+    diagnostic and duplicate the handler.
+    """
+    return _parse_cli_value(_load_config().get("cli_provider", ""), warn=warn)
 
 
 def get_cli_config(project_name: str = "") -> Dict[str, Tuple[str, str]]:

--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -178,11 +178,17 @@ def format_message(raw_content: str, soul: str, prefs: str,
         from app.cli_exec import run_cli
 
         models = get_model_config()
+        # This already runs on the `lightweight` MODEL; take the `lightweight`
+        # CLI too, so a `cli:` binary override is honored rather than the
+        # global provider's binary being used with the role's model.
+        from app.provider import get_provider_for_role
+        provider = get_provider_for_role("lightweight")
         # Outbox formatting runs at KOAN_ROOT — suppress contributor tooling (#2379).
         cmd = build_full_command(
             prompt=prompt,
             model=models["lightweight"],
             project_context=False,
+            provider=provider,
         )
         result = run_cli(
             cmd,
@@ -190,7 +196,8 @@ def format_message(raw_content: str, soul: str, prefs: str,
             capture_output=True,
             text=True,
             timeout=30,
-            check=False
+            check=False,
+            provider=provider,
         )
 
         if result.returncode == 0 and result.stdout.strip():

--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -177,12 +177,15 @@ def format_message(raw_content: str, soul: str, prefs: str,
     try:
         from app.cli_exec import run_cli
 
-        models = get_model_config()
-        # This already runs on the `lightweight` MODEL; take the `lightweight`
-        # CLI too, so a `cli:` binary override is honored rather than the
-        # global provider's binary being used with the role's model.
+        # Take the `lightweight` CLI so a `cli:` binary override is honored, and
+        # resolve the model against THAT provider's section so a cross-flavor
+        # role override (e.g. lightweight→codex) gets codex's model, not the
+        # global provider's — spawning a provider with a foreign model fails.
         from app.provider import get_provider_for_role
         provider = get_provider_for_role("lightweight")
+        models = get_model_config(
+            role_providers={"lightweight": provider.name, "fallback": provider.name},
+        )
         # Outbox formatting runs at KOAN_ROOT — suppress contributor tooling (#2379).
         cmd = build_full_command(
             prompt=prompt,

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -137,16 +137,28 @@ _PROVIDERS = {
 # it here would break that CI fixer.
 READ_ONLY_ROLES = frozenset({"review_mode"})
 
-# Cached provider instance (reset with reset_provider() in tests)
+# Cached provider instance (reset with reset_provider() in tests). The path is
+# part of the key: `cli_provider: claude:/a` and `claude:/b` are the same flavor
+# but must not share an instance.
 _cached_provider: Optional[CLIProvider] = None
 _cached_provider_name: str = ""
+_cached_provider_path: str = ""
+
+# True once an unparseable global cli_provider has been reported. get_provider()
+# runs on every command build, so without this a stale value (e.g. the removed
+# "local" flavor, which config_validator still special-cases) would log once per
+# CLI invocation for the life of the process.
+_warned_global_cli: bool = False
 
 
 def reset_provider():
-    """Reset the cached provider (for testing)."""
-    global _cached_provider, _cached_provider_name
+    """Reset the cached provider and warn-once state (for testing)."""
+    global _cached_provider, _cached_provider_name, _cached_provider_path
+    global _warned_global_cli
     _cached_provider = None
     _cached_provider_name = ""
+    _cached_provider_path = ""
+    _warned_global_cli = False
 
 
 def is_known_provider(name: str) -> bool:
@@ -154,45 +166,70 @@ def is_known_provider(name: str) -> bool:
     return str(name or "").strip().lower() in _PROVIDERS
 
 
-def get_provider_name() -> str:
-    """Determine which CLI provider to use.
+def _global_cli_spec() -> Tuple[str, str]:
+    """Resolve the global provider as ``(flavor, binary_path)``.
 
     Resolution order:
-    1. KOAN_CLI_PROVIDER env var (with CLI_PROVIDER fallback; highest priority)
-    2. config.yaml cli_provider key
-    3. Default: "claude"
+    1. KOAN_CLI_PROVIDER env var (with CLI_PROVIDER fallback; highest priority).
+       Flavor only — ``KOAN_CLAUDE_CLI_PATH`` is the env channel for a custom
+       binary, so this one deliberately carries no path.
+    2. config.yaml ``cli_provider`` key — ``flavor`` or ``flavor:path``, the same
+       grammar the per-role ``cli:`` entries use.
+    3. Default: ``("claude", "")``
+
+    An unparseable value warns once per distinct value rather than once per
+    call: this runs on every command build via :func:`get_provider`.
     """
     # Lazy import to avoid circular dependency
-    from app.utils import get_cli_provider_env, load_config
+    from app.utils import get_cli_provider_env
 
     env_val = get_cli_provider_env()
     if env_val and env_val in _PROVIDERS:
-        return env_val
+        return (env_val, "")
 
     try:
-        config = load_config()
-        config_val = str(config.get("cli_provider", "")).strip().lower()
-        if config_val and config_val in _PROVIDERS:
-            return config_val
+        from app.config import get_global_cli_spec
+
+        global _warned_global_cli
+        flavor, path = get_global_cli_spec(warn=not _warned_global_cli)
+        if not flavor:
+            _warned_global_cli = True
+        if flavor:
+            return (flavor, path)
     except Exception as e:
         print(f"[provider] Config loading failed: {e}", file=sys.stderr)
 
-    return "claude"
+    return ("claude", "")
+
+
+def get_provider_name() -> str:
+    """Determine which CLI provider to use.
+
+    Returns the bare flavor name; a ``cli_provider: flavor:path`` value resolves
+    to its flavor here and the path is applied by :func:`get_provider`.
+    """
+    return _global_cli_spec()[0]
 
 
 def get_provider() -> CLIProvider:
     """Get the configured CLI provider instance (cached singleton)."""
-    global _cached_provider, _cached_provider_name
+    global _cached_provider, _cached_provider_name, _cached_provider_path
+    # The flavor still comes from get_provider_name() so tests that patch it keep
+    # steering resolution. The configured path applies only when the resolved
+    # flavor is still the one it was configured for — an override must not
+    # inherit another flavor's binary.
+    spec_flavor, spec_path = _global_cli_spec()
     name = get_provider_name()
-    if _cached_provider is None or name != _cached_provider_name:
-        _cached_provider = _PROVIDERS[name]()
+    path = spec_path if name == spec_flavor else ""
+    if (
+        _cached_provider is None
+        or name != _cached_provider_name
+        or path != _cached_provider_path
+    ):
+        _cached_provider = _PROVIDERS[name](binary_path=path)
         _cached_provider_name = name
+        _cached_provider_path = path
     return _cached_provider
-
-
-def is_known_provider(name: str) -> bool:
-    """True when ``name`` resolves to a registered CLI provider."""
-    return str(name or "").strip().lower() in _PROVIDERS
 
 
 def known_providers() -> list:

--- a/koan/app/rituals.py
+++ b/koan/app/rituals.py
@@ -76,18 +76,25 @@ def run_ritual(ritual_type: str, instance_dir: Path) -> bool:
         return False
 
     try:
+        # Rituals are short, cheap and read-only — route them through the
+        # `lightweight` role so a `cli:` binary override applies here too,
+        # instead of silently taking the global provider's binary.
+        from app.provider import get_provider_for_role
+        provider = get_provider_for_role("lightweight")
         # Rituals run at KOAN_ROOT — suppress contributor project tooling (#2379).
         cmd = build_full_command(
             prompt=prompt,
             allowed_tools=["Read", "Write", "Glob"],
             max_turns=7,
             project_context=False,
+            provider=provider,
         )
         result = run_cli(
             cmd,
             cwd=koan_root,
             capture_output=True, text=True, timeout=90,
-            check=False
+            check=False,
+            provider=provider,
         )
         if result.returncode == 0:
             print(f"[rituals] {ritual_type} ritual completed")

--- a/koan/app/startup_info.py
+++ b/koan/app/startup_info.py
@@ -55,7 +55,12 @@ def gather_startup_info(koan_root: Path) -> dict:
 
 
 def _get_provider(koan_root: Path) -> str:
-    """Detect the CLI provider from env or config."""
+    """Detect the CLI provider FLAVOR from env or config.
+
+    ``cli_provider`` accepts ``flavor:path``, so the raw value is not a display
+    name — strip any binary path rather than printing
+    ``claude:/root/.local/bin/wrap`` as the provider.
+    """
     try:
         from app.utils import get_cli_provider_env
         provider = get_cli_provider_env()
@@ -63,7 +68,7 @@ def _get_provider(koan_root: Path) -> str:
         provider = ""
     if not provider:
         provider = _get_config_value("cli_provider", "claude")
-    return provider
+    return str(provider or "").partition(":")[0].strip().lower() or "claude"
 
 
 def _get_projects_summary(koan_root: Path) -> str:

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4194,3 +4194,75 @@ def test_read_sections_cached_expires_after_ttl():
     assert first == {"pending": ["a"]}
     assert second == {"pending": ["b"]}  # TTL expired → re-read
     assert mock_read.call_count == 2
+
+
+class TestHandleChatHonoursCliRole:
+    """Chat builds its command from the `chat` role's provider.
+
+    It already asked for the chat MODEL while taking the global provider's
+    binary, so a `cli.default.chat` override never reached the spawn — the
+    symptom that surfaced as a 401 auth error delivered as a chat reply.
+    """
+
+    @patch("app.awake.save_conversation_message")
+    @patch("app.awake.load_recent_history", return_value=[])
+    @patch("app.awake.format_conversation_history", return_value="")
+    @patch("app.awake.get_tools_description", return_value="")
+    @patch("app.awake.get_chat_tools", return_value="")
+    @patch("app.awake.send_telegram", return_value=True)
+    @patch("app.awake.subprocess.run")
+    def test_uses_the_chat_role_binary(self, mock_run, mock_send, mock_tools,
+                                       mock_tools_desc, mock_fmt, mock_hist,
+                                       mock_save, tmp_path):
+        from app.provider import ClaudeProvider
+
+        mock_run.return_value = MagicMock(stdout="Hello back!", returncode=0)
+        (tmp_path / "journal" / "2026-02-01").mkdir(parents=True)
+        with patch("app.awake.INSTANCE_DIR", tmp_path), \
+             patch("app.awake.KOAN_ROOT", tmp_path), \
+             patch("app.awake.PROJECT_PATH", ""), \
+             patch("app.awake.CONVERSATION_HISTORY_FILE", tmp_path / "history.jsonl"), \
+             patch("app.awake.SOUL", "test soul"), \
+             patch("app.awake.SUMMARY", "test summary"), \
+             patch("app.provider.get_provider_for_role",
+                   return_value=ClaudeProvider(binary_path="/opt/bin/wrap-claude")) as mock_role:
+            handle_chat("hello")
+
+        mock_role.assert_called_once_with("chat")
+        assert mock_run.call_args[0][0][0] == "/opt/bin/wrap-claude"
+
+    @patch("app.awake.save_conversation_message")
+    @patch("app.awake.load_recent_history", return_value=[])
+    @patch("app.awake.format_conversation_history", return_value="")
+    @patch("app.awake.get_tools_description", return_value="")
+    @patch("app.awake.get_chat_tools", return_value="")
+    @patch("app.awake.send_telegram", return_value=True)
+    @patch("app.awake.subprocess.run")
+    def test_routing_changes_only_the_binary(self, mock_run, mock_send, mock_tools,
+                                             mock_tools_desc, mock_fmt, mock_hist,
+                                             mock_save, tmp_path):
+        """Routing the provider must not disturb any other argument — same
+        model, tools and flags, only argv[0] moves."""
+        from app.provider import ClaudeProvider
+
+        mock_run.return_value = MagicMock(stdout="Hello back!", returncode=0)
+        (tmp_path / "journal" / "2026-02-01").mkdir(parents=True)
+        patches = [
+            patch("app.awake.INSTANCE_DIR", tmp_path),
+            patch("app.awake.KOAN_ROOT", tmp_path),
+            patch("app.awake.PROJECT_PATH", ""),
+            patch("app.awake.CONVERSATION_HISTORY_FILE", tmp_path / "history.jsonl"),
+            patch("app.awake.SOUL", "test soul"),
+            patch("app.awake.SUMMARY", "test summary"),
+        ]
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            handle_chat("hello")
+            baseline = list(mock_run.call_args[0][0])
+            with patch("app.provider.get_provider_for_role",
+                       return_value=ClaudeProvider(binary_path="/opt/bin/wrap-claude")):
+                handle_chat("hello")
+            routed = list(mock_run.call_args[0][0])
+
+        assert routed[0] == "/opt/bin/wrap-claude"
+        assert baseline[0] == "claude"
+        assert routed[1:] == baseline[1:]

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4266,3 +4266,43 @@ class TestHandleChatHonoursCliRole:
         assert routed[0] == "/opt/bin/wrap-claude"
         assert baseline[0] == "claude"
         assert routed[1:] == baseline[1:]
+
+    @patch("app.awake.save_conversation_message")
+    @patch("app.awake.load_recent_history", return_value=[])
+    @patch("app.awake.format_conversation_history", return_value="")
+    @patch("app.awake.get_tools_description", return_value="")
+    @patch("app.awake.get_chat_tools", return_value="")
+    @patch("app.awake.send_telegram", return_value=True)
+    @patch("app.awake.subprocess.run")
+    def test_cross_flavor_role_uses_the_role_providers_model(
+        self, mock_run, mock_send, mock_tools, mock_tools_desc, mock_fmt,
+        mock_hist, mock_save, tmp_path
+    ):
+        """A cross-flavor `cli.default.chat` override (chat→codex under a claude
+        global) must resolve the chat model against codex's section, not
+        claude's — else codex is spawned with claude's model and rejects it."""
+        from app.provider import CodexProvider
+
+        mock_run.return_value = MagicMock(stdout="Hello back!", returncode=0)
+        (tmp_path / "journal" / "2026-02-01").mkdir(parents=True)
+        config = {
+            "cli_provider": "claude",
+            "models": {
+                "default": {"chat": "sonnet"},
+                "codex": {"chat": "gpt-5-codex"},
+            },
+        }
+        with patch("app.awake.INSTANCE_DIR", tmp_path), \
+             patch("app.awake.KOAN_ROOT", tmp_path), \
+             patch("app.awake.PROJECT_PATH", ""), \
+             patch("app.awake.CONVERSATION_HISTORY_FILE", tmp_path / "history.jsonl"), \
+             patch("app.awake.SOUL", "test soul"), \
+             patch("app.awake.SUMMARY", "test summary"), \
+             patch("app.config._load_config", return_value=config), \
+             patch("app.provider.get_provider_for_role",
+                   return_value=CodexProvider(binary_path="/opt/bin/codex")):
+            handle_chat("hello")
+
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == "/opt/bin/codex"
+        assert argv[argv.index("--model") + 1] == "gpt-5-codex"

--- a/koan/tests/test_cli_config.py
+++ b/koan/tests/test_cli_config.py
@@ -52,6 +52,50 @@ class TestParseCliValue:
         assert cfg._parse_cli_value(None) == ("", "")
 
 
+class TestParseCliValueWarnFlag:
+    def test_warn_false_suppresses_the_unknown_flavor_line(self, capsys):
+        """Callers that re-parse an already-reported value stay quiet."""
+        assert cfg._parse_cli_value("bogus:/x", warn=False) == ("", "")
+        assert "unknown provider flavor" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# get_global_cli_spec
+# ---------------------------------------------------------------------------
+
+class TestGlobalCliSpec:
+    def test_flavor_only(self):
+        with _config({"cli_provider": "claude"}):
+            assert cfg.get_global_cli_spec() == ("claude", "")
+
+    def test_flavor_with_path(self):
+        with _config({"cli_provider": "claude:/opt/bin/wrap-claude"}):
+            assert cfg.get_global_cli_spec() == ("claude", "/opt/bin/wrap-claude")
+
+    def test_relative_path_returned_raw(self):
+        # The provider resolves it against KOAN_ROOT in binary().
+        with _config({"cli_provider": "claude:bin/wrap"}):
+            assert cfg.get_global_cli_spec() == ("claude", "bin/wrap")
+
+    def test_non_claude_flavor_with_path(self):
+        with _config({"cli_provider": "codex:/opt/bin/codex"}):
+            assert cfg.get_global_cli_spec() == ("codex", "/opt/bin/codex")
+
+    def test_unknown_flavor_warns_and_falls_through(self, capsys):
+        with _config({"cli_provider": "bogus:/x"}):
+            assert cfg.get_global_cli_spec() == ("", "")
+        assert "unknown provider flavor" in capsys.readouterr().err
+
+    def test_absent_key(self):
+        with _config({}):
+            assert cfg.get_global_cli_spec() == ("", "")
+
+    def test_warn_false_is_quiet(self, capsys):
+        with _config({"cli_provider": "bogus:/x"}):
+            assert cfg.get_global_cli_spec(warn=False) == ("", "")
+        assert "unknown provider flavor" not in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # get_cli_config
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -1468,3 +1468,74 @@ class TestRoleProviderSelection:
         assert "review_mode→claude(deep-claude)" in summary
         assert "fallback→claude" in summary
         assert "mission→" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Global cli_provider with a binary path (flavor:path)
+# ---------------------------------------------------------------------------
+
+class TestGlobalProviderBinaryPath:
+    """`cli_provider` accepts the same flavor:path grammar as `cli:` values.
+
+    Before this, a `flavor:path` value failed the `in _PROVIDERS` membership
+    test and the whole setting was silently discarded — every path that used the
+    global provider spawned the bare binary.
+    """
+
+    def setup_method(self):
+        import app.provider as provider
+        import os
+        os.environ.pop("KOAN_CLI_PROVIDER", None)
+        os.environ.pop("CLI_PROVIDER", None)
+        provider.reset_provider()
+
+    def teardown_method(self):
+        import app.provider as provider
+        provider.reset_provider()
+
+    @patch("app.utils.load_config", return_value={"cli_provider": "claude:/opt/bin/wrap-claude"})
+    def test_path_reaches_the_global_provider(self, mock_config):
+        assert get_provider_name() == "claude"
+        assert get_provider().binary() == "/opt/bin/wrap-claude"
+
+    @patch("app.utils.load_config", return_value={"cli_provider": "claude"})
+    def test_flavor_only_is_unchanged(self, mock_config):
+        # Backward compatibility: the documented form must behave exactly as before.
+        assert get_provider_name() == "claude"
+        assert get_provider().binary() == "claude"
+
+    @patch("app.utils.load_config", return_value={"cli_provider": "codex:/opt/bin/codex"})
+    def test_works_for_non_claude_flavors(self, mock_config):
+        assert get_provider_name() == "codex"
+        assert get_provider().binary() == "/opt/bin/codex"
+
+    @patch("app.utils.load_config", return_value={"cli_provider": "bogus:/x"})
+    def test_unknown_flavor_falls_back_and_warns_once(self, mock_config, capsys):
+        assert get_provider().binary() == "claude"
+        # One line per resolution, not one per internal lookup.
+        assert capsys.readouterr().err.count("unknown provider flavor") == 1
+
+    def test_cache_is_keyed_on_the_path_too(self):
+        """Two values sharing a flavor must not share a cached instance."""
+        import app.provider as provider
+        with patch("app.utils.load_config", return_value={"cli_provider": "claude:/first"}):
+            assert get_provider().binary() == "/first"
+        with patch("app.utils.load_config", return_value={"cli_provider": "claude:/second"}):
+            assert get_provider().binary() == "/second"
+        provider.reset_provider()
+
+    @patch("app.provider.get_provider_name", return_value="codex")
+    @patch("app.utils.load_config", return_value={"cli_provider": "claude:/opt/bin/wrap-claude"})
+    def test_patched_name_does_not_inherit_another_flavors_path(self, mock_config, mock_name):
+        """A patched/overridden flavor must not pick up a path configured for
+        a different flavor — and the 164 existing get_provider_name mocks must
+        keep steering get_provider()."""
+        p = get_provider()
+        assert p.name == "codex"
+        assert p.binary() == "codex"
+
+    @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "codex"})
+    @patch("app.utils.load_config", return_value={"cli_provider": "claude:/opt/bin/wrap-claude"})
+    def test_env_var_still_wins_and_carries_no_path(self, mock_config):
+        assert get_provider_name() == "codex"
+        assert get_provider().binary() == "codex"

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -438,3 +438,28 @@ class TestOutboxHonoursCliRole:
         expected = get_model_config()["lightweight"]
         assert "--model" in argv
         assert argv[argv.index("--model") + 1] == expected
+
+    @patch("app.cli_exec.run_cli")
+    def test_cross_flavor_role_uses_the_role_providers_model(self, mock_run):
+        """A cross-flavor `cli:` override (lightweight→codex under a claude
+        global) must resolve the model against codex's section, not claude's —
+        else codex is spawned with claude's model and rejects it."""
+        from app.provider import CodexProvider
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="formatted", stderr="")
+        config = {
+            "cli_provider": "claude",
+            "models": {
+                "default": {"lightweight": "haiku"},
+                "codex": {"lightweight": "gpt-5-codex"},
+            },
+        }
+        with patch("app.config._load_config", return_value=config), patch(
+            "app.provider.get_provider_for_role",
+            return_value=CodexProvider(binary_path="/opt/bin/codex"),
+        ):
+            format_message("cross-flavor-outbox-probe", "soul", "prefs")
+
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == "/opt/bin/codex"
+        assert argv[argv.index("--model") + 1] == "gpt-5-codex"

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -402,3 +402,39 @@ class TestFormatMessageCaching:
             format_message("raw", "soul", "prefs")
 
         assert mock_run.call_count == 2
+
+
+class TestOutboxHonoursCliRole:
+    """Outbox formatting builds its command from the `lightweight` role.
+
+    It already asked for the lightweight MODEL while taking the global
+    provider's binary; the two now agree.
+    """
+
+    @patch("app.cli_exec.run_cli")
+    def test_uses_the_lightweight_role_binary(self, mock_run):
+        from app.provider import ClaudeProvider
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="formatted", stderr="")
+        with patch(
+            "app.provider.get_provider_for_role",
+            return_value=ClaudeProvider(binary_path="/opt/bin/wrap-claude"),
+        ) as mock_role:
+            format_message("raw content", "soul", "prefs")
+
+        mock_role.assert_called_once_with("lightweight")
+        assert mock_run.call_args[0][0][0] == "/opt/bin/wrap-claude"
+
+    @patch("app.cli_exec.run_cli")
+    def test_still_requests_the_lightweight_model(self, mock_run):
+        """Routing the provider must not change which model is used."""
+        from app.config import get_model_config
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="formatted", stderr="")
+        # Unique text per test: format_message short-circuits on a response cache.
+        format_message("outbox-model-parity-probe", "soul", "prefs")
+
+        argv = mock_run.call_args[0][0]
+        expected = get_model_config()["lightweight"]
+        assert "--model" in argv
+        assert argv[argv.index("--model") + 1] == expected

--- a/koan/tests/test_rituals.py
+++ b/koan/tests/test_rituals.py
@@ -314,3 +314,33 @@ class TestRitualsCLI:
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
+
+
+class TestRitualHonoursCliRole:
+    """Rituals build their command from the `lightweight` role's provider.
+
+    Previously they passed no provider, so argv[0] came from the global
+    provider and a `cli:` binary override was silently ignored.
+    """
+
+    @patch("app.rituals.subprocess.run")
+    def test_uses_the_lightweight_role_binary(self, mock_run, prompt_dir, instance_dir):
+        from app.provider import ClaudeProvider
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        with patch(
+            "app.provider.get_provider_for_role",
+            return_value=ClaudeProvider(binary_path="/opt/bin/wrap-claude"),
+        ) as mock_role:
+            assert run_ritual("morning", instance_dir) is True
+
+        mock_role.assert_called_once_with("lightweight")
+        assert mock_run.call_args[0][0][0] == "/opt/bin/wrap-claude"
+
+    @patch("app.rituals.subprocess.run")
+    def test_falls_back_to_the_global_binary_without_an_override(
+        self, mock_run, prompt_dir, instance_dir
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        assert run_ritual("morning", instance_dir) is True
+        assert mock_run.call_args[0][0][0] == "claude"


### PR DESCRIPTION
`cli_provider: "claude:/root/.local/bin/lmpanel-claude"` was silently
discarded. get_provider_name() tested the whole config string for
membership in _PROVIDERS; a `flavor:path` value is not a key, so the
guard failed and control fell through to the hardcoded `return "claude"`.
The setting was not partially parsed — it was dropped entirely, with no
warning, and `cli_provider: "grok:/path"` would likewise have yielded
Claude.

get_provider() then built the provider with no binary_path, so
ClaudeProvider.binary() returned the literal "claude". Every path that
uses the global provider — chat, rituals, outbox formatting, and ~14
other sites that call build_full_command without provider= — therefore
spawned the bare binary regardless of what `cli:` said. On a host where
the wrapper supplies auth, that surfaces as `401 OAuth access token has
expired`, delivered to the user as a chat reply.

The per-role `cli:` section was never at fault: get_cli_config() and
get_provider_for_role() already resolve `flavor:path` correctly. Only
the global channel was missing it.

Route `cli_provider` through _parse_cli_value(), the parser the `cli:`
section already uses — one grammar, one validator, no second parser:

- config.get_global_cli_spec() reads the key and returns (flavor, path).
  A config-load failure propagates; provider.get_provider_name() owns
  that error path and logs it.
- get_provider_name() keeps its exact contract (bare flavor, `-> str`).
  It keys models.<provider> sections and display strings, and is patched
  in 164 places across 24 test files that expect it to steer
  get_provider() — so the path resolution is a sibling, not a rewrite.
- get_provider() passes binary_path and caches on (name, path). A
  name-only key would serve a stale instance when only the path moved.
- An unknown flavor now warns instead of silently defaulting, once per
  process — get_provider() runs on every command build, and a stale
  value like the removed `local` flavor would otherwise log per
  invocation.

KOAN_CLI_PROVIDER stays flavor-only: KOAN_CLAUDE_CLI_PATH already covers
"custom binary from the environment", and a second env spelling for the
same thing would only invite drift.

Also drop a duplicate is_known_provider() definition, and strip the path
before the startup banner prints the provider name.