### PR TITLE
fix(events): quarantine non-UTF-8 event files instead of crashing tick

### DIFF
--- a/docs/architecture/shared-state.md
+++ b/docs/architecture/shared-state.md
@@ -25,7 +25,11 @@ generated read-only export. Everything else below remains file-based.
 - `config.yaml` - instance behavior and integration configuration.
 - `memory/` - global and per-project memory files.
 - `journal/` - daily logs and reflections.
-- `events/` - scheduled mission JSON files.
+- `events/` - scheduled mission JSON files. Fired events move to
+  `events/archive/`; files that can never yield a valid event (undecodable
+  bytes, invalid JSON, non-object payload, missing/blank `mission`/`run_at`,
+  unparseable `run_at`) move to `events/quarantine/` so one bad file cannot
+  re-poison every iteration. Check there when a scheduled mission never fired.
 - `hooks/` - user-defined lifecycle hooks (see [Lifecycle Hooks & Automation Rules](hooks.md)).
 - hidden tracker files for pause, focus, passive mode, usage, CI dispatch,
   review dispatch, burn rate, and similar daemon state.

--- a/koan/app/event_scheduler.py
+++ b/koan/app/event_scheduler.py
@@ -6,6 +6,12 @@ Reads ``instance/events/*.json`` each iteration.  Any event whose ``run_at``
 timestamp has passed is inserted into the pending mission queue and then moved
 to ``instance/events/archive/`` for audit purposes.
 
+A file that cannot be turned into a valid event -- undecodable bytes, invalid
+JSON, a non-object payload, a missing/blank ``mission`` or ``run_at``, or an
+unparseable ``run_at`` -- is moved to ``instance/events/quarantine/`` so it
+cannot re-poison every later iteration.  An operator whose scheduled mission
+never fired should look there.
+
 Event file format::
 
     {
@@ -17,19 +23,19 @@ Event file format::
 Only ``type: "once"`` is supported.  Additional types may be added later.
 """
 
+import contextlib
 import json
-import logging
 import os
 import re
 import shutil
+import tempfile
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional
 
-from app.utils import insert_pending_mission
-
-log = logging.getLogger(__name__)
+from app.run_log import log_safe
+from app.utils import append_to_outbox, insert_pending_mission
 
 # Regex for relative time specs like "30m", "2h", "1h30m", "90s"
 _RELATIVE_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
@@ -37,24 +43,53 @@ _RELATIVE_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 _HHMM_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
 
 
-def _quarantine(event_file: Path, quarantine_dir: Path) -> None:
-    """Move an unparseable event file to quarantine, suffixing on collision."""
-    quarantine_dir.mkdir(parents=True, exist_ok=True)
-    dest = quarantine_dir / event_file.name
-    if dest.exists():
-        stem = event_file.stem
-        suffix = event_file.suffix
-        ts = int(time.time())
-        dest = quarantine_dir / f"{stem}_{ts}{suffix}"
-    shutil.move(str(event_file), str(dest))
+def _quarantine(event_file: Path, quarantine_dir: Path) -> bool:
+    """Move an unparseable event file out of the scan path.
+
+    Returns ``True`` when the file left ``events/``.  Never raises: this runs
+    from inside an ``except`` block, so a quarantine that itself fails (
+    read-only directory, ENOSPC, a competing process that already moved the
+    file) must degrade to "skip this file" rather than abort the caller's scan.
+    """
+    try:
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+        dest = quarantine_dir / event_file.name
+        # shutil.move() overwrites its destination silently, so probe for a
+        # free name instead of trusting a single second-resolution suffix --
+        # the quarantined copy is the only remaining evidence of the event.
+        while dest.exists():
+            dest = quarantine_dir / f"{event_file.stem}_{time.time_ns()}{event_file.suffix}"
+        shutil.move(str(event_file), str(dest))
+        return True
+    except OSError as exc:
+        log_safe("warning", f"[events] could not quarantine {event_file.name}: {exc}")
+        return False
+
+
+def _notify_dropped(instance: Path, filename: str, mission: str) -> None:
+    """Tell the operator that a scheduled mission will never run.
+
+    A log line is not a channel the operator watches; a well-formed-looking
+    event carrying real mission text deserves an outbox message.
+    """
+    try:
+        append_to_outbox(
+            instance / "outbox.md",
+            f"⚠️ Scheduled event `{filename}` was quarantined; its mission "
+            f"will not run:\n{mission[:200]}\n\n",
+        )
+    except OSError as exc:
+        log_safe("warning", f"[events] could not report dropped {filename}: {exc}")
 
 
 def tick(instance_dir: str) -> List[str]:
     """Process overdue one-shot events and insert their missions.
 
-    Scans ``instance_dir/events/*.json`` (excluding the ``archive/``
-    subdirectory), inserts missions whose ``run_at`` has passed, and
-    moves processed files to ``instance_dir/events/archive/``.
+    Scans ``instance_dir/events/*.json`` (excluding the ``archive/`` and
+    ``quarantine/`` subdirectories), inserts missions whose ``run_at`` has
+    passed, and moves processed files to ``instance_dir/events/archive/``.
+    Files that cannot yield a valid event are moved to
+    ``instance_dir/events/quarantine/`` instead of firing.
 
     Args:
         instance_dir: Path to the Kōan instance directory.
@@ -81,19 +116,25 @@ def tick(instance_dir: str) -> List[str]:
             # than being masked by errors="replace" inside a JSON string value.
             text = event_file.read_bytes().decode("utf-8")
             data = json.loads(text)
-        except (UnicodeDecodeError, OSError) as exc:
-            # UnicodeDecodeError is a ValueError subclass, not OSError, so a
-            # bare OSError except would miss it and crash the whole iteration.
-            log.warning("[events] skipping unparseable %s: %s", event_file.name, exc)
-            _quarantine(event_file, quarantine_dir)
+        except OSError as exc:
+            # A read failure is transient: the file may be mid-write, or the
+            # bridge may have archived it between the glob and the read.
+            # Leave it in place and retry next tick -- quarantining here would
+            # destroy a still-valid pending mission.
+            log_safe("warning", f"[events] could not read {event_file.name}: {exc}")
             continue
         except ValueError as exc:
-            log.warning("[events] skipping unparseable %s: %s", event_file.name, exc)
+            # UnicodeDecodeError and json.JSONDecodeError are both ValueError
+            # subclasses, not OSError, so a bare OSError except would miss them
+            # and crash the whole iteration. write_event_file() publishes the
+            # body atomically, so a parse failure means genuine corruption
+            # rather than an in-flight write.
+            log_safe("warning", f"[events] quarantining unparseable {event_file.name}: {exc}")
             _quarantine(event_file, quarantine_dir)
             continue
 
         if not isinstance(data, dict):
-            log.warning("[events] structurally invalid %s; quarantining", event_file.name)
+            log_safe("warning", f"[events] quarantining structurally invalid {event_file.name}")
             _quarantine(event_file, quarantine_dir)
             continue
 
@@ -105,7 +146,7 @@ def tick(instance_dir: str) -> List[str]:
             or not isinstance(run_at_value, str)
             or not run_at_value
         ):
-            log.warning("[events] structurally invalid %s; quarantining", event_file.name)
+            log_safe("warning", f"[events] quarantining structurally invalid {event_file.name}")
             _quarantine(event_file, quarantine_dir)
             continue
         mission = mission_value.strip()
@@ -114,8 +155,9 @@ def tick(instance_dir: str) -> List[str]:
         try:
             run_at = datetime.fromisoformat(run_at_str)
         except ValueError as exc:
-            log.warning("[events] invalid run_at in %s: %s", event_file.name, exc)
+            log_safe("warning", f"[events] quarantining {event_file.name}: bad run_at: {exc}")
             _quarantine(event_file, quarantine_dir)
+            _notify_dropped(instance, event_file.name, mission)
             continue
         # ISO strings may carry a 'Z' or offset (tz-aware); 'now' is naive-local.
         # Comparing the two raises TypeError, which would crash the tick and leave
@@ -208,7 +250,11 @@ def write_event_file(events_dir: Path, run_at: datetime, mission: str) -> Path:
         mission: Mission text to enqueue when the trigger fires.
 
     Returns:
-        Path to the created file.
+        Path to the created file.  The final ``*.json`` name never exists in a
+        partial state: the body is written to a hidden sibling the ``*.json``
+        glob cannot match, then the final name is claimed with ``os.link()``,
+        which is atomic and refuses to clobber.  ``tick()`` in the other
+        process therefore cannot read a half-written event and quarantine it.
     """
     events_dir.mkdir(parents=True, exist_ok=True)
     ts = int(run_at.timestamp() * 1000)  # millisecond precision for uniqueness
@@ -218,15 +264,27 @@ def write_event_file(events_dir: Path, run_at: datetime, mission: str) -> Path:
         "mission": mission,
     }
     content = json.dumps(payload, indent=2, ensure_ascii=False)
-    # Use O_CREAT|O_EXCL for atomic create — avoids TOCTOU race vs exists() loop
-    for counter in range(100):
-        suffix = f"_{counter}" if counter else ""
-        candidate = events_dir / f"event_{ts}{suffix}.json"
-        try:
-            fd = os.open(str(candidate), os.O_WRONLY | os.O_CREAT | os.O_EXCL)
-        except FileExistsError:
-            continue
+    # Stage the complete body under a hidden name the "*.json" scan glob cannot
+    # match; mkstemp() keeps concurrent writers (same process or not) off each
+    # other's staging file.
+    fd, tmp_name = tempfile.mkstemp(dir=str(events_dir), prefix=".koan-event-", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
-        return candidate
-    raise RuntimeError(f"Failed to create unique event file after 100 attempts: {ts}")
+        for counter in range(100):
+            suffix = f"_{counter}" if counter else ""
+            candidate = events_dir / f"event_{ts}{suffix}.json"
+            try:
+                # link() is the atomic claim: it fails instead of overwriting,
+                # so it both replaces the old O_EXCL uniqueness check and
+                # guarantees the final name only ever appears with the whole
+                # payload already behind it.
+                os.link(str(tmp), str(candidate))
+            except FileExistsError:
+                continue
+            return candidate
+        raise RuntimeError(f"Failed to create unique event file after 100 attempts: {ts}")
+    finally:
+        with contextlib.suppress(OSError):
+            tmp.unlink()

--- a/koan/app/event_scheduler.py
+++ b/koan/app/event_scheduler.py
@@ -18,6 +18,7 @@ Only ``type: "once"`` is supported.  Additional types may be added later.
 """
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -28,10 +29,24 @@ from typing import List, Optional
 
 from app.utils import insert_pending_mission
 
+log = logging.getLogger(__name__)
+
 # Regex for relative time specs like "30m", "2h", "1h30m", "90s"
 _RELATIVE_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 # Regex for HH:MM
 _HHMM_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
+
+
+def _quarantine(event_file: Path, quarantine_dir: Path) -> None:
+    """Move an unparseable event file to quarantine, suffixing on collision."""
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    dest = quarantine_dir / event_file.name
+    if dest.exists():
+        stem = event_file.stem
+        suffix = event_file.suffix
+        ts = int(time.time())
+        dest = quarantine_dir / f"{stem}_{ts}{suffix}"
+    shutil.move(str(event_file), str(dest))
 
 
 def tick(instance_dir: str) -> List[str]:
@@ -54,23 +69,53 @@ def tick(instance_dir: str) -> List[str]:
 
     missions_path = instance / "missions.md"
     archive_dir = events_dir / "archive"
+    quarantine_dir = events_dir / "quarantine"
     now = datetime.now()
     enqueued: List[str] = []
 
     for event_file in sorted(events_dir.glob("*.json")):
         try:
-            data = json.loads(event_file.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+            # Strict, explicit-UTF-8 read: invalid bytes must be quarantined,
+            # not silently enqueued as a replacement-char mission. Decode in
+            # two steps so a bad byte surfaces as UnicodeDecodeError rather
+            # than being masked by errors="replace" inside a JSON string value.
+            text = event_file.read_bytes().decode("utf-8")
+            data = json.loads(text)
+        except (UnicodeDecodeError, OSError) as exc:
+            # UnicodeDecodeError is a ValueError subclass, not OSError, so a
+            # bare OSError except would miss it and crash the whole iteration.
+            log.warning("[events] skipping unparseable %s: %s", event_file.name, exc)
+            _quarantine(event_file, quarantine_dir)
+            continue
+        except ValueError as exc:
+            log.warning("[events] skipping unparseable %s: %s", event_file.name, exc)
+            _quarantine(event_file, quarantine_dir)
             continue
 
-        mission = data.get("mission", "").strip()
-        run_at_str = data.get("run_at", "")
-        if not mission or not run_at_str:
+        if not isinstance(data, dict):
+            log.warning("[events] structurally invalid %s; quarantining", event_file.name)
+            _quarantine(event_file, quarantine_dir)
             continue
+
+        mission_value = data.get("mission")
+        run_at_value = data.get("run_at")
+        if (
+            not isinstance(mission_value, str)
+            or not mission_value.strip()
+            or not isinstance(run_at_value, str)
+            or not run_at_value
+        ):
+            log.warning("[events] structurally invalid %s; quarantining", event_file.name)
+            _quarantine(event_file, quarantine_dir)
+            continue
+        mission = mission_value.strip()
+        run_at_str = run_at_value
 
         try:
             run_at = datetime.fromisoformat(run_at_str)
-        except ValueError:
+        except ValueError as exc:
+            log.warning("[events] invalid run_at in %s: %s", event_file.name, exc)
+            _quarantine(event_file, quarantine_dir)
             continue
         # ISO strings may carry a 'Z' or offset (tz-aware); 'now' is naive-local.
         # Comparing the two raises TypeError, which would crash the tick and leave

--- a/koan/skills/core/brief/handler.py
+++ b/koan/skills/core/brief/handler.py
@@ -1,7 +1,11 @@
 """Kōan brief skill — daily digest of agent activity."""
 
 import json
+import logging
 from datetime import date, datetime, timedelta
+
+
+log = logging.getLogger(__name__)
 
 
 def handle(ctx):
@@ -128,7 +132,7 @@ def _add_journal_highlights(parts, instance_dir):
 def _maybe_reschedule(instance_dir):
     """Ensure tomorrow's brief event exists (idempotent)."""
     try:
-        from app.event_scheduler import write_event_file
+        from app.event_scheduler import _quarantine, write_event_file
     except ImportError:
         return
 
@@ -141,11 +145,17 @@ def _maybe_reschedule(instance_dir):
     if events_dir.is_dir():
         for f in events_dir.glob("*.json"):
             try:
-                data = json.loads(f.read_text())
-                if tag in data.get("mission", ""):
-                    return
-            except (OSError, json.JSONDecodeError, ValueError):
+                data = json.loads(f.read_bytes().decode("utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                log.warning("[brief] quarantining unparseable %s: %s", f.name, exc)
+                _quarantine(f, events_dir / "quarantine")
                 continue
+            if not isinstance(data, dict) or not isinstance(data.get("mission"), str):
+                log.warning("[brief] quarantining structurally invalid %s", f.name)
+                _quarantine(f, events_dir / "quarantine")
+                continue
+            if tag in data["mission"]:
+                return
 
     write_event_file(events_dir, tomorrow, f"/brief [{tag}]")
 
@@ -153,7 +163,7 @@ def _maybe_reschedule(instance_dir):
 def _seed_schedule(instance_dir):
     """Explicitly seed the daily brief schedule."""
     try:
-        from app.event_scheduler import write_event_file
+        from app.event_scheduler import _quarantine, write_event_file
     except ImportError:
         return "event_scheduler not available."
 
@@ -166,11 +176,17 @@ def _seed_schedule(instance_dir):
     if events_dir.is_dir():
         for f in events_dir.glob("*.json"):
             try:
-                data = json.loads(f.read_text())
-                if tag in data.get("mission", ""):
-                    return f"Already scheduled for {tomorrow.strftime('%Y-%m-%d %H:%M')}."
-            except (OSError, json.JSONDecodeError, ValueError):
+                data = json.loads(f.read_bytes().decode("utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                log.warning("[brief] quarantining unparseable %s: %s", f.name, exc)
+                _quarantine(f, events_dir / "quarantine")
                 continue
+            if not isinstance(data, dict) or not isinstance(data.get("mission"), str):
+                log.warning("[brief] quarantining structurally invalid %s", f.name)
+                _quarantine(f, events_dir / "quarantine")
+                continue
+            if tag in data["mission"]:
+                return f"Already scheduled for {tomorrow.strftime('%Y-%m-%d %H:%M')}."
 
     write_event_file(events_dir, tomorrow, f"/brief [{tag}]")
     return f"Daily brief scheduled for {tomorrow.strftime('%Y-%m-%d %H:%M')}."

--- a/koan/skills/core/brief/handler.py
+++ b/koan/skills/core/brief/handler.py
@@ -1,11 +1,9 @@
 """Kōan brief skill — daily digest of agent activity."""
 
 import json
-import logging
 from datetime import date, datetime, timedelta
 
-
-log = logging.getLogger(__name__)
+from app.run_log import log_safe
 
 
 def handle(ctx):
@@ -146,12 +144,19 @@ def _maybe_reschedule(instance_dir):
         for f in events_dir.glob("*.json"):
             try:
                 data = json.loads(f.read_bytes().decode("utf-8"))
-            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-                log.warning("[brief] quarantining unparseable %s: %s", f.name, exc)
+            except OSError as exc:
+                # Transient: the run loop may have archived this file between
+                # the glob and the read. Quarantining a path that no longer
+                # exists would raise and skip write_event_file() below,
+                # permanently breaking the self-rescheduling chain.
+                log_safe("warning", f"[brief] could not read {f.name}: {exc}")
+                continue
+            except ValueError as exc:
+                log_safe("warning", f"[brief] quarantining unparseable {f.name}: {exc}")
                 _quarantine(f, events_dir / "quarantine")
                 continue
             if not isinstance(data, dict) or not isinstance(data.get("mission"), str):
-                log.warning("[brief] quarantining structurally invalid %s", f.name)
+                log_safe("warning", f"[brief] quarantining structurally invalid {f.name}")
                 _quarantine(f, events_dir / "quarantine")
                 continue
             if tag in data["mission"]:
@@ -177,12 +182,15 @@ def _seed_schedule(instance_dir):
         for f in events_dir.glob("*.json"):
             try:
                 data = json.loads(f.read_bytes().decode("utf-8"))
-            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-                log.warning("[brief] quarantining unparseable %s: %s", f.name, exc)
+            except OSError as exc:
+                log_safe("warning", f"[brief] could not read {f.name}: {exc}")
+                continue
+            except ValueError as exc:
+                log_safe("warning", f"[brief] quarantining unparseable {f.name}: {exc}")
                 _quarantine(f, events_dir / "quarantine")
                 continue
             if not isinstance(data, dict) or not isinstance(data.get("mission"), str):
-                log.warning("[brief] quarantining structurally invalid %s", f.name)
+                log_safe("warning", f"[brief] quarantining structurally invalid {f.name}")
                 _quarantine(f, events_dir / "quarantine")
                 continue
             if tag in data["mission"]:

--- a/koan/tests/test_brief.py
+++ b/koan/tests/test_brief.py
@@ -197,6 +197,29 @@ class TestRescheduling:
         event_files = list((instance / "events").glob("*.json"))
         assert len(event_files) == 1
 
+    def test_maybe_reschedule_ignores_corrupt_event_file(self, tmp_path, instance):
+        """_maybe_reschedule tolerates a non-UTF-8 event file without raising."""
+        from skills.core.brief.handler import _maybe_reschedule
+
+        (instance / "events" / "bad.json").write_bytes(b'{"mission": "\xa3"}')
+
+        _maybe_reschedule(instance)  # must not raise
+
+        fresh = list((instance / "events").glob("event_*.json"))
+        assert fresh, "a new well-formed event file is written after the corrupt one"
+        assert (instance / "events" / "quarantine" / "bad.json").exists()
+
+    def test_maybe_reschedule_quarantines_non_object_event(self, tmp_path, instance):
+        """A valid JSON array cannot crash brief schedule scanning."""
+        from skills.core.brief.handler import _maybe_reschedule
+
+        (instance / "events" / "bad.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        _maybe_reschedule(instance)
+
+        assert (instance / "events" / "quarantine" / "bad.json").exists()
+        assert list((instance / "events").glob("event_*.json"))
+
     def test_schedule_flag_idempotent(self, tmp_path, instance):
         from skills.core.brief.handler import handle
 

--- a/koan/tests/test_brief.py
+++ b/koan/tests/test_brief.py
@@ -220,6 +220,24 @@ class TestRescheduling:
         assert (instance / "events" / "quarantine" / "bad.json").exists()
         assert list((instance / "events").glob("event_*.json"))
 
+    def test_maybe_reschedule_survives_transient_read_error(self, tmp_path, instance):
+        """A read failure must not abort the self-rescheduling chain: the file
+        may simply have been archived by the run loop mid-glob."""
+        from skills.core.brief.handler import _maybe_reschedule
+
+        (instance / "events" / "evt.json").write_text(
+            '{"mission": "something"}', encoding="utf-8"
+        )
+
+        with patch.object(Path, "read_bytes", side_effect=FileNotFoundError("gone")):
+            _maybe_reschedule(instance)
+
+        assert list((instance / "events").glob("event_*.json")), (
+            "tomorrow's brief is still scheduled"
+        )
+        assert not (instance / "events" / "quarantine").exists()
+        assert (instance / "events" / "evt.json").exists()
+
     def test_schedule_flag_idempotent(self, tmp_path, instance):
         from skills.core.brief.handler import handle
 

--- a/koan/tests/test_event_scheduler.py
+++ b/koan/tests/test_event_scheduler.py
@@ -117,6 +117,127 @@ class TestTick:
         assert "Mission A" in mission_texts
         assert "Mission B" in mission_texts
 
+    def test_non_utf8_file_tick_does_not_crash_and_is_quarantined(self, tmp_path):
+        """An event file with invalid UTF-8 bytes (byte 0xa3, the issue repro)
+        must not crash tick(); it is moved to events/quarantine/ so it can't
+        re-poison."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        bad = events_dir / "bad_enc.json"
+        bad.write_bytes(
+            b'{"type": "once", "run_at": "2020-01-01T00:00:00", "mission": "\xa3"}'
+        )
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        assert not bad.exists(), "malformed file must leave the scan path"
+        quarantine_dir = events_dir / "quarantine"
+        assert (quarantine_dir / "bad_enc.json").exists()
+
+    def test_corrupt_but_utf8_json_quarantined(self, tmp_path):
+        """A valid-UTF-8 file that is invalid JSON is quarantined, not left to
+        re-poison every iteration."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        (events_dir / "bad.json").write_text("{not valid json", encoding="utf-8")
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        assert not (events_dir / "bad.json").exists()
+        assert (events_dir / "quarantine" / "bad.json").exists()
+
+    def test_quarantine_collision_suffixed(self, tmp_path):
+        """Re-poisoning a same-named file must not clobber an earlier quarantine."""
+        events_dir = tmp_path / "events"
+        quarantine_dir = events_dir / "quarantine"
+        quarantine_dir.mkdir(parents=True)
+        (quarantine_dir / "bad.json").write_text("old corrupt", encoding="utf-8")
+
+        events_dir.mkdir(exist_ok=True)
+        (events_dir / "bad.json").write_text("{still bad", encoding="utf-8")
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        # The pre-existing quarantine entry is untouched.
+        assert (quarantine_dir / "bad.json").read_text() == "old corrupt"
+        # Exactly one suffixed collision copy now sits alongside it, and the
+        # original scan-path file is gone.
+        quarantined = list(quarantine_dir.glob("bad_*.json"))
+        assert len(quarantined) == 1
+        assert not (events_dir / "bad.json").exists()
+
+    def test_missing_fields_quarantined(self, tmp_path):
+        """Events missing run_at or mission are quarantined (fail-loud), so they
+        stop re-tripping every iteration."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        (events_dir / "no_mission.json").write_text(
+            json.dumps({"type": "once", "run_at": "2020-01-01T00:00:00"}),
+            encoding="utf-8",
+        )
+        (events_dir / "no_run_at.json").write_text(
+            json.dumps({"type": "once", "mission": "Do something"}),
+            encoding="utf-8",
+        )
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        quarantine_dir = events_dir / "quarantine"
+        assert (quarantine_dir / "no_mission.json").exists()
+        assert (quarantine_dir / "no_run_at.json").exists()
+
+    @pytest.mark.parametrize(
+        "contents",
+        ["[1, 2, 3]", "null", '{"mission": null, "run_at": 42}'],
+    )
+    def test_structurally_invalid_json_quarantined(self, tmp_path, contents):
+        """Valid JSON with an invalid event shape cannot crash the scheduler."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        (events_dir / "bad_shape.json").write_text(contents, encoding="utf-8")
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        assert (events_dir / "quarantine" / "bad_shape.json").exists()
+
+    def test_invalid_run_at_quarantined(self, tmp_path):
+        """An invalid ISO timestamp leaves the active scan path."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        _write_event(
+            events_dir,
+            "bad_time.json",
+            {"type": "once", "run_at": "tomorrowish", "mission": "Do something"},
+        )
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        assert (events_dir / "quarantine" / "bad_time.json").exists()
+
     def test_malformed_json_skipped(self, tmp_path):
         """Malformed JSON files are skipped without crashing."""
         events_dir = tmp_path / "events"

--- a/koan/tests/test_event_scheduler.py
+++ b/koan/tests/test_event_scheduler.py
@@ -238,6 +238,95 @@ class TestTick:
         assert result == []
         assert (events_dir / "quarantine" / "bad_time.json").exists()
 
+    def test_transient_read_error_is_not_quarantined(self, tmp_path):
+        """A read that fails transiently (mid-write, or archived by the other
+        process between glob and read) is retried next tick, not destroyed."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        past = datetime.now() - timedelta(hours=1)
+        _write_event(events_dir, "evt.json", _make_event(past, "Run smoke tests"))
+
+        with patch.object(Path, "read_bytes", side_effect=OSError("EIO")), \
+                patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+        assert (events_dir / "evt.json").exists(), "valid event must survive"
+        assert not (events_dir / "quarantine").exists()
+
+    def test_failing_quarantine_does_not_abort_the_scan(self, tmp_path):
+        """When quarantine itself fails, the file is skipped (old behavior) and
+        later events still fire — no exception escapes tick()."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        # A regular file where the quarantine directory belongs: mkdir() raises
+        # FileExistsError, i.e. an OSError from inside the except block.
+        (events_dir / "quarantine").write_text("not a directory", encoding="utf-8")
+        (events_dir / "aaa_bad.json").write_text("{not valid json", encoding="utf-8")
+        past = datetime.now() - timedelta(hours=1)
+        _write_event(events_dir, "zzz_good.json", _make_event(past, "Still fires"))
+
+        with patch("app.event_scheduler.insert_pending_mission"):
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        assert result == ["Still fires"]
+        assert (events_dir / "aaa_bad.json").exists()
+
+    def test_tick_racing_an_in_flight_write_sees_no_partial_file(self, tmp_path):
+        """write_event_file() publishes atomically: a tick() running while the
+        bridge writes must not observe — and quarantine — a partial event."""
+        import os as _os
+
+        from app.event_scheduler import tick, write_event_file
+
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        real_link = _os.link
+        observed = {}
+
+        def _tick_then_link(src, dst):
+            # At this point the payload is staged but not yet published.
+            observed["json_seen"] = sorted(p.name for p in events_dir.glob("*.json"))
+            with patch("app.event_scheduler.insert_pending_mission"):
+                observed["enqueued"] = tick(str(tmp_path))
+            return real_link(src, dst)
+
+        past = datetime.now() - timedelta(hours=1)
+        with patch("app.event_scheduler.os.link", side_effect=_tick_then_link):
+            path = write_event_file(events_dir, past, "Run smoke tests")
+
+        assert observed["json_seen"] == []
+        assert observed["enqueued"] == []
+        assert not (events_dir / "quarantine").exists()
+
+        # The published event is intact and fires on the next tick.
+        with patch("app.event_scheduler.insert_pending_mission"):
+            assert tick(str(tmp_path)) == ["Run smoke tests"]
+        assert not path.exists(), "fired event is archived"
+        assert not list(events_dir.glob(".koan-event-*")), "no staging leftovers"
+
+    def test_dropped_scheduled_mission_is_reported_to_the_operator(self, tmp_path):
+        """A quarantined event that still carries real mission text reaches the
+        operator's outbox, not just a log line."""
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        _write_event(
+            events_dir,
+            "bad_time.json",
+            {"type": "once", "run_at": "tomorrowish", "mission": "Run smoke tests"},
+        )
+
+        with patch("app.event_scheduler.insert_pending_mission"):
+            from app.event_scheduler import tick
+            tick(str(tmp_path))
+
+        outbox = (tmp_path / "outbox.md").read_text(encoding="utf-8")
+        assert "bad_time.json" in outbox
+        assert "Run smoke tests" in outbox
+
     def test_malformed_json_skipped(self, tmp_path):
         """Malformed JSON files are skipped without crashing."""
         events_dir = tmp_path / "events"


### PR DESCRIPTION
A single malformed or foreign-encoded file under instance/events/*.json used to crash the whole planning iteration: strict utf-8 reading raised UnicodeDecodeError (a ValueError subclass, not OSError), which escaped the except (json.JSONDecodeError, OSError) and aborted tick().

tick() now decodes UTF-8 explicitly and quarantines unparseable files to events/quarantine/ (suffixed on collision) with a loud warning, so a corrupt or structurally invalid file can never re-poison a later iteration. Invalid event shapes and timestamps are quarantined the same way. The /brief idempotency scans are aligned to the same tolerant handling.

<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
