### PR TITLE
we have added support for !command and /command for slack, as operator

### DIFF
--- a/docs/messaging/slack.md
+++ b/docs/messaging/slack.md
@@ -4,7 +4,7 @@ title: "Slack Setup Guide"
 description: "Step-by-step guide to configuring Kōan with Slack (Socket Mode app setup, scopes, env vars) plus Slack-specific behavior like threading, reactions, and the assistant \"thinking\" status."
 tags: [messaging]
 created: 2026-05-28
-updated: 2026-08-12
+updated: 2026-08-31
 ---
 
 # Slack Setup Guide
@@ -201,8 +201,10 @@ You should see in the logs:
   ignored, so the bot is safe to drop into a shared channel.
 - **Commands need no mention**: A message beginning with `/` or `!` followed by
   a letter (e.g. `/help`, `!status`) is treated as a command addressed to Kōan —
-  exactly like `@Koan /help`. Slack normalizes `!command` to `/command` before
-  handing it to the shared bridge, avoiding conflicts with Slack slash commands.
+  exactly like `@Koan /help`. `!command` is normalized to `/command` before
+  dispatch — Slack does it in its own provider (it must decide *addressing*
+  before the shared bridge sees the text), and the shared bridge does it for
+  every provider, so the same bang form also works on Telegram.
   Slack's `<url>` and `<url|label>` link markup is also converted back to a
   plain URL, so URL-based commands keep any context written after the link.
   It replies in a thread under the command, no @mention required. A leading

--- a/docs/messaging/telegram.md
+++ b/docs/messaging/telegram.md
@@ -4,7 +4,7 @@ title: "Telegram Setup Guide"
 description: "Step-by-step guide to configuring Kōan with Telegram (bot creation, chat ID, env vars), including group-chat privacy-mode setup and troubleshooting."
 tags: [messaging]
 created: 2026-05-28
-updated: 2026-07-16
+updated: 2026-08-31
 ---
 
 # Telegram Setup Guide
@@ -102,6 +102,26 @@ Your `.env` file is missing or the variable name is wrong. Double-check the form
 - Telegram has a 4000-character limit per message. Long messages are auto-chunked. Messages containing ` ``` ` code blocks are converted to HTML `<pre>` and chunked at code-block boundaries so a split never leaves an unbalanced `<pre>` tag (which Telegram rejects with a parse error, dropping the whole message — e.g. a long `/report`).
 - Duplicate messages within 5 minutes are flood-protected (first duplicate triggers a warning, subsequent ones are silently dropped).
 - **Duplicate startup/shutdown notices across restarts are also suppressed.** The flood protection above lives in memory and resets on every process restart, so a crash/restart loop (or repeated `stop`+`start`) used to re-announce idempotent lifecycle notices — "🌅 Running morning ritual…", "🛑 Shutting down…" — once per incarnation. These now dedupe across restarts (and across providers) via a persistent `instance/.notify-dedup.json` window (default 5 min), so you see each notice once even if the process restarts several times in quick succession. The dedup is fail-open: if its state file is unreadable, the notice is sent rather than dropped. (Event-bearing lines like "📬 GitHub: N new mission(s) queued." are intentionally not deduped — that count can differ per real batch.)
+
+## Commands: `/help` and `!help`
+
+Kōan accepts both prefixes for every command. A message starting with `!`
+followed by a letter is normalized to the slash form by the shared bridge, so
+`!help`, `!status`, `!review <url>` behave exactly like `/help`, `/status`,
+`/review <url>`. This exists so an operator moving from Slack (where `!command`
+avoids clashing with Slack's own slash commands) keeps the same muscle memory
+on Telegram.
+
+A bang before a non-letter is ordinary text: `!!`, `!42`, `!` are not commands.
+
+Two Telegram-specific caveats:
+
+- **No autocomplete.** Telegram's command menu only knows `/` commands, so `!`
+  gives no suggestions or inline help.
+- **In groups with Privacy Mode ON, `!` commands never arrive.** Telegram
+  delivers only `/commands`, `@mentions`, and replies to a privacy-mode bot —
+  `!help` is a plain message to Telegram and is dropped before Kōan sees it.
+  Use `/help`, or disable Privacy Mode (see [Group chats](#group-chats)).
 
 ## Group chats
 

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-08-19
+updated: 2026-08-31
 ---
 
 # Kōan User Manual
@@ -115,6 +115,8 @@ By default, Kōan processes one mission at a time. When idle, it picks the next 
 Just send a regular message — Kōan classifies it automatically. Short conversational messages get instant replies (chat mode). Task-like messages get queued as missions.
 
 **Bare skill shortcut:** if the first word of a plain message is the name (or alias) of a core skill, Kōan treats the whole message as that slash command — `time` runs `/time`, `review <url>` runs `/review <url>`. Only core skills trigger this; custom/instance skills do not. If a common word collides with a skill name and you meant to chat, prefix with `/chat`.
+
+**Bang prefix:** `!command` works everywhere `/command` does — `!help`, `!status`, `!review <url>`. Useful if you came from Slack, where `!` avoids clashing with Slack's own slash commands. A bang before a non-letter (`!!`, `!42`) is plain text. On Telegram there's no autocomplete for `!`, and in a group with Privacy Mode ON Telegram never delivers `!` messages to the bot — use `/` there.
 
 If Kōan misclassifies your message, use `/chat` to force chat mode:
 

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -197,6 +197,17 @@ def is_command(text: str) -> bool:
     return text.startswith("/")
 
 
+# `!cmd` is an alias for `/cmd` on every provider (Slack users who move to
+# Telegram keep their muscle memory). A bang before a non-letter — `!!`, `!42` —
+# is ordinary text, not a command.
+_BANG_COMMAND_RE = re.compile(r"![a-zA-Z]")
+
+
+def normalize_bang_command(text: str) -> str:
+    """Rewrite a leading ``!command`` to ``/command``; return text unchanged otherwise."""
+    return "/" + text[1:] if _BANG_COMMAND_RE.match(text) else text
+
+
 def promote_bare_skill_command(text: str) -> Optional[str]:
     """Promote a bare core-skill word to its slash form.
 
@@ -991,7 +1002,7 @@ def _handle_reaction_update(update: dict):
 
 
 def handle_message(text: str):
-    text = text.strip()
+    text = normalize_bang_command(text.strip())
     if not text:
         return
 

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -14,6 +14,7 @@ from app.awake import (
     is_mission,
     is_command,
     promote_bare_skill_command,
+    normalize_bang_command,
     parse_project,
     handle_chat,
     handle_message,
@@ -263,6 +264,46 @@ class TestPromoteBareSkillCommand:
         handle_message("time")
         mock_cmd.assert_called_once_with("/time")
         mock_worker.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# normalize_bang_command
+# ---------------------------------------------------------------------------
+
+class TestNormalizeBangCommand:
+    def test_bang_becomes_slash(self):
+        assert normalize_bang_command("!help") == "/help"
+        assert normalize_bang_command("!Status") == "/Status"
+
+    def test_arguments_preserved(self):
+        assert normalize_bang_command(
+            "!review https://github.com/o/r/pull/1"
+        ) == "/review https://github.com/o/r/pull/1"
+
+    def test_bang_before_non_letter_untouched(self):
+        for text in ("!! deploy note", "!42 is surprising", "!", "!/help"):
+            assert normalize_bang_command(text) == text
+
+    def test_non_leading_bang_untouched(self):
+        assert normalize_bang_command("wow! amazing") == "wow! amazing"
+        assert normalize_bang_command("/help") == "/help"
+        assert normalize_bang_command("") == ""
+
+    @patch("app.awake._run_in_worker")
+    @patch("app.awake.handle_command")
+    def test_handle_message_routes_bang_to_command(self, mock_cmd, mock_worker):
+        """A bang command reaches handle_command as its slash form, not chat."""
+        handle_message("  !help  ")
+        mock_cmd.assert_called_once_with("/help")
+        mock_worker.assert_not_called()
+
+    @patch("app.awake._run_in_worker")
+    @patch("app.awake.handle_command")
+    def test_handle_message_bang_non_letter_not_a_command(self, mock_cmd, mock_worker):
+        """`!!` punctuation stays chat — it must not be dispatched as a command."""
+        handle_message("!! server was flaky")
+        mock_cmd.assert_not_called()
+        assert mock_worker.call_args.args[0].__name__ == "handle_chat"
 
 
 # ---------------------------------------------------------------------------

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -4,7 +4,7 @@ title: "Component Spec — Telegram Bridge"
 description: "Design contract for the Telegram bridge process that classifies human messages into chat vs. mission, dispatches commands/skills, and flushes the agent's outbox crash-safely."
 tags: [bridge]
 created: 2026-06-27
-updated: 2026-08-12
+updated: 2026-08-31
 ---
 
 # Component Spec — Telegram Bridge
@@ -78,10 +78,15 @@ awake.py (loop, ~3s poll)
   *how* the agent behaves.
 - **Command parsing is hyphen-hostile.** Skill names/aliases use underscores; Telegram
   treats `-` as a word boundary and truncates the command.
-- **Slack accepts bang-prefixed commands.** Slack recognizes `!command` and
-  `/command` without a bot mention. Its provider normalizes the bang form to
-  `/command` before the shared bridge dispatches it, keeping command handlers
-  provider-agnostic and avoiding Slack slash-command conflicts.
+- **Bang-prefixed commands are accepted on every provider.** A message whose
+  first characters are `!` followed by a letter (e.g. `!help`) is a command,
+  equivalent to `/help`. The **shared bridge** (`handle_message`) normalizes the
+  bang form to the slash form before dispatch, so every messaging provider gets
+  it without provider-specific code and command handlers stay provider-agnostic.
+  A bang followed by a non-letter (`!!`, `!42`) is not a command. Slack
+  additionally normalizes inbound bangs in its own provider because it must also
+  decide *addressing* (a bang command needs no bot mention) before the shared
+  bridge sees the text; that normalization is idempotent with the bridge's.
 - **Slack URLs reach shared dispatch as plain URLs.** Slack's provider removes
   mrkdwn link wrappers (`<url>` and `<url|label>`) before queueing inbound text.
   It also repairs a wrapper truncated immediately after the URL or separator so


### PR DESCRIPTION
## Summary

- Accept `!command` syntax on every provider, not just Slack (e.g. `!help`, `!status`, `!review <url>`)
- Normalize bang commands to slash form in the shared bridge before dispatch, making the behavior provider-agnostic
- Documented Telegram-specific caveats: no autocomplete for `!`, and Privacy Mode groups don't deliver `!` messages

## Why

Slack users moving to Telegram lose muscle memory of `!command` syntax (used on Slack to avoid clashing with Slack's own slash commands). Centralizing normalization in the shared bridge eliminates provider-specific command handling and keeps cross-provider UX consistent.

## How

- Added `normalize_bang_command()` regex-based rewrite that converts `!letter…` to `/letter…`
- Integrated normalization into `handle_message()` to cover all incoming text from any provider
- Left non-letter bangs (`!!`, `!42`) as plain text (not commands)
- Updated spec to clarify both Slack provider and shared bridge normalize bangs; idempotent design
- Documented Telegram caveats and clarified the bang-to-slash conversion applies everywhere

## Testing

- Unit tests for normalization: bang→slash, arguments preserved, non-letter bangs untouched, non-leading bangs
- Integration tests: `!help` reaches `handle_command` as `/help`, `!!` stays in chat path

## Limitations & Risk

- Telegram autocomplete menu only knows `/` commands, not `!` — no inline help for `!` form
- In Telegram group chats with Privacy Mode ON, `!` messages are dropped by Telegram before Kōan receives them — use `/` instead or disable Privacy Mode

---
### Quality Report

**Changes**: 6 files changed, 92 insertions(+), 11 deletions(-)

**Code scan**: clean

**Tests**: failed (timeout (120s))

**Branch hygiene**: clean

- [x] **Architectural change** — this PR modifies a durable design contract (`specs/components/**` or `specs/skills/**`). The new architecture needs review before approval. Rationale: 

_Generated by [Skuggi](https://skuggi.ai)_