### PR TITLE
feat(review): force a fresh review on explicit @mention

### DIFF
--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -603,6 +603,13 @@ def build_mission_from_command(
     if context and skill.github_context_aware:
         parts.append(context)
 
+    # An explicit @mention asking for a review is a deliberate human request:
+    # carry --force so the runner bypasses its incremental "no new commits"
+    # skip and always produces a fresh review. Implicit review_requested
+    # notifications don't go through this builder, so they keep the dedup.
+    if command_name in ("review", "ultrareview") and "--force" not in parts:
+        parts.append("--force")
+
     mission_text = " ".join(parts)
     # Trailing 📬 marks missions originating from GitHub @mentions.
     # The /list handler repositions it as a leading visual hint.

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -3880,7 +3880,9 @@ def run_review(
             (errors) pass. Equivalent to passing architecture=True and
             errors=True; provided as a single semantic switch for the
             /ultrareview skill.
-        force: If True, review even if the PR is closed/merged.
+        force: If True, review even if the PR is closed/merged, and
+            re-review even when no new commits were pushed (bypasses the
+            incremental SHA skip and the prior-review reuse short-circuit).
         bot_comments: If True, run an additional pass to triage inline
             comments from code-review bots and post replies to actionable
             findings.
@@ -4007,12 +4009,13 @@ def run_review(
     )
 
     # If all current commits were already reviewed AND this is not an
-    # explicit re-request, skip.
+    # explicit re-request (Reviewers-panel re-request or --force), skip.
     if (
         current_shas
         and prior_shas
         and set(current_shas) == set(prior_shas)
         and not review_was_requested
+        and not force
     ):
         bot_triage_cfg = get_review_bot_triage_config()
         bot_triage_enabled = bot_comments or bot_triage_cfg["enabled"]
@@ -4072,7 +4075,7 @@ def run_review(
     _request_signature = request_signature(_focus_flags, _discovery_enabled)
     _consistency_cfg = _get_cc_cfg(project_name or "")
     _base_sha = ""
-    if _consistency_cfg["reuse_enabled"] and _head_sha:
+    if _consistency_cfg["reuse_enabled"] and _head_sha and not force:
         _base_sha = _merge_base_sha(owner, repo, context.get("base") or "", _head_sha)
         if _base_sha:
             _prior_record = _read_prior_review_record(
@@ -4527,7 +4530,8 @@ def main(argv=None):
     )
     parser.add_argument(
         "--force", action="store_true",
-        help="Review even if the PR is closed or merged.",
+        help="Review even if the PR is closed or merged, and re-review even "
+             "when no new commits were pushed since the last review.",
     )
     parser.add_argument(
         "--bot-comments", action="store_true",

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -367,6 +367,36 @@ class TestBuildMissionFromCommand:
         )
         assert mission == "- [project:koan] /rebase https://github.com/sukria/koan/pull/42 📬"
 
+    def test_review_mention_carries_force(self, mock_skill, sample_notification):
+        """An explicit @mention review always forces a fresh review."""
+        mission = build_mission_from_command(
+            mock_skill, "review", "", sample_notification, "koan"
+        )
+        assert mission == (
+            "- [project:koan] /review "
+            "https://github.com/sukria/koan/pull/42 --force 📬"
+        )
+
+    def test_ultrareview_mention_carries_force(self, mock_skill, sample_notification):
+        mission = build_mission_from_command(
+            mock_skill, "ultrareview", "", sample_notification, "koan"
+        )
+        assert "--force 📬" in mission
+
+    def test_review_mention_does_not_duplicate_force(
+        self, mock_context_skill, sample_notification
+    ):
+        mission = build_mission_from_command(
+            mock_context_skill, "review", "--force", sample_notification, "koan"
+        )
+        assert mission.count("--force") == 1
+
+    def test_non_review_mention_has_no_force(self, mock_skill, sample_notification):
+        mission = build_mission_from_command(
+            mock_skill, "rebase", "", sample_notification, "koan"
+        )
+        assert "--force" not in mission
+
     def test_context_aware_with_context(self, mock_context_skill, sample_notification):
         mission = build_mission_from_command(
             mock_context_skill, "implement", "phase 1 only",
@@ -2153,8 +2183,8 @@ class TestProcessNotificationEdgeCases:
         assert error is None
         inserted = [args[0][1] for args in mock_insert.call_args_list]
         assert inserted == [
-            "- [project:koan] /review https://github.com/sukria/koan/pull/76 📬",
-            "- [project:koan] /review https://github.com/sukria/koan/pull/77 📬",
+            "- [project:koan] /review https://github.com/sukria/koan/pull/76 --force 📬",
+            "- [project:koan] /review https://github.com/sukria/koan/pull/77 --force 📬",
         ]
 
     @patch("app.github_command_handler.mark_notification_read")
@@ -4479,7 +4509,7 @@ class TestRecentMentionScan:
 
         assert queued == 1
         content = (instance_dir / "missions.md").read_text()
-        assert "[project:koan] /review https://github.com/sukria/koan/pull/42 📬" in content
+        assert "[project:koan] /review https://github.com/sukria/koan/pull/42 --force 📬" in content
         mock_react.assert_called_once()
 
         from app.github_notification_tracker import is_comment_tracked

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -4671,6 +4671,38 @@ class TestIncrementalReview:
         # Claude should NOT have been called — review was skipped
         mock_claude.assert_not_called()
 
+    @patch("app.review_runner._fetch_pr_commit_shas", return_value=["abc", "def"])
+
+    @patch("app.review_runner.find_bot_comment")
+    @patch("app.review_runner.fetch_repliable_comments", return_value=[])
+    @patch("app.review_runner.run_gh")
+    @patch("app.review_runner._run_claude_review")
+    @patch("app.review_runner.fetch_pr_context")
+    def test_force_bypasses_no_new_commits_skip(
+        self, mock_fetch, mock_claude, mock_gh, mock_repliable,
+        mock_find_bot, _mock_shas, pr_context, review_skill_dir,
+    ):
+        """force=True re-reviews even when all SHAs were already reviewed."""
+        from app.review_markers import SUMMARY_TAG, COMMIT_IDS_START, COMMIT_IDS_END
+
+        mock_fetch.return_value = pr_context
+        sha_block = f"{COMMIT_IDS_START}\nabc\ndef\n{COMMIT_IDS_END}"
+        prior_comment = {"id": 42, "body": f"{SUMMARY_TAG}\n{sha_block}", "user": "koan-bot"}
+        updated_comment = {"id": 42, "body": f"{SUMMARY_TAG}\n## Review\n\nLGTM", "user": "koan-bot"}
+        mock_find_bot.side_effect = [prior_comment, updated_comment]
+        mock_claude.return_value = (json.dumps(LGTM_REVIEW_JSON), "")
+
+        success, summary, _ = run_review(
+            "owner", "repo", "42", "/tmp/project",
+            notify_fn=MagicMock(),
+            skill_dir=review_skill_dir,
+            force=True,
+        )
+
+        assert success is True
+        assert "no new commits" not in summary.lower()
+        mock_claude.assert_called_once()
+
     @patch("app.review_runner._fetch_pr_commit_shas", return_value=["abc", "def", "ghi"])
 
     @patch("app.review_runner.find_bot_comment")


### PR DESCRIPTION
## What

An explicit `@bot review` mention now always produces a fresh review, even when no new commits were pushed since the last one.

## Why

Today a re-mention on an unchanged PR is answered with "no new commits since last review — skipping". The only escape hatches are pushing a commit or a Reviewers-panel re-request. But a human mentioning the bot again *is* an explicit ask — e.g. after replying to a finding and wanting the review to take the discussion into account.

## How

- `build_mission_from_command` (mention ingress only) appends `--force` to `review`/`ultrareview` missions.
- `run_review`: `force=True` now bypasses the incremental SHA skip **and** the prior-review reuse short-circuit (a forced run must re-analyze, not reproduce).
- `--force` help/docstring updated.

Implicit `review_requested` notifications and auto-reviews of newly opened PRs don't go through the mention builder, so they keep the dedup that protects against duplicate notification deliveries.

## Tests

- 5 new tests (mention carries `--force`, no duplication, non-review mentions unaffected, force bypasses the SHA skip).
- 2 existing expectations updated to the new mention mission text.
- `test_github_command_handler.py` + `test_review_runner.py` + `test_skill_dispatch.py`: 1094 passed. `ruff` clean.