### PR TITLE
Upstream worktree selfheal

### DIFF
--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -4,7 +4,7 @@ title: "Daemon Runtime"
 description: "Describes how the Koan daemon is assembled: startup/process management, the bridge's chat/bg worker lanes, the agent loop's modular pieces, runtime modes, parallel sessions, and the bounded-memory model for CLI stdout capture."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-07-17
+updated: 2026-08-07
 ---
 
 # Daemon Runtime
@@ -44,9 +44,9 @@ See `specs/components/bridge.md` for the design contract behind this process
 Bridge state that would otherwise create circular imports lives in
 `bridge_state.py`. Bridge logging lives in `bridge_log.py`.
 
-### Worker lanes (chat vs background)
+### Worker lanes
 
-The bridge runs heavy work off the messaging poll loop in two independent
+The bridge runs heavy work off the messaging poll loop in independent
 daemon-thread lanes (`awake._run_in_worker(fn, lane=...)`):
 
 - **chat** — interactive replies (`handle_chat`). When busy, a second chat
@@ -59,6 +59,10 @@ daemon-thread lanes (`awake._run_in_worker(fn, lane=...)`):
   (a `/review`, `/implement`, etc. typed in chat) dispatch on the bg lane
   but surface a "⏳ Busy with a previous task" reply when the lane was full,
   so a typed command never vanishes without feedback.
+- **maintenance** — internal housekeeping such as the hourly foreign-worktree
+  sweep. It is single-flight and silent when busy; its work never runs on the
+  poll loop, so a large repository cannot delay Slack, Telegram, or other
+  inbound commands.
 
 Because the lanes run concurrently, a long-running background task never
 blocks an interactive chat reply, and neither blocks the poll loop. One

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -62,7 +62,8 @@ daemon-thread lanes (`awake._run_in_worker(fn, lane=...)`):
 - **maintenance** — internal housekeeping such as the hourly foreign-worktree
   sweep. It is single-flight and silent when busy; its work never runs on the
   poll loop, so a large repository cannot delay Slack, Telegram, or other
-  inbound commands.
+  inbound commands. Each sweep has a fixed two-minute deadline and a 15-second
+  cap per Git command; incomplete checks retain worktrees for a later sweep.
 
 Because the lanes run concurrently, a long-running background task never
 blocks an interactive chat reply, and neither blocks the poll loop. One

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -4,7 +4,7 @@ title: "Daemon Runtime"
 description: "Describes how the Koan daemon is assembled: startup/process management, the bridge's chat/bg worker lanes, the agent loop's modular pieces, runtime modes, parallel sessions, and the bounded-memory model for CLI stdout capture."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-08-07
+updated: 2026-09-02
 ---
 
 # Daemon Runtime
@@ -64,6 +64,11 @@ daemon-thread lanes (`awake._run_in_worker(fn, lane=...)`):
   poll loop, so a large repository cannot delay Slack, Telegram, or other
   inbound commands. Each sweep has a fixed two-minute deadline and a 15-second
   cap per Git command; incomplete checks retain worktrees for a later sweep.
+  Unlike chat and bg, this lane does **not** hold back the bridge's memory
+  watchdog: its work is idempotent and restart-safe (a half-removed worktree is
+  pruned on the next sweep), so a sweep wedged in uninterruptible I/O — which
+  outlives its Python-level timeout — cannot silently disable the watchdog and
+  trade a clean re-exec for an OOM kill.
 
 Because the lanes run concurrently, a long-running background task never
 blocks an interactive chat reply, and neither blocks the poll loop. One

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting"
 description: "Catalogs common operational issues (agent loop, git/worktrees, memory, bridge, GitHub, CLI provider, parallel sessions, config) and their fixes."
 tags: [operations]
 created: 2026-06-04
-updated: 2026-07-30
+updated: 2026-08-07
 ---
 
 # Troubleshooting
@@ -69,8 +69,9 @@ git worktree prune         # Remove stale references
 
 Kōan cleans up worktrees on startup during crash recovery. If you see stale worktrees, restarting the agent loop should clear them.
 
-The bridge also sweeps hourly for leaked worktrees registered outside the project, such
-as temporary review checkouts. It keeps locked worktrees, worktrees with recent
+The bridge also starts an hourly background sweep for leaked worktrees registered outside
+the project, such as temporary review checkouts. The sweep does not block messaging. It
+keeps locked worktrees, worktrees with recent
 non-ignored file activity, tracking branches with commits missing upstream, and
 detached commits missing every durable branch, remote, or tag.
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -73,10 +73,10 @@ The bridge also starts an hourly background sweep for leaked worktrees registere
 the project, such as temporary review checkouts. The sweep does not block messaging. It
 keeps locked worktrees, worktrees with recent
 non-ignored file activity, tracking branches with commits missing upstream, and
-detached commits not reachable from the repository's `origin/HEAD` default branch. This
-avoids an expensive all-ref scan; if the default branch cannot be resolved, the worktree
-is retained. Each sweep is capped at two minutes, with a 15-second limit per Git command;
-deferred worktrees are retried in a later hourly sweep.
+detached commits that no local branch, tag, or remote-tracking ref reaches. That last
+check is a single revision walk rather than a per-ref scan, so it stays fast in
+repositories with many refs. Each sweep is capped at two minutes, with a 15-second limit
+per Git command; deferred worktrees are retried in a later hourly sweep.
 
 ### Branch conflicts (can't checkout, can't push)
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -72,12 +72,15 @@ Kōan cleans up worktrees on startup during crash recovery. If you see stale wor
 The bridge also starts an hourly background sweep for leaked worktrees, such as temporary
 review checkouts. The sweep does not block messaging.
 
-**What is in scope** — every worktree registered on the project *except* the main
-checkout itself and anything under `<project>/.worktrees/` or
-`<project>/.claude/worktrees/`, which other code owns. That includes worktrees outside
-the project (`/tmp/review-<sha>`) **and** worktrees you created by hand inside it
-(`<project>/tmp/wip`, `<project>/wt/feature-x`) — nothing else on the host reclaims
-those, so the sweep can delete them once they go idle.
+**What is in scope** — every worktree registered on the project that lives *outside* the
+project directory (`/tmp/review-<sha>`), plus scratch checkouts under `<project>/tmp/`.
+Nothing else on the host reclaims either, so the sweep can delete them once they go idle.
+Everything else inside the project is out of scope: the main checkout,
+`<project>/.worktrees/` and `<project>/.claude/worktrees/` (other code owns those), and
+any worktree you made by hand elsewhere in the project (`<project>/wt/feature-x`). The
+guards below all read git, and git says nothing about the gitignored files — `.env.local`,
+`dev.db` — a workspace like that keeps, so it is kept whole by scope rather than by the
+dirty check.
 
 **What it keeps** — locked worktrees, worktrees with recent non-ignored file activity
 (idle for less than two days), **any worktree with uncommitted changes** (removal is

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -73,7 +73,9 @@ The bridge also starts an hourly background sweep for leaked worktrees registere
 the project, such as temporary review checkouts. The sweep does not block messaging. It
 keeps locked worktrees, worktrees with recent
 non-ignored file activity, tracking branches with commits missing upstream, and
-detached commits missing every durable branch, remote, or tag.
+detached commits missing every durable branch, remote, or tag. Each sweep is capped at
+two minutes, with a 15-second limit per Git command; deferred worktrees are retried in a
+later hourly sweep.
 
 ### Branch conflicts (can't checkout, can't push)
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -80,12 +80,18 @@ the project (`/tmp/review-<sha>`) **and** worktrees you created by hand inside i
 those, so the sweep can delete them once they go idle.
 
 **What it keeps** — locked worktrees, worktrees with recent non-ignored file activity
-(idle for less than two days), tracking branches with commits missing upstream, and
-detached commits that no local branch, tag, or remote-tracking ref reaches. That last
-check is a single revision walk rather than a per-ref scan, so it stays fast in
-repositories with many refs. Each sweep is capped at two minutes, with a 15-second limit
-per Git command; deferred worktrees are retried in a later hourly sweep, and every
-retained worktree logs its reason (`skip (locked)`, `retain (activity check failed)`, …).
+(idle for less than two days), **any worktree with uncommitted changes** (removal is
+`--force`, so a dirty tree is never touched, however durable its branch is), tracking
+branches with commits missing upstream, and detached commits that no local branch, tag,
+or remote-tracking ref reaches. That last check is a single revision walk rather than a
+per-ref scan, so it stays fast in repositories with many refs. Each sweep is capped at two
+minutes, with a 15-second limit per Git command; deferred worktrees are retried in a later
+hourly sweep, and every retained worktree logs its reason (`skip (locked)`, `skip
+(uncommitted changes)`, `retain (activity check failed)`, …).
+
+So a leaked review checkout that left an edit behind is *kept*, not reclaimed — commit and
+discard it (or remove the worktree by hand) if you want the disk back. That is the
+deliberate trade: disk is recoverable, an unattended `--force` on someone's WIP is not.
 
 **Opting out** — `git worktree lock <path>` marks a worktree as a live workspace. The
 sweep never removes a locked worktree, and git prep never detaches one (see below).

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -73,9 +73,10 @@ The bridge also starts an hourly background sweep for leaked worktrees registere
 the project, such as temporary review checkouts. The sweep does not block messaging. It
 keeps locked worktrees, worktrees with recent
 non-ignored file activity, tracking branches with commits missing upstream, and
-detached commits missing every durable branch, remote, or tag. Each sweep is capped at
-two minutes, with a 15-second limit per Git command; deferred worktrees are retried in a
-later hourly sweep.
+detached commits not reachable from the repository's `origin/HEAD` default branch. This
+avoids an expensive all-ref scan; if the default branch cannot be resolved, the worktree
+is retained. Each sweep is capped at two minutes, with a 15-second limit per Git command;
+deferred worktrees are retried in a later hourly sweep.
 
 ### Branch conflicts (can't checkout, can't push)
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting"
 description: "Catalogs common operational issues (agent loop, git/worktrees, memory, bridge, GitHub, CLI provider, parallel sessions, config) and their fixes."
 tags: [operations]
 created: 2026-06-04
-updated: 2026-08-07
+updated: 2026-09-02
 ---
 
 # Troubleshooting
@@ -69,19 +69,40 @@ git worktree prune         # Remove stale references
 
 Kōan cleans up worktrees on startup during crash recovery. If you see stale worktrees, restarting the agent loop should clear them.
 
-The bridge also starts an hourly background sweep for leaked worktrees registered outside
-the project, such as temporary review checkouts. The sweep does not block messaging. It
-keeps locked worktrees, worktrees with recent
-non-ignored file activity, tracking branches with commits missing upstream, and
+The bridge also starts an hourly background sweep for leaked worktrees, such as temporary
+review checkouts. The sweep does not block messaging.
+
+**What is in scope** — every worktree registered on the project *except* the main
+checkout itself and anything under `<project>/.worktrees/` or
+`<project>/.claude/worktrees/`, which other code owns. That includes worktrees outside
+the project (`/tmp/review-<sha>`) **and** worktrees you created by hand inside it
+(`<project>/tmp/wip`, `<project>/wt/feature-x`) — nothing else on the host reclaims
+those, so the sweep can delete them once they go idle.
+
+**What it keeps** — locked worktrees, worktrees with recent non-ignored file activity
+(idle for less than two days), tracking branches with commits missing upstream, and
 detached commits that no local branch, tag, or remote-tracking ref reaches. That last
 check is a single revision walk rather than a per-ref scan, so it stays fast in
 repositories with many refs. Each sweep is capped at two minutes, with a 15-second limit
-per Git command; deferred worktrees are retried in a later hourly sweep.
+per Git command; deferred worktrees are retried in a later hourly sweep, and every
+retained worktree logs its reason (`skip (locked)`, `retain (activity check failed)`, …).
+
+**Opting out** — `git worktree lock <path>` marks a worktree as a live workspace. The
+sweep never removes a locked worktree, and git prep never detaches one (see below).
 
 ### Branch conflicts (can't checkout, can't push)
 
 1. **Force-push protection** — Kōan uses `koan/*` branches (configurable via `branch_prefix`). If the branch already exists on remote from another instance, the agent may fail to push.
 2. **Shared project repos** — if multiple Kōan instances target the same repo, ensure each uses a distinct `branch_prefix` in `config.yaml`.
+3. **Another worktree holds the base branch** — git allows a branch in at most one
+   worktree, so a second worktree sitting on `main` blocks the project's own checkout and
+   every mission fails in git prep. Kōan self-heals this before each mission: it runs
+   `git checkout --detach` in the holding worktree, which frees the branch while leaving
+   that worktree, its files and any uncommitted changes exactly where they are (nothing is
+   removed). The heal is reported in the prep result and the log. `/doctor` reports the
+   same collision, and `/doctor --fix` performs the same detach. To keep a worktree on the
+   base branch, `git worktree lock <path>` — a locked holder is never detached, and the
+   collision is reported instead.
 
 ### SSH authentication failures
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting"
 description: "Catalogs common operational issues (agent loop, git/worktrees, memory, bridge, GitHub, CLI provider, parallel sessions, config) and their fixes."
 tags: [operations]
 created: 2026-06-04
-updated: 2026-09-02
+updated: 2026-09-08
 ---
 
 # Troubleshooting
@@ -111,7 +111,12 @@ sweep never removes a locked worktree, and git prep never detaches one (see belo
    removed). The heal is reported in the prep result and the log. `/doctor` reports the
    same collision, and `/doctor --fix` performs the same detach. To keep a worktree on the
    base branch, `git worktree lock <path>` — a locked holder is never detached, and the
-   collision is reported instead.
+   collision is reported instead: `/doctor` flags it as a non-fixable error, and the fix
+   is yours to run (`git worktree unlock <path> && git -C <path> checkout --detach`).
+   If `/doctor` instead reports that the collision check was *skipped*, the project's
+   base branch could not be resolved without the network — set
+   `git_auto_merge.base_branch` in `projects.yaml`, or run `git remote set-head origin -a`
+   in the project.
 
 ### SSH authentication failures
 

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -855,22 +855,37 @@ def _reap_worktrees() -> None:
     outside the project, unlocked, untouched for days, and free of unpushed commits.
 
     """
+    from app.worktree_manager import FOREIGN_WORKTREE_REAP_BUDGET_SECONDS
+
     started = time.monotonic()
+    deadline = started + FOREIGN_WORKTREE_REAP_BUDGET_SECONDS
     reaped_count = 0
-    log("health", "Starting periodic foreign-worktree reap")
+    log("health", f"Starting periodic foreign-worktree reap (budget {FOREIGN_WORKTREE_REAP_BUDGET_SECONDS:.0f}s)")
     try:
         from app.project_explorer import get_projects
         from app.worktree_manager import reap_foreign_worktrees
 
-        projects = get_projects()
+        projects = sorted(get_projects())
     except Exception as e:
         log("error", f"periodic worktree reap failed: {e}")
         return
 
+    # Rotate projects hourly so a large first project cannot starve the rest.
+    if projects:
+        rotation = int(time.time() // WORKTREE_REAP_INTERVAL) % len(projects)
+        projects = projects[rotation:] + projects[:rotation]
+
     # Per-project isolation: one unreadable repo must not stop the others being swept.
-    for _name, path in projects:
+    for projects_checked, (_name, path) in enumerate(projects, start=1):
+        if time.monotonic() >= deadline:
+            log("health", f"Foreign-worktree reap budget reached after {projects_checked - 1} project(s)")
+            break
         try:
-            reaped = reap_foreign_worktrees(path)
+            reaped = reap_foreign_worktrees(
+                path,
+                deadline=deadline,
+                start_index=int(time.time() // WORKTREE_REAP_INTERVAL),
+            )
         except Exception as e:
             log("error", f"worktree reap failed for {path}: {e}")
             continue

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -710,33 +710,34 @@ def _format_outbox_message(raw_content: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Worker lanes — chat replies and background tasks run independently so a
-# long background task never blocks an interactive reply, and neither ever
-# blocks the Telegram poll loop.  One in-flight task per lane (back-pressure).
+# Worker lanes — chat replies, user-triggered background tasks, and maintenance
+# run independently, so none can block the Telegram poll loop. One in-flight
+# task per lane provides back-pressure.
 # ---------------------------------------------------------------------------
 
-_WORKER_LANES = ("chat", "bg")
+_WORKER_LANES = ("chat", "bg", "maintenance")
 _worker_threads: Dict[str, Optional[threading.Thread]] = {
     lane: None for lane in _WORKER_LANES
 }
 _worker_lock = threading.Lock()
 
-# The chat lane tells the user when it is busy; the bg lane stays silent so
-# background work (worker skills like /review, /rebase) never spams the channel.
+# The chat lane tells the user when it is busy; background and maintenance work
+# stay silent so internal work never spams the channel.
 _LANE_BUSY_MSG: Dict[str, Optional[str]] = {
     "chat": "⏳ Busy with a previous message. Try again in a moment.",
     "bg": None,
+    "maintenance": None,
 }
 
 
 def _run_in_worker(fn, *args, lane: str = "chat") -> bool:
     """Run fn(*args) in a background thread on a named lane.
 
-    Two lanes exist: ``"chat"`` (interactive replies) and ``"bg"``
-    (background tasks such as worker skills typed in chat — ``/review``,
-    ``/rebase``, etc.).  Each lane allows one worker at a time, but the lanes run
-    concurrently, so a background task never blocks a chat reply and vice
-    versa.  The Telegram poll loop is never blocked by either.
+    The ``"chat"`` lane handles interactive replies, ``"bg"`` runs worker
+    skills typed in chat (for example ``/review``), and ``"maintenance"`` runs
+    internal housekeeping. Each lane allows one worker at a time, but the lanes
+    run concurrently, so internal work never blocks an interactive reply or the
+    Telegram poll loop.
 
     Captures the current reply context so that send_telegram() calls inside
     the worker thread reply to the correct message in groups.
@@ -844,8 +845,8 @@ def _bridge_should_restart(monitor) -> bool:
 WORKTREE_REAP_INTERVAL = 3600
 
 
-def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERVAL) -> float:
-    """Reclaim leaked review worktrees across known projects, every ``interval`` seconds.
+def _reap_worktrees() -> None:
+    """Reclaim leaked review worktrees across known projects off the poll loop.
 
     Agents check revisions out ad hoc during PR review (`git worktree add /tmp/review-<sha>`)
     and never remove them. On a large checkout each is hundreds of megabytes, so they fill
@@ -853,13 +854,10 @@ def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERV
     crash-looped this service. reap_foreign_worktrees() only touches worktrees registered
     outside the project, unlocked, untouched for days, and free of unpushed commits.
 
-    Returns the (possibly updated) last-reap timestamp.
     """
-    if not interval:
-        return last_reap
-    now = time.time()
-    if (now - last_reap) < interval:
-        return last_reap
+    started = time.monotonic()
+    reaped_count = 0
+    log("health", "Starting periodic foreign-worktree reap")
     try:
         from app.project_explorer import get_projects
         from app.worktree_manager import reap_foreign_worktrees
@@ -867,7 +865,7 @@ def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERV
         projects = get_projects()
     except Exception as e:
         log("error", f"periodic worktree reap failed: {e}")
-        return now
+        return
 
     # Per-project isolation: one unreadable repo must not stop the others being swept.
     for _name, path in projects:
@@ -877,8 +875,28 @@ def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERV
             log("error", f"worktree reap failed for {path}: {e}")
             continue
         if reaped:
-            log("health", f"Reclaimed {len(reaped)} leaked worktree(s) in {path}")
-    return now
+            count = len(reaped)
+            reaped_count += count
+            log("health", f"Reclaimed {count} leaked worktree(s) in {path}")
+    elapsed = time.monotonic() - started
+    log("health", f"Finished periodic foreign-worktree reap: {reaped_count} reclaimed in {elapsed:.1f}s")
+
+
+def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERVAL) -> float:
+    """Start a due worktree reap without blocking bridge message processing.
+
+    The full sweep runs on the single-flight maintenance lane. If a previous
+    sweep is still active, retain ``last_reap`` so the next poll starts one as
+    soon as the lane becomes available instead of delaying cleanup for an hour.
+    """
+    if not interval:
+        return last_reap
+    now = time.time()
+    if (now - last_reap) < interval:
+        return last_reap
+    if _run_in_worker(_reap_worktrees, lane="maintenance"):
+        return now
+    return last_reap
 
 
 def _maybe_periodic_compact(last_compact: float, interval: int) -> float:

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -854,21 +854,30 @@ def _reap_worktrees() -> None:
     crash-looped this service. reap_foreign_worktrees() only touches worktrees registered
     outside the project, unlocked, untouched for days, and free of unpushed commits.
 
+    This runs detached on the maintenance lane, where nothing catches an escaping
+    exception: threading's excepthook would print to stderr and leave no koan log entry at
+    all, making a permanently broken sweep look exactly like an idle one. Hence the blanket
+    guard around the whole sweep rather than around its parts.
     """
-    from app.worktree_manager import FOREIGN_WORKTREE_REAP_BUDGET_SECONDS
+    try:
+        _sweep_foreign_worktrees()
+    except Exception as e:
+        log("error", f"periodic worktree reap failed: {e}")
+
+
+def _sweep_foreign_worktrees() -> None:
+    """Sweep every known project for leaked foreign worktrees within one time budget."""
+    from app.project_explorer import get_projects
+    from app.worktree_manager import (
+        FOREIGN_WORKTREE_REAP_BUDGET_SECONDS,
+        reap_foreign_worktrees,
+    )
 
     started = time.monotonic()
     deadline = started + FOREIGN_WORKTREE_REAP_BUDGET_SECONDS
     reaped_count = 0
     log("health", f"Starting periodic foreign-worktree reap (budget {FOREIGN_WORKTREE_REAP_BUDGET_SECONDS:.0f}s)")
-    try:
-        from app.project_explorer import get_projects
-        from app.worktree_manager import reap_foreign_worktrees
-
-        projects = sorted(get_projects())
-    except Exception as e:
-        log("error", f"periodic worktree reap failed: {e}")
-        return
+    projects = sorted(get_projects())
 
     # Rotate projects hourly so a large first project cannot starve the rest.
     if projects:

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -813,16 +813,25 @@ def _build_bridge_memory_monitor():
 
 
 def _workers_idle() -> bool:
-    """True when no worker lane has a live thread.
+    """True when no *user-facing* worker lane has a live thread.
 
     Reuses the pre-existing module globals ``_worker_threads`` and
     ``_worker_lock`` — the same ones ``_run_in_worker`` uses for
     back-pressure. Introduces no new lock.
+
+    The maintenance lane is deliberately excluded. It carries internal,
+    idempotent, restart-safe housekeeping (the worktree sweep — a half-removed
+    worktree is pruned on the next pass), and unlike chat/bg it is not tied to a
+    human waiting on a reply. A wedged sweep — a git child stuck in
+    uninterruptible I/O outlives its Python-level timeout — would otherwise
+    disable the memory watchdog permanently and silently, trading a clean
+    re-exec for the OOM kill the watchdog exists to prevent.
     """
     with _worker_lock:
         return all(
             t is None or not t.is_alive()
-            for t in _worker_threads.values()
+            for lane, t in _worker_threads.items()
+            if lane != "maintenance"
         )
 
 

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -844,6 +844,9 @@ def _bridge_should_restart(monitor) -> bool:
 # two days anyway, so sweeping more often would find nothing new.
 WORKTREE_REAP_INTERVAL = 3600
 
+# Last time the "maintenance lane still busy" warning was emitted (throttle state).
+_worktree_reap_busy_logged_at = 0.0
+
 
 def _reap_worktrees() -> None:
     """Reclaim leaked review worktrees across known projects off the poll loop.
@@ -912,7 +915,14 @@ def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERV
     The full sweep runs on the single-flight maintenance lane. If a previous
     sweep is still active, retain ``last_reap`` so the next poll starts one as
     soon as the lane becomes available instead of delaying cleanup for an hour.
+
+    A wedged sweep thread (a Git call blocked past its timeout on an unresponsive
+    mount) would otherwise make this retry silently every poll forever, which looks
+    exactly like a healthy idle system. Once a whole extra interval has passed with
+    the lane still busy, say so — throttled to once per interval so a permanently
+    stuck lane does not flood the log every 3 s.
     """
+    global _worktree_reap_busy_logged_at
     if not interval:
         return last_reap
     now = time.time()
@@ -920,6 +930,17 @@ def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERV
         return last_reap
     if _run_in_worker(_reap_worktrees, lane="maintenance"):
         return now
+    if (
+        (now - last_reap) >= 2 * interval
+        and (now - _worktree_reap_busy_logged_at) >= interval
+    ):
+        _worktree_reap_busy_logged_at = now
+        log(
+            "error",
+            "Worktree reap has not started for "
+            f"{(now - last_reap) / 60:.0f} min: the maintenance lane is still busy "
+            "(previous sweep may be stuck)",
+        )
     return last_reap
 
 

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -557,6 +557,7 @@ def prepare_project_branch(
     result.remote_used = remote
 
     config_explicit = False
+    config_configured = False
     try:
         config = load_projects_config(koan_root)
         if config:
@@ -572,6 +573,13 @@ def prepare_project_branch(
             proj_am = proj_cfg.get("git_auto_merge", {}) or {}
             if proj_am.get("base_branch"):
                 config_explicit = True
+            # Separately: was the branch typed by a human *anywhere* (project or
+            # defaults), or is it the hardcoded "main" fallback? The pre-fetch
+            # override below may only rewrite the hardcoded fallback.
+            defaults_am = (config.get("defaults", {}) or {}).get(
+                "git_auto_merge", {}
+            ) or {}
+            config_configured = config_explicit or bool(defaults_am.get("base_branch"))
     except Exception as e:
         logger.warning("config load error for base_branch: %s", e)
 
@@ -601,19 +609,25 @@ def prepare_project_branch(
         result.base_branch = result.previous_branch
         return result
 
-    # When the project pins no base branch and the generic default has no
-    # remote-tracking ref here, resolve the remote's real default *before*
-    # fetching. Detecting only after a failure made every mission on such a
+    # When nothing configured a base branch at all and the hardcoded "main"
+    # fallback has no remote-tracking ref here, resolve the remote's real default
+    # *before* fetching. Detecting only after a failure made every mission on such a
     # project pay for a doomed fetch first: a project setting
     # issue_tracker.default_branch to a release branch but no
     # git_auto_merge.base_branch had base_branch fall back to "main", so every run
     # fetched a branch that does not exist before finding the real one.
-    # Guarded on the missing ref so a configured branch that works is never
-    # second-guessed; when the ref check is inconclusive the original
-    # detect-after-failure path below still applies. resolve_* (not detect_*) so a
-    # failed resolution stays None instead of overriding the configured branch with
-    # the "main" fallback.
-    if not config_explicit and not _has_remote_tracking_ref(
+    #
+    # Gated on config_configured, not config_explicit: a branch inherited from
+    # `defaults:` was still typed by a human, and _has_remote_tracking_ref() answers
+    # "is this ref in refs/remotes/ already", not "does it exist on the remote". A
+    # `defaults: develop` project whose tracking ref simply had not been fetched yet
+    # (fresh clone, new project, after `git remote prune`) would otherwise be
+    # silently rebased onto the remote's default and open its PR against the wrong
+    # base. Fetching the configured branch answers the real question; when that
+    # fetch fails the detect-after-failure path below still applies. resolve_* (not
+    # detect_*) so a failed resolution stays None instead of promoting the "main"
+    # fallback to an answer.
+    if not config_configured and not _has_remote_tracking_ref(
         remote, base_branch, project_path
     ):
         detected = resolve_remote_default_branch(remote, project_path)

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -406,6 +406,70 @@ def _heal_interrupted_operation(project_path: str) -> Optional[str]:
     return "; ".join(actions) if actions else None
 
 
+def _has_remote_tracking_ref(remote: str, branch: str, project_path: str) -> bool:
+    """Return True when refs/remotes/<remote>/<branch> exists locally.
+
+    Purely local, no network. Used to tell "this base branch is real" from
+    "nobody configured one and the generic default does not exist here".
+    """
+    rc, _, _ = run_git(
+        "rev-parse", "--verify", "--quiet",
+        f"refs/remotes/{remote}/{branch}",
+        cwd=project_path,
+    )
+    return rc == 0
+
+
+def _find_branch_holder(project_path: str, branch: str) -> Optional[str]:
+    """Return the path of another worktree that has ``branch`` checked out.
+
+    Git allows a branch to be checked out in at most one worktree, so a second
+    worktree holding the base branch blocks the main checkout for as long as it
+    holds it. Returns None when nothing holds it, when the holder is the main
+    worktree itself, or when the holder is ``locked`` (someone's live workspace
+    — never disturb those).
+    """
+    if not branch:
+        return None
+    try:
+        from app.worktree_manager import list_worktrees
+        worktrees = list_worktrees(project_path)
+    except (ImportError, OSError):
+        # Unreadable repo (missing path, permissions): nothing to detach. Prep
+        # falls through to its normal fallback rather than failing here.
+        return None
+
+    for wt in worktrees:
+        if wt.is_main or not wt.path or wt.branch != branch:
+            continue
+        if wt.locked:
+            logger.warning(
+                "Branch %s is held by locked worktree %s — not detaching",
+                branch, wt.path,
+            )
+            continue
+        return wt.path
+    return None
+
+
+def _release_branch_from_worktree(holder: str, branch: str) -> bool:
+    """Detach ``holder`` so ``branch`` becomes checkout-able again.
+
+    Detach, never remove: this runs unattended before every mission, so a false
+    positive must not be able to destroy an agent's in-flight work. Detaching
+    keeps the worktree, its files and any uncommitted changes exactly where they
+    are — it only gives up the branch name. Reclaiming the disk is the bridge's
+    foreign-worktree sweep's job.
+    """
+    rc, _, stderr = run_git("checkout", "--detach", cwd=holder)
+    if rc != 0:
+        logger.warning(
+            "Could not detach worktree %s holding %s: %s", holder, branch, stderr,
+        )
+        return False
+    return True
+
+
 def _diagnose_stash_failure(project_path: str, stderr: str) -> str:
     """Build an informative error for a failed pre-mission stash.
 
@@ -508,6 +572,27 @@ def prepare_project_branch(
         result.base_branch = result.previous_branch
         return result
 
+    # When the project pins no base branch and the generic default has no
+    # remote-tracking ref here, resolve the remote's real default *before*
+    # fetching. Detecting only after a failure made every mission on such a
+    # project pay for a doomed fetch first: `cp` sets issue_tracker.default_branch
+    # "140" but no git_auto_merge.base_branch, so base_branch fell back to "main"
+    # and every run fetched a branch that does not exist before finding "140".
+    # Guarded on the missing ref so a configured branch that works is never
+    # second-guessed; when the ref check is inconclusive the original
+    # detect-after-failure path below still applies.
+    if not config_explicit and not _has_remote_tracking_ref(
+        remote, base_branch, project_path
+    ):
+        detected = detect_remote_default_branch(remote, project_path)
+        if detected != base_branch:
+            logger.info(
+                "Default branch for %s/%s is '%s', not '%s' (resolved pre-fetch)",
+                remote, project_name, detected, base_branch,
+            )
+            base_branch = detected
+            result.base_branch = detected
+
     # Fetch latest refs (with HTTPS token fallback for repos cloned via
     # gh with an unauthenticated HTTPS remote URL)
     rc, _, stderr = _fetch_with_https_fallback(
@@ -561,17 +646,45 @@ def prepare_project_branch(
             return result
 
     # Checkout base branch
-    rc, _, stderr = run_git("checkout", base_branch, cwd=project_path)
+    rc, _, checkout_err = run_git("checkout", base_branch, cwd=project_path)
     if rc != 0:
-        # Branch may not exist locally — create from remote tracking
-        rc, _, stderr = run_git(
-            "checkout", "-b", base_branch, f"{remote}/{base_branch}",
-            cwd=project_path,
-        )
+        # Two different faults land here and they need different fixes:
+        #
+        #   1. another worktree holds the branch  -> detach that worktree, retry
+        #   2. the branch does not exist locally  -> create it from the remote
+        #
+        # Case 1 used to fall through to the case-2 fallback, which then failed
+        # with "a branch named 'X' already exists" — and that message overwrote
+        # the original stderr, so the log never named the holding worktree. One
+        # agent-created worktree holding the base branch cost 90 consecutive
+        # missions before anyone could see why. Try the real fix first, and never
+        # let the fallback's error be the only one reported. (If the detach works
+        # and the retry still fails, that retry error IS the useful one — the
+        # held-branch problem is solved by then.)
+        holder = _find_branch_holder(project_path, base_branch)
+        if holder and _release_branch_from_worktree(holder, base_branch):
+            rc, _, checkout_err = run_git(
+                "checkout", base_branch, cwd=project_path,
+            )
+            if rc == 0:
+                freed = f"detached worktree {holder} which held {base_branch}"
+                result.healed = f"{result.healed}; {freed}" if result.healed else freed
+                logger.info("git prep self-heal for %s: %s", project_name, freed)
+
         if rc != 0:
-            result.success = False
-            result.error = f"checkout failed: {stderr}"
-            return result
+            # Branch may not exist locally — create from remote tracking
+            rc, _, fallback_err = run_git(
+                "checkout", "-b", base_branch, f"{remote}/{base_branch}",
+                cwd=project_path,
+            )
+            if rc != 0:
+                result.success = False
+                result.error = (
+                    f"checkout failed: {checkout_err}"
+                    f" (creating from {remote}/{base_branch} also failed:"
+                    f" {fallback_err})"
+                )
+                return result
 
     # Fast-forward to match remote
     rc, _, stderr = run_git(

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -183,6 +183,35 @@ def detect_remote_default_branch(remote: str, project_path: str) -> str:
     1. Local symbolic ref (refs/remotes/<remote>/HEAD) — fast, no network
     2. git ls-remote --symref — requires network but always accurate
     3. Falls back to "main"
+
+    Callers that must not mistake the "main" fallback for a real detection use
+    resolve_remote_default_branch(), which returns None when both steps fail.
+    """
+    return resolve_remote_default_branch(remote, project_path) or "main"
+
+
+def local_remote_default_branch(remote: str, project_path: str) -> Optional[str]:
+    """Return the remote's default branch from local refs only — never the network.
+
+    Reads refs/remotes/<remote>/HEAD, which a clone (or a fetch with --set-head)
+    sets. Returns None when it is unset, so callers on latency-sensitive paths can
+    skip rather than reach for ls-remote.
+    """
+    rc, stdout, _ = run_git(
+        "symbolic-ref", f"refs/remotes/{remote}/HEAD", cwd=project_path
+    )
+    if rc == 0 and stdout:
+        # Output: refs/remotes/origin/master → extract "master"
+        return stdout.strip().rsplit("/", 1)[-1] or None
+    return None
+
+
+def resolve_remote_default_branch(remote: str, project_path: str) -> Optional[str]:
+    """Detect the default branch for a remote, or None when resolution is exhausted.
+
+    Same two steps as detect_remote_default_branch(), minus the "main" fallback:
+    an unreachable remote with no local symbolic ref returns None instead of a
+    guess that a caller could otherwise promote to an authoritative answer.
     """
     # 1. Try local symbolic ref (set after clone or fetch with --set-head)
     rc, stdout, _ = run_git(
@@ -215,7 +244,7 @@ def detect_remote_default_branch(remote: str, project_path: str) -> str:
                     if branch:
                         return branch
 
-    return "main"
+    return None
 
 
 @dataclass
@@ -575,17 +604,20 @@ def prepare_project_branch(
     # When the project pins no base branch and the generic default has no
     # remote-tracking ref here, resolve the remote's real default *before*
     # fetching. Detecting only after a failure made every mission on such a
-    # project pay for a doomed fetch first: `cp` sets issue_tracker.default_branch
-    # "140" but no git_auto_merge.base_branch, so base_branch fell back to "main"
-    # and every run fetched a branch that does not exist before finding "140".
+    # project pay for a doomed fetch first: a project setting
+    # issue_tracker.default_branch to a release branch but no
+    # git_auto_merge.base_branch had base_branch fall back to "main", so every run
+    # fetched a branch that does not exist before finding the real one.
     # Guarded on the missing ref so a configured branch that works is never
     # second-guessed; when the ref check is inconclusive the original
-    # detect-after-failure path below still applies.
+    # detect-after-failure path below still applies. resolve_* (not detect_*) so a
+    # failed resolution stays None instead of overriding the configured branch with
+    # the "main" fallback.
     if not config_explicit and not _has_remote_tracking_ref(
         remote, base_branch, project_path
     ):
-        detected = detect_remote_default_branch(remote, project_path)
-        if detected != base_branch:
+        detected = resolve_remote_default_branch(remote, project_path)
+        if detected and detected != base_branch:
             logger.info(
                 "Default branch for %s/%s is '%s', not '%s' (resolved pre-fetch)",
                 remote, project_name, detected, base_branch,

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -449,36 +449,56 @@ def _has_remote_tracking_ref(remote: str, branch: str, project_path: str) -> boo
     return rc == 0
 
 
-def _find_branch_holder(project_path: str, branch: str) -> Optional[str]:
-    """Return the path of another worktree that has ``branch`` checked out.
+def _branch_holder_worktree(project_path: str, branch: str):
+    """Return the worktree entry that has ``branch`` checked out, locked or not.
 
     Git allows a branch to be checked out in at most one worktree, so a second
     worktree holding the base branch blocks the main checkout for as long as it
     holds it. Returns None when nothing holds it, when the holder is the main
-    worktree itself, or when the holder is ``locked`` (someone's live workspace
-    — never disturb those).
+    worktree itself, or when the worktree list could not be read — the last case
+    is logged, so "we could not look" never reads like "nothing holds it".
+
+    Locked holders are returned, not filtered: prep must not detach them, but
+    /doctor must still report them — that collision is the one no automation can
+    heal, so hiding it leaves a fully-broken project looking clean.
     """
     if not branch:
         return None
     try:
         from app.worktree_manager import list_worktrees
         worktrees = list_worktrees(project_path)
-    except (ImportError, OSError):
+    except (ImportError, OSError) as e:
         # Unreadable repo (missing path, permissions): nothing to detach. Prep
         # falls through to its normal fallback rather than failing here.
+        logger.warning(
+            "Could not inspect worktrees in %s while checking who holds %s: %s",
+            project_path, branch, e,
+        )
         return None
 
     for wt in worktrees:
         if wt.is_main or not wt.path or wt.branch != branch:
             continue
-        if wt.locked:
-            logger.warning(
-                "Branch %s is held by locked worktree %s — not detaching",
-                branch, wt.path,
-            )
-            continue
-        return wt.path
+        return wt
     return None
+
+
+def _find_branch_holder(project_path: str, branch: str) -> Optional[str]:
+    """Return the path of a *detachable* worktree holding ``branch``.
+
+    None when nothing holds it, or when the holder is ``locked`` (someone's live
+    workspace — never disturb those).
+    """
+    wt = _branch_holder_worktree(project_path, branch)
+    if wt is None:
+        return None
+    if wt.locked:
+        logger.warning(
+            "Branch %s is held by locked worktree %s — not detaching",
+            branch, wt.path,
+        )
+        return None
+    return wt.path
 
 
 def _release_branch_from_worktree(holder: str, branch: str) -> bool:
@@ -709,13 +729,16 @@ def prepare_project_branch(
         # held-branch problem is solved by then.)
         holder = _find_branch_holder(project_path, base_branch)
         if holder and _release_branch_from_worktree(holder, base_branch):
+            # Record the detach the moment it happens, not after the retry: it
+            # mutated someone else's worktree either way, and if the retry fails
+            # for an unrelated reason (corrupt index, …) an operator must still
+            # be able to find out what moved their worktree off the branch.
+            freed = f"detached worktree {holder} which held {base_branch}"
+            result.healed = f"{result.healed}; {freed}" if result.healed else freed
+            logger.info("git prep self-heal for %s: %s", project_name, freed)
             rc, _, checkout_err = run_git(
                 "checkout", base_branch, cwd=project_path,
             )
-            if rc == 0:
-                freed = f"detached worktree {holder} which held {base_branch}"
-                result.healed = f"{result.healed}; {freed}" if result.healed else freed
-                logger.info("git prep self-heal for %s: %s", project_name, freed)
 
         if rc != 0:
             # Branch may not exist locally — create from remote tracking

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -647,6 +647,7 @@ def prepare_project_branch(
     # fetch fails the detect-after-failure path below still applies. resolve_* (not
     # detect_*) so a failed resolution stays None instead of promoting the "main"
     # fallback to an answer.
+    original_base = base_branch
     if not config_configured and not _has_remote_tracking_ref(
         remote, base_branch, project_path
     ):
@@ -665,18 +666,32 @@ def prepare_project_branch(
         remote, base_branch, project_path, timeout=30
     )
     if rc != 0 and not config_explicit:
-        # Base branch was not explicitly configured — detect remote default
+        # Base branch was not explicitly configured — detect remote default.
+        # Then, if the pre-fetch override above moved us off the fallback, fall
+        # back to that original value: resolution reads refs/remotes/<remote>/HEAD
+        # without touching the network, so a symbolic ref left stale by an upstream
+        # rename points at a branch that no longer exists. Retrying the value we
+        # started from recovers the case where the fallback branch is the one that
+        # actually exists — otherwise every mission on that project fails in prep
+        # until head_tracker refreshes the ref (throttled to 12h).
+        candidates = []
         detected = detect_remote_default_branch(remote, project_path)
         if detected != base_branch:
+            candidates.append(detected)
+        if original_base != base_branch and original_base not in candidates:
+            candidates.append(original_base)
+        for candidate in candidates:
             logger.info(
-                "Default branch for %s/%s is '%s', not '%s'",
-                remote, project_name, detected, base_branch,
+                "Fetch of '%s' failed for %s/%s; trying '%s' instead",
+                base_branch, remote, project_name, candidate,
             )
-            base_branch = detected
-            result.base_branch = detected
+            base_branch = candidate
+            result.base_branch = candidate
             rc, _, stderr = _fetch_with_https_fallback(
                 remote, base_branch, project_path, timeout=30
             )
+            if rc == 0:
+                break
     if rc != 0:
         result.success = False
         result.error = f"fetch failed: {stderr}"

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -458,6 +458,12 @@ def _branch_holder_worktree(project_path: str, branch: str):
     worktree itself, or when the worktree list could not be read — the last case
     is logged, so "we could not look" never reads like "nothing holds it".
 
+    ``is_main`` alone is not enough to recognise the project's own checkout: it
+    is a ``normpath`` comparison, while git reports the path it recorded with
+    symlinks already resolved. A project registered under a symlinked (or
+    relative) path therefore shows up as a non-main worktree of itself, so the
+    identity test goes through ``_is_same_dir`` as well.
+
     Locked holders are returned, not filtered: prep must not detach them, but
     /doctor must still report them — that collision is the one no automation can
     heal, so hiding it leaves a fully-broken project looking clean.
@@ -478,6 +484,9 @@ def _branch_holder_worktree(project_path: str, branch: str):
 
     for wt in worktrees:
         if wt.is_main or not wt.path or wt.branch != branch:
+            continue
+        if _is_same_dir(wt.path, project_path):
+            # The project's own checkout, reported under a different path.
             continue
         return wt
     return None

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -435,8 +435,11 @@ def reap_foreign_worktrees(
       * never a `locked` worktree — that is someone's live workspace
       * never one with tracked or untracked file activity within max_age_days — a review
         that started minutes ago is still running, and removing its tree kills the job
-      * never one on a branch holding commits absent from its upstream
-      * never one whose working tree is dirty when no durable ref reaches its HEAD
+      * never one whose working tree is dirty — removal is `--force`, so uncommitted work
+        would be deleted with no recovery path. This applies to every candidate, on a
+        branch or detached: a hand-made in-project worktree (`<project>/wt/feature-x`) is
+        exactly where a human parks WIP, and its local branch says nothing about the tree
+      * never one holding commits no other ref would keep reachable after removal
 
     ``deadline`` is a monotonic deadline shared by callers that sweep several
     projects. When omitted, the fixed maintenance budget applies. A timed-out
@@ -505,6 +508,16 @@ def reap_foreign_worktrees(
             )
             continue  # possibly a live review, or activity could not be verified
 
+        # Every candidate, not just the unreachable-detached one: removal is `--force`,
+        # and a dirty tree on a perfectly durable local branch still holds uncommitted
+        # work that nothing else has a copy of.
+        if _has_uncommitted_changes(wt_real, deadline=deadline):
+            print(
+                f"[worktree_manager] skip (uncommitted changes) {wt.path}",
+                file=sys.stderr,
+            )
+            continue
+
         if _has_unpushed_commits(wt_real, deadline=deadline):
             print(
                 f"[worktree_manager] skip (unpushed commits) {wt.path}",
@@ -517,8 +530,9 @@ def reap_foreign_worktrees(
             continue
 
         try:
-            # force=True: reviews routinely leave incidental edits behind (a regenerated
-            # lockfile, a touched test file), which would otherwise block removal.
+            # force=True: reviews leave ignored build output (node_modules, .venv) behind,
+            # which can block a plain removal. Safe only because the dirty-tree guard above
+            # already ran — `--force` deletes uncommitted work without asking.
             remove_worktree(
                 project_path,
                 worktree_path=wt.path,
@@ -732,9 +746,10 @@ def _has_unpushed_commits(
     exactly this reason while the reaper reported "0 reclaimed" every hour for days.
 
     So an unreachable detached HEAD is removable only when it still equals the commit used
-    to create the worktree and its tree is clean. A changed HEAD may contain committed but
-    never-pushed work, while a dirty tree contains uncommitted work. Age is already covered
-    by the caller's activity guard. Any git or verification failure keeps the worktree.
+    to create the worktree: a changed HEAD may contain committed but never-pushed work.
+    This answers only "would commits be lost". Uncommitted work is a separate question,
+    guarded for every candidate by the caller, and age by the caller's activity guard.
+    Any git or verification failure keeps the worktree.
     """
     try:
         branch = subprocess.run(
@@ -812,13 +827,10 @@ def _has_unpushed_commits(
     head = result.stdout.strip().splitlines()[0]
     # Unreachable: a closed pull request, or genuinely unique work. A closed-PR
     # checkout remains at its creation commit; locally committed work moves HEAD.
-    return (
-        _head_moved_since_worktree_creation(
-            worktree_path,
-            head,
-            deadline=deadline,
-        )
-        or _has_uncommitted_changes(worktree_path, deadline=deadline)
+    return _head_moved_since_worktree_creation(
+        worktree_path,
+        head,
+        deadline=deadline,
     )
 
 

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -598,11 +598,14 @@ def _has_unpushed_commits(
 ) -> bool:
     """Return True when removing the worktree could make commits unreachable.
 
-    Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD is
-    safe only when the remote default branch reaches it. This deliberately avoids an
-    all-ref containment scan, which is prohibitively expensive in repositories with many
-    refs. Local branches without upstreams remain durable after path-based removal. Any
-    git or verification failure keeps the worktree.
+    Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD is safe
+    only when some durable ref — a local branch, a tag, or a remote-tracking ref — already
+    reaches it, since those survive removing the worktree's path. Testing reachability from
+    the default branch alone would be wrong, not merely stricter: review worktrees sit at
+    pull-request head commits, which live on their remote branch but are never ancestors of
+    the default branch, so every one of them would be retained forever. Local branches
+    without upstreams remain durable after path-based removal. Any git or verification
+    failure keeps the worktree.
     """
     try:
         branch = subprocess.run(
@@ -660,26 +663,12 @@ def _has_unpushed_commits(
     if branch.returncode != 1:
         return True
 
-    try:
-        default_branch = subprocess.run(
-            ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-            cwd=worktree_path,
-            capture_output=True,
-            text=True,
-            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
-        )
-    except (OSError, subprocess.SubprocessError):
-        return True
-    if default_branch.returncode != 0:
-        return True
-
-    default_ref = default_branch.stdout.strip()
-    if not default_ref:
-        return True
-
+    # One revision walk, negated by every durable ref, instead of a containment scan per
+    # ref. --max-count=1 stops at the first commit that no ref reaches, so the cost is the
+    # divergence rather than the ref count.
     try:
         result = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", "HEAD", default_ref],
+            ["git", "rev-list", "--max-count=1", "HEAD", "--not", "--branches", "--tags", "--remotes"],
             cwd=worktree_path,
             capture_output=True,
             text=True,
@@ -687,7 +676,9 @@ def _has_unpushed_commits(
         )
     except (OSError, subprocess.SubprocessError):
         return True
-    return result.returncode != 0
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
 
 
 def prune_worktrees(project_path: str, timeout: Optional[float] = None):

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -37,6 +37,11 @@ WORKTREE_DIR = ".worktrees"
 # reap_foreign_worktrees() will remove it. Two days is comfortably longer than any single
 # review run, so a live job is never stripped of its working tree.
 FOREIGN_WORKTREE_MAX_AGE_DAYS = 2.0
+# Foreign worktree cleanup is best-effort maintenance. It must never consume an
+# unbounded amount of time on a large repository or delay other daemon work.
+FOREIGN_WORKTREE_REAP_BUDGET_SECONDS = 120.0
+FOREIGN_WORKTREE_GIT_TIMEOUT_SECONDS = 15.0
+_ACTIVITY_BUDGET_CHECK_EVERY = 128
 
 
 @dataclass
@@ -210,6 +215,8 @@ def remove_worktree(
     session_id: str = "",
     worktree_path: str = "",
     force: bool = False,
+    timeout: Optional[float] = None,
+    fallback_remove: bool = True,
 ):
     """Remove a git worktree and clean up associated state.
 
@@ -218,6 +225,8 @@ def remove_worktree(
         session_id: Session identifier (used to derive worktree path).
         worktree_path: Direct path to the worktree (alternative to session_id).
         force: If True, use --force flag for stubborn worktrees.
+        timeout: Optional subprocess timeout in seconds.
+        fallback_remove: Remove the directory directly if Git removal fails.
 
     Either session_id or worktree_path must be provided.
     """
@@ -241,24 +250,30 @@ def remove_worktree(
             capture_output=True,
             text=True,
             check=True,
+            **({"timeout": timeout} if timeout is not None else {}),
         )
+    except subprocess.TimeoutExpired:
+        print(f"[worktree_manager] git worktree remove timed out for {wt}", file=sys.stderr)
+        return
     except subprocess.CalledProcessError as e:
         stderr = (e.stderr or "").strip()
         print(
             f"[worktree_manager] git worktree remove failed for {wt}: {stderr}",
             file=sys.stderr,
         )
-        # If git worktree remove fails, try manual cleanup
-        if wt.exists():
+        # Maintenance reaping disables this fallback: shutil.rmtree() has no
+        # interruptible deadline and could violate the sweep's hard budget.
+        if fallback_remove and wt.exists():
             shutil.rmtree(str(wt), ignore_errors=True)
 
     # Prune any stale worktree references
-    with contextlib.suppress(subprocess.CalledProcessError):
+    with contextlib.suppress(subprocess.CalledProcessError, subprocess.TimeoutExpired):
         subprocess.run(
             ["git", "worktree", "prune"],
             cwd=project_path,
             capture_output=True,
             text=True,
+            **({"timeout": timeout} if timeout is not None else {}),
         )
 
     # Delete the branch if it still exists
@@ -272,6 +287,7 @@ def remove_worktree(
                 cwd=project_path,
                 capture_output=True,
                 text=True,
+                **({"timeout": timeout} if timeout is not None else {}),
             )
             if result.returncode != 0:
                 stderr = (result.stderr or "").strip()
@@ -279,6 +295,8 @@ def remove_worktree(
                     f"[worktree_manager] git branch -D failed for {branch}: {stderr}",
                     file=sys.stderr,
                 )
+        except subprocess.TimeoutExpired:
+            print(f"[worktree_manager] git branch -D timed out for {branch}", file=sys.stderr)
         except subprocess.CalledProcessError as e:
             stderr = (e.stderr or "").strip()
             print(
@@ -287,7 +305,7 @@ def remove_worktree(
             )
 
 
-def list_worktrees(project_path: str) -> List[WorktreeInfo]:
+def list_worktrees(project_path: str, timeout: Optional[float] = None) -> List[WorktreeInfo]:
     """List all git worktrees for a project.
 
     Returns a list of WorktreeInfo, including the main worktree.
@@ -299,8 +317,9 @@ def list_worktrees(project_path: str) -> List[WorktreeInfo]:
             capture_output=True,
             text=True,
             check=True,
+            **({"timeout": timeout} if timeout is not None else {}),
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return []
 
     worktrees = []
@@ -368,6 +387,8 @@ def reap_foreign_worktrees(
     project_path: str,
     max_age_days: float = FOREIGN_WORKTREE_MAX_AGE_DAYS,
     dry_run: bool = False,
+    deadline: Optional[float] = None,
+    start_index: int = 0,
 ) -> List[str]:
     """Remove stale worktrees registered in this project but living outside it.
 
@@ -392,20 +413,40 @@ def reap_foreign_worktrees(
         that started minutes ago is still running, and removing its tree kills the job
       * never one holding commits absent from its upstream or from every durable ref
 
+    ``deadline`` is a monotonic deadline shared by callers that sweep several
+    projects. When omitted, the fixed maintenance budget applies. A timed-out
+    safety check retains the worktree. ``start_index`` rotates candidates so a
+    large early worktree cannot starve every later one across capped sweeps.
+
     Returns the list of paths removed (or, with dry_run, the paths that would be).
     """
     project_real = os.path.realpath(project_path)
     removed: List[str] = []
     cutoff = time.time() - (max_age_days * 86400)
+    if deadline is None:
+        deadline = time.monotonic() + FOREIGN_WORKTREE_REAP_BUDGET_SECONDS
 
     # Drop registrations whose directory is already gone before looking at what remains.
     # These accumulate whenever something deletes a worktree without telling git — the 10d
     # systemd-tmpfiles sweep of /tmp does exactly that — and nothing else clears them. A
     # fleet survey on 2026-07-30 found ~20 across six hosts, including 10 on one repo.
     if not dry_run:
-        prune_worktrees(project_path)
+        try:
+            prune_worktrees(project_path, timeout=_reap_timeout(deadline))
+        except subprocess.TimeoutExpired:
+            _log_reap_deadline(project_path)
+            return removed
+    if _reap_expired(deadline):
+        _log_reap_deadline(project_path)
+        return removed
 
-    for wt in list_worktrees(project_path):
+    candidates = []
+    try:
+        list_timeout = _reap_timeout(deadline)
+    except subprocess.TimeoutExpired:
+        _log_reap_deadline(project_path)
+        return removed
+    for wt in list_worktrees(project_path, timeout=list_timeout):
         if wt.is_main or not wt.path:
             continue
 
@@ -413,7 +454,17 @@ def reap_foreign_worktrees(
         wt_real = os.path.realpath(wt.path)
         if wt_real == project_real or wt_real.startswith(project_real + os.sep):
             continue
+        candidates.append((wt, wt_real))
 
+    candidates.sort(key=lambda item: item[0].path)
+    if candidates:
+        offset = start_index % len(candidates)
+        candidates = candidates[offset:] + candidates[:offset]
+
+    for wt, wt_real in candidates:
+        if _reap_expired(deadline):
+            _log_reap_deadline(project_path)
+            break
         if wt.locked:
             print(f"[worktree_manager] skip (locked) {wt.path}", file=sys.stderr)
             continue
@@ -421,10 +472,10 @@ def reap_foreign_worktrees(
         if not os.path.isdir(wt_real):
             continue  # already gone — prune_worktrees() drops the registration
 
-        if _has_recent_worktree_activity(wt_real, cutoff):
+        if _has_recent_worktree_activity(wt_real, cutoff, deadline=deadline):
             continue  # possibly a live review, or activity could not be verified
 
-        if _has_unpushed_commits(wt_real):
+        if _has_unpushed_commits(wt_real, deadline=deadline):
             print(
                 f"[worktree_manager] skip (unpushed commits) {wt.path}",
                 file=sys.stderr,
@@ -438,7 +489,19 @@ def reap_foreign_worktrees(
         try:
             # force=True: reviews routinely leave incidental edits behind (a regenerated
             # lockfile, a touched test file), which would otherwise block removal.
-            remove_worktree(project_path, worktree_path=wt.path, force=True)
+            remove_worktree(
+                project_path,
+                worktree_path=wt.path,
+                force=True,
+                timeout=_reap_timeout(deadline),
+                fallback_remove=False,
+            )
+            if os.path.exists(wt.path):
+                print(
+                    f"[worktree_manager] foreign worktree reap incomplete for {wt.path}",
+                    file=sys.stderr,
+                )
+                continue
             removed.append(wt.path)
             print(f"[worktree_manager] reaped foreign worktree {wt.path}", file=sys.stderr)
         except Exception as e:
@@ -450,7 +513,31 @@ def reap_foreign_worktrees(
     return removed
 
 
-def _has_recent_worktree_activity(worktree_path: str, cutoff: float) -> bool:
+def _reap_expired(deadline: float) -> bool:
+    return time.monotonic() >= deadline
+
+
+def _reap_timeout(deadline: float) -> float:
+    """Return a bounded Git timeout or raise when no sweep time remains."""
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired("foreign-worktree-reap", 0)
+    return min(FOREIGN_WORKTREE_GIT_TIMEOUT_SECONDS, remaining)
+
+
+def _log_reap_deadline(project_path: str) -> None:
+    print(
+        f"[worktree_manager] foreign worktree reap budget reached in {project_path}; "
+        "remaining worktrees will be retried next sweep",
+        file=sys.stderr,
+    )
+
+
+def _has_recent_worktree_activity(
+    worktree_path: str,
+    cutoff: float,
+    deadline: Optional[float] = None,
+) -> bool:
     """Return True when non-ignored worktree content changed after ``cutoff``.
 
     Root directory mtime alone misses edits to existing files. Ask git for tracked and
@@ -464,6 +551,7 @@ def _has_recent_worktree_activity(worktree_path: str, cutoff: float) -> bool:
             cwd=worktree_path,
             capture_output=True,
             text=True,
+            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
     except (OSError, subprocess.SubprocessError):
         return True
@@ -472,7 +560,10 @@ def _has_recent_worktree_activity(worktree_path: str, cutoff: float) -> bool:
 
     root = os.path.realpath(worktree_path)
     directories = {root}
-    for relative_path in result.stdout.split("\0"):
+    for index, relative_path in enumerate(result.stdout.split("\0")):
+        if deadline is not None and index % _ACTIVITY_BUDGET_CHECK_EVERY == 0:
+            if _reap_expired(deadline):
+                return True
         if not relative_path:
             continue
         path = os.path.join(root, relative_path)
@@ -490,12 +581,21 @@ def _has_recent_worktree_activity(worktree_path: str, cutoff: float) -> bool:
             parent = os.path.dirname(parent)
 
     try:
-        return any(os.lstat(path).st_mtime > cutoff for path in directories)
+        for index, path in enumerate(directories):
+            if deadline is not None and index % _ACTIVITY_BUDGET_CHECK_EVERY == 0:
+                if _reap_expired(deadline):
+                    return True
+            if os.lstat(path).st_mtime > cutoff:
+                return True
+        return False
     except OSError:
         return True
 
 
-def _has_unpushed_commits(worktree_path: str) -> bool:
+def _has_unpushed_commits(
+    worktree_path: str,
+    deadline: Optional[float] = None,
+) -> bool:
     """Return True when removing the worktree could make commits unreachable.
 
     Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD
@@ -509,6 +609,7 @@ def _has_unpushed_commits(worktree_path: str) -> bool:
             cwd=worktree_path,
             capture_output=True,
             text=True,
+            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
     except (OSError, subprocess.SubprocessError):
         return True
@@ -521,12 +622,14 @@ def _has_unpushed_commits(worktree_path: str) -> bool:
                 cwd=worktree_path,
                 capture_output=True,
                 text=True,
+                **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
             )
             merge = subprocess.run(
                 ["git", "config", "--get", f"branch.{branch_name}.merge"],
                 cwd=worktree_path,
                 capture_output=True,
                 text=True,
+                **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
             )
         except (OSError, subprocess.SubprocessError):
             return True
@@ -542,6 +645,7 @@ def _has_unpushed_commits(worktree_path: str) -> bool:
                 cwd=worktree_path,
                 capture_output=True,
                 text=True,
+                **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
             )
         except (OSError, subprocess.SubprocessError):
             return True
@@ -569,6 +673,7 @@ def _has_unpushed_commits(worktree_path: str) -> bool:
             cwd=worktree_path,
             capture_output=True,
             text=True,
+            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
     except (OSError, subprocess.SubprocessError):
         return True
@@ -577,7 +682,7 @@ def _has_unpushed_commits(worktree_path: str) -> bool:
     return not bool(result.stdout.strip())
 
 
-def prune_worktrees(project_path: str):
+def prune_worktrees(project_path: str, timeout: Optional[float] = None):
     """Run git worktree prune to clear stale worktree references.
 
     Intended to be called on startup to clean up leftover refs from
@@ -589,6 +694,7 @@ def prune_worktrees(project_path: str):
             cwd=project_path,
             capture_output=True,
             text=True,
+            **({"timeout": timeout} if timeout is not None else {}),
         )
         output = (result.stdout or "").strip()
         if output:
@@ -596,6 +702,8 @@ def prune_worktrees(project_path: str):
     except subprocess.CalledProcessError as e:
         stderr = (e.stderr or "").strip()
         print(f"[worktree_manager] git worktree prune failed: {stderr}", file=sys.stderr)
+    except subprocess.TimeoutExpired:
+        print(f"[worktree_manager] git worktree prune timed out for {project_path}", file=sys.stderr)
     except FileNotFoundError:
         pass  # git not available
 

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -32,6 +32,10 @@ GIT_RETRY_MAX_DELAY = 0.5
 
 # Default worktree directory name (relative to project root)
 WORKTREE_DIR = ".worktrees"
+# Directories inside a project that belong to other code and must never be reaped.
+# Everything else under the project — notably `<project>/tmp/`, where agents and
+# skills drop scratch checkouts — has no owner and is in scope.
+OWNED_WORKTREE_DIRS = (".worktrees", os.path.join(".claude", "worktrees"))
 
 # How long a worktree registered outside the project must sit untouched before
 # reap_foreign_worktrees() will remove it. Two days is comfortably longer than any single
@@ -392,10 +396,12 @@ def reap_foreign_worktrees(
 ) -> List[str]:
     """Remove stale worktrees registered in this project but living outside it.
 
-    Agents with a shell tool check revisions out ad hoc — `git worktree add
-    /tmp/review-<sha> <sha>` — because that is what the review skill instructs, and the
-    skill has no teardown step. Those worktrees are registered in the project's repo but
-    sit outside `<project>/.worktrees/`, so `cleanup_stale_worktrees()` (which only walks
+    Agents with an unrestricted shell check revisions out ad hoc — `git worktree add
+    /tmp/base140 140` — improvising, not following any skill instruction. (`/review` runs
+    in a worktree Kōan creates and removes, behind a read-only shell guard that denies
+    `git worktree` outright; the leak comes from `/fix`-class missions, whose shell is
+    unhooked.) Those worktrees are registered in the project's repo but sit outside
+    `<project>/.worktrees/`, so `cleanup_stale_worktrees()` (which only walks
     `.worktrees/`) never sees them, and `prune_worktrees()` only drops registrations whose
     directory is *already* gone. Nothing reclaims a leaked worktree whose directory still
     exists.
@@ -405,13 +411,17 @@ def reap_foreign_worktrees(
     phantom registrations.
 
     Guards, in order — each one exists because skipping it would destroy work:
-      * only worktrees *outside* project_path — anything inside is owned by
-        cleanup_stale_worktrees() or by another harness (e.g. `.claude/worktrees/`)
+      * never a worktree owned by other code — `<project>/.worktrees/` belongs to
+        cleanup_stale_worktrees(), `<project>/.claude/worktrees/` to the Claude Code
+        harness. Scratch worktrees under `<project>/tmp/` have no owner and ARE in
+        scope: the OS temp sweeper does not reach inside a project either, so a blanket
+        "skip anything inside the project" rule left them unreclaimable by anything.
       * never the main worktree
       * never a `locked` worktree — that is someone's live workspace
       * never one with tracked or untracked file activity within max_age_days — a review
         that started minutes ago is still running, and removing its tree kills the job
-      * never one holding commits absent from its upstream or from every durable ref
+      * never one on a branch holding commits absent from its upstream
+      * never one whose working tree is dirty when no durable ref reaches its HEAD
 
     ``deadline`` is a monotonic deadline shared by callers that sweep several
     projects. When omitted, the fixed maintenance budget applies. A timed-out
@@ -450,9 +460,8 @@ def reap_foreign_worktrees(
         if wt.is_main or not wt.path:
             continue
 
-        # Only foreign worktrees. Anything under the project belongs to another owner.
         wt_real = os.path.realpath(wt.path)
-        if wt_real == project_real or wt_real.startswith(project_real + os.sep):
+        if wt_real == project_real or _is_owned_by_other_code(wt_real, project_real):
             continue
         candidates.append((wt, wt_real))
 
@@ -473,6 +482,12 @@ def reap_foreign_worktrees(
             continue  # already gone — prune_worktrees() drops the registration
 
         if _has_recent_worktree_activity(wt_real, cutoff, deadline=deadline):
+            # Log it: `locked` and `unpushed commits` both report, so a silent skip
+            # here made a retained worktree impossible to explain from the logs.
+            print(
+                f"[worktree_manager] skip (recent activity) {wt.path}",
+                file=sys.stderr,
+            )
             continue  # possibly a live review, or activity could not be verified
 
         if _has_unpushed_commits(wt_real, deadline=deadline):
@@ -531,6 +546,80 @@ def _log_reap_deadline(project_path: str) -> None:
         "remaining worktrees will be retried next sweep",
         file=sys.stderr,
     )
+
+
+def _is_owned_by_other_code(wt_real: str, project_real: str) -> bool:
+    """Return True when this worktree belongs to code other than the sweep.
+
+    Only two directories inside a project have an owner: `.worktrees/` (managed by
+    ``cleanup_stale_worktrees``) and `.claude/worktrees/` (managed by the Claude Code
+    harness). A worktree living anywhere else inside the project — in practice
+    `<project>/tmp/` — is unowned scratch and must stay in scope, because nothing else
+    on the host reclaims it: the OS temp sweeper only walks the system temp directory.
+    """
+    if not wt_real.startswith(project_real + os.sep):
+        return False  # outside the project entirely — foreign, always in scope
+    relative = wt_real[len(project_real) + 1:]
+    return any(
+        relative == owned or relative.startswith(owned + os.sep)
+        for owned in OWNED_WORKTREE_DIRS
+    )
+
+
+def _has_uncommitted_changes(
+    worktree_path: str,
+    deadline: Optional[float] = None,
+) -> bool:
+    """Return True when the worktree has tracked or untracked local changes.
+
+    Any inspection failure reports True, so an unreadable worktree is retained.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
+
+
+def _head_moved_since_worktree_creation(
+    worktree_path: str,
+    head: str,
+    deadline: Optional[float] = None,
+) -> bool:
+    """Return True when detached HEAD differs from its worktree-add commit.
+
+    A linked worktree has its own HEAD reflog. Its oldest entry records the commit
+    supplied to ``git worktree add``; a later detached commit changes HEAD while a
+    closed pull-request checkout does not. Any inspection failure returns True so
+    unique committed work is retained.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "reflog", "show", "--format=%H%x00%gs", "HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    entries = [entry for entry in result.stdout.splitlines() if entry]
+    if result.returncode != 0 or not entries:
+        return True
+    creation = entries[-1].split("\0", 1)
+    if len(creation) != 2 or creation[1]:
+        # The initial worktree-add entry has no reflog subject. If it expired,
+        # the oldest visible entry cannot prove which commit created the tree.
+        return True
+    return creation[0] != head
 
 
 def _has_recent_worktree_activity(
@@ -598,14 +687,22 @@ def _has_unpushed_commits(
 ) -> bool:
     """Return True when removing the worktree could make commits unreachable.
 
-    Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD is safe
-    only when some durable ref — a local branch, a tag, or a remote-tracking ref — already
-    reaches it, since those survive removing the worktree's path. Testing reachability from
-    the default branch alone would be wrong, not merely stricter: review worktrees sit at
-    pull-request head commits, which live on their remote branch but are never ancestors of
-    the default branch, so every one of them would be retained forever. Local branches
-    without upstreams remain durable after path-based removal. Any git or verification
-    failure keeps the worktree.
+    Tracking branches are unsafe when HEAD exceeds their upstream. Local branches without
+    upstreams remain durable after path-based removal.
+
+    For a detached HEAD, reachability alone cannot decide. A durable ref — local branch,
+    tag, or remote-tracking ref — reaching HEAD proves the commits survive removal, so the
+    worktree is safe to reap. But the converse does not hold. A review worktree sits at a
+    pull-request head commit, durable on its remote branch only while that PR is open; once
+    the PR is squash-merged the remote branch is deleted and nothing reaches that commit any
+    more. Retaining on unreachability therefore made every *completed* review immortal —
+    measured on the koan host, three of four leaked worktrees were permanently retained for
+    exactly this reason while the reaper reported "0 reclaimed" every hour for days.
+
+    So an unreachable detached HEAD is removable only when it still equals the commit used
+    to create the worktree and its tree is clean. A changed HEAD may contain committed but
+    never-pushed work, while a dirty tree contains uncommitted work. Age is already covered
+    by the caller's activity guard. Any git or verification failure keeps the worktree.
     """
     try:
         branch = subprocess.run(
@@ -678,7 +775,19 @@ def _has_unpushed_commits(
         return True
     if result.returncode != 0:
         return True
-    return bool(result.stdout.strip())
+    if not result.stdout.strip():
+        return False  # a durable ref reaches HEAD — removal loses nothing
+    head = result.stdout.strip().splitlines()[0]
+    # Unreachable: a closed pull request, or genuinely unique work. A closed-PR
+    # checkout remains at its creation commit; locally committed work moves HEAD.
+    return (
+        _head_moved_since_worktree_creation(
+            worktree_path,
+            head,
+            deadline=deadline,
+        )
+        or _has_uncommitted_changes(worktree_path, deadline=deadline)
+    )
 
 
 def prune_worktrees(project_path: str, timeout: Optional[float] = None):
@@ -689,7 +798,9 @@ def prune_worktrees(project_path: str, timeout: Optional[float] = None):
     """
     try:
         result = subprocess.run(
-            ["git", "worktree", "prune", "--verbose"],
+            # --expire now: the default gc.worktreePruneExpire is 3.months.ago, which
+            # would leave a freshly orphaned registration in place for a quarter.
+            ["git", "worktree", "prune", "--verbose", "--expire", "now"],
             cwd=project_path,
             capture_output=True,
             text=True,

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -32,10 +32,11 @@ GIT_RETRY_MAX_DELAY = 0.5
 
 # Default worktree directory name (relative to project root)
 WORKTREE_DIR = ".worktrees"
-# Directories inside a project that belong to other code and must never be reaped.
-# Everything else under the project — notably `<project>/tmp/`, where agents and
-# skills drop scratch checkouts — has no owner and is in scope.
-OWNED_WORKTREE_DIRS = (".worktrees", os.path.join(".claude", "worktrees"))
+# Directories inside a project the sweep may reclaim from. `<project>/tmp/` is where
+# agents and skills drop scratch checkouts: nothing else on the host reclaims them, and
+# the directory name says the contents are disposable. Every other in-project path is
+# out of scope — see _is_in_scope().
+IN_PROJECT_SCRATCH_DIRS = ("tmp",)
 
 # How long a worktree registered outside the project must sit untouched before
 # reap_foreign_worktrees() will remove it. Two days is comfortably longer than any single
@@ -426,19 +427,21 @@ def reap_foreign_worktrees(
     phantom registrations.
 
     Guards, in order — each one exists because skipping it would destroy work:
-      * never a worktree owned by other code — `<project>/.worktrees/` belongs to
-        cleanup_stale_worktrees(), `<project>/.claude/worktrees/` to the Claude Code
-        harness. Scratch worktrees under `<project>/tmp/` have no owner and ARE in
-        scope: the OS temp sweeper does not reach inside a project either, so a blanket
-        "skip anything inside the project" rule left them unreclaimable by anything.
+      * never a worktree inside the project other than one under `<project>/tmp/`.
+        `.worktrees/` belongs to cleanup_stale_worktrees() and `.claude/worktrees/` to
+        the Claude Code harness; a hand-made `<project>/wt/feature-x` is a human's
+        workspace, whose gitignored local-only files no guard below can see. Scratch
+        worktrees under `<project>/tmp/` have no owner and ARE in scope: the OS temp
+        sweeper does not reach inside a project either, so a blanket "skip anything
+        inside the project" rule left them unreclaimable by anything.
       * never the main worktree
       * never a `locked` worktree — that is someone's live workspace
       * never one with tracked or untracked file activity within max_age_days — a review
         that started minutes ago is still running, and removing its tree kills the job
       * never one whose working tree is dirty — removal is `--force`, so uncommitted work
         would be deleted with no recovery path. This applies to every candidate, on a
-        branch or detached: a hand-made in-project worktree (`<project>/wt/feature-x`) is
-        exactly where a human parks WIP, and its local branch says nothing about the tree
+        branch or detached: a scratch checkout on a local branch still holds uncommitted
+        edits nothing else has a copy of, and its branch says nothing about the tree
       * never one holding commits no other ref would keep reachable after removal
 
     ``deadline`` is a monotonic deadline shared by callers that sweep several
@@ -479,7 +482,7 @@ def reap_foreign_worktrees(
             continue
 
         wt_real = os.path.realpath(wt.path)
-        if wt_real == project_real or _is_owned_by_other_code(wt_real, project_real):
+        if wt_real == project_real or not _is_in_scope(wt_real, project_real):
             continue
         candidates.append((wt, wt_real))
 
@@ -589,21 +592,30 @@ def _log_reap_deadline(project_path: str) -> None:
     )
 
 
-def _is_owned_by_other_code(wt_real: str, project_real: str) -> bool:
-    """Return True when this worktree belongs to code other than the sweep.
+def _is_in_scope(wt_real: str, project_real: str) -> bool:
+    """Return True when the sweep may consider this worktree for removal at all.
 
-    Only two directories inside a project have an owner: `.worktrees/` (managed by
-    ``cleanup_stale_worktrees``) and `.claude/worktrees/` (managed by the Claude Code
-    harness). A worktree living anywhere else inside the project — in practice
-    `<project>/tmp/` — is unowned scratch and must stay in scope, because nothing else
-    on the host reclaims it: the OS temp sweeper only walks the system temp directory.
+    Outside the project, always: nothing else on the host reclaims a leaked
+    `/tmp/review-<sha>`. Inside the project, only `<project>/tmp/` — an unowned
+    scratch checkout (`cleanup_stale_worktrees()` walks `.worktrees/` only, and the OS
+    temp sweeper never reaches inside a project), announced as disposable by the
+    directory it sits in.
+
+    Every other in-project path is out of scope. `.worktrees/` and `.claude/worktrees/`
+    because other code owns them; anything else (`<project>/wt/feature-x`) because it
+    is a hand-made human workspace, and none of the retention guards below can see one.
+    They all ask git, and git is silent about the gitignored `.env.local` or `dev.db`
+    such a workspace keeps: `git status --porcelain` omits ignored files, the activity
+    scan uses `--exclude-standard`, and a local branch with no upstream reports nothing
+    unpushed. A clean-looking tree would be `--force`-removed with those files in it,
+    unattended, on an hourly timer.
     """
     if not wt_real.startswith(project_real + os.sep):
-        return False  # outside the project entirely — foreign, always in scope
+        return True  # outside the project entirely — foreign, always in scope
     relative = wt_real[len(project_real) + 1:]
     return any(
-        relative == owned or relative.startswith(owned + os.sep)
-        for owned in OWNED_WORKTREE_DIRS
+        relative.startswith(scratch + os.sep)
+        for scratch in IN_PROJECT_SCRATCH_DIRS
     )
 
 

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -313,6 +313,10 @@ def list_worktrees(project_path: str, timeout: Optional[float] = None) -> List[W
     """List all git worktrees for a project.
 
     Returns a list of WorktreeInfo, including the main worktree.
+
+    An inspection failure returns an empty list — but never silently: callers use
+    this as the sole evidence that no worktree holds a branch, so "git could not
+    tell us" must be distinguishable from "nothing holds it" in the logs.
     """
     try:
         result = subprocess.run(
@@ -323,7 +327,18 @@ def list_worktrees(project_path: str, timeout: Optional[float] = None) -> List[W
             check=True,
             **({"timeout": timeout} if timeout is not None else {}),
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        print(
+            f"[worktree_manager] git worktree list failed in {project_path}: {stderr}",
+            file=sys.stderr,
+        )
+        return []
+    except subprocess.TimeoutExpired:
+        print(
+            f"[worktree_manager] git worktree list timed out in {project_path}",
+            file=sys.stderr,
+        )
         return []
 
     worktrees = []
@@ -540,6 +555,18 @@ def _reap_timeout(deadline: float) -> float:
     return min(FOREIGN_WORKTREE_GIT_TIMEOUT_SECONDS, remaining)
 
 
+def _retain(worktree_path: str, reason: str) -> bool:
+    """Log why a worktree is being kept and return True (retain).
+
+    Every guard below fails toward retention, so "kept because work would be lost"
+    and "kept because the check could not run" look identical from the reap loop's
+    skip line. Naming the reason is what makes a reaper that has silently reverted
+    to retain-everything distinguishable from one with nothing to do.
+    """
+    print(f"[worktree_manager] retain ({reason}) {worktree_path}", file=sys.stderr)
+    return True
+
+
 def _log_reap_deadline(project_path: str) -> None:
     print(
         f"[worktree_manager] foreign worktree reap budget reached in {project_path}; "
@@ -582,10 +609,10 @@ def _has_uncommitted_changes(
             text=True,
             **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
-    except (OSError, subprocess.SubprocessError):
-        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        return _retain(worktree_path, f"status check failed: {e}")
     if result.returncode != 0:
-        return True
+        return _retain(worktree_path, "status check failed")
     return bool(result.stdout.strip())
 
 
@@ -609,17 +636,22 @@ def _head_moved_since_worktree_creation(
             text=True,
             **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
-    except (OSError, subprocess.SubprocessError):
-        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        return _retain(worktree_path, f"reflog check failed: {e}")
     entries = [entry for entry in result.stdout.splitlines() if entry]
     if result.returncode != 0 or not entries:
-        return True
+        return _retain(worktree_path, "reflog check failed")
     creation = entries[-1].split("\0", 1)
     if len(creation) != 2 or creation[1]:
         # The initial worktree-add entry has no reflog subject. If it expired,
         # the oldest visible entry cannot prove which commit created the tree.
-        return True
-    return creation[0] != head
+        # The empty subject is a git implementation detail, so log this case
+        # explicitly: a git version that writes a subject there would silently
+        # turn the sweep back into retain-everything.
+        return _retain(worktree_path, "reflog subject present on oldest HEAD entry")
+    if creation[0] != head:
+        return _retain(worktree_path, "HEAD moved since worktree creation")
+    return False
 
 
 def _has_recent_worktree_activity(
@@ -642,17 +674,17 @@ def _has_recent_worktree_activity(
             text=True,
             **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
-    except (OSError, subprocess.SubprocessError):
-        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        return _retain(worktree_path, f"activity check failed: {e}")
     if result.returncode != 0:
-        return True
+        return _retain(worktree_path, "activity check failed")
 
     root = os.path.realpath(worktree_path)
     directories = {root}
     for index, relative_path in enumerate(result.stdout.split("\0")):
         if deadline is not None and index % _ACTIVITY_BUDGET_CHECK_EVERY == 0:
             if _reap_expired(deadline):
-                return True
+                return _retain(worktree_path, "activity check ran out of budget")
         if not relative_path:
             continue
         path = os.path.join(root, relative_path)
@@ -661,8 +693,8 @@ def _has_recent_worktree_activity(
                 return True
         except FileNotFoundError:
             pass  # A tracked deletion updates its parent directory mtime.
-        except OSError:
-            return True
+        except OSError as e:
+            return _retain(worktree_path, f"activity check failed: {e}")
 
         parent = os.path.dirname(path)
         while parent != root:
@@ -673,12 +705,12 @@ def _has_recent_worktree_activity(
         for index, path in enumerate(directories):
             if deadline is not None and index % _ACTIVITY_BUDGET_CHECK_EVERY == 0:
                 if _reap_expired(deadline):
-                    return True
+                    return _retain(worktree_path, "activity check ran out of budget")
             if os.lstat(path).st_mtime > cutoff:
                 return True
         return False
-    except OSError:
-        return True
+    except OSError as e:
+        return _retain(worktree_path, f"activity check failed: {e}")
 
 
 def _has_unpushed_commits(
@@ -712,8 +744,8 @@ def _has_unpushed_commits(
             text=True,
             **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
-    except (OSError, subprocess.SubprocessError):
-        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        return _retain(worktree_path, f"HEAD ref check failed: {e}")
 
     if branch.returncode == 0:
         branch_name = branch.stdout.strip()
@@ -732,13 +764,13 @@ def _has_unpushed_commits(
                 text=True,
                 **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
             )
-        except (OSError, subprocess.SubprocessError):
-            return True
+        except (OSError, subprocess.SubprocessError) as e:
+            return _retain(worktree_path, f"upstream config check failed: {e}")
 
         if remote.returncode == 1 and merge.returncode == 1:
             return False  # The local branch itself keeps HEAD reachable.
         if remote.returncode != 0 or merge.returncode != 0:
-            return True
+            return _retain(worktree_path, "upstream config check failed")
 
         try:
             result = subprocess.run(
@@ -748,17 +780,17 @@ def _has_unpushed_commits(
                 text=True,
                 **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
             )
-        except (OSError, subprocess.SubprocessError):
-            return True
+        except (OSError, subprocess.SubprocessError) as e:
+            return _retain(worktree_path, f"upstream comparison failed: {e}")
         if result.returncode != 0:
-            return True
+            return _retain(worktree_path, "upstream comparison failed")
         try:
             return int(result.stdout.strip()) > 0
         except ValueError:
-            return True
+            return _retain(worktree_path, "upstream comparison unparseable")
 
     if branch.returncode != 1:
-        return True
+        return _retain(worktree_path, "HEAD ref check failed")
 
     # One revision walk, negated by every durable ref, instead of a containment scan per
     # ref. --max-count=1 stops at the first commit that no ref reaches, so the cost is the
@@ -771,10 +803,10 @@ def _has_unpushed_commits(
             text=True,
             **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
         )
-    except (OSError, subprocess.SubprocessError):
-        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        return _retain(worktree_path, f"reachability walk failed: {e}")
     if result.returncode != 0:
-        return True
+        return _retain(worktree_path, "reachability walk failed")
     if not result.stdout.strip():
         return False  # a durable ref reaches HEAD — removal loses nothing
     head = result.stdout.strip().splitlines()[0]
@@ -806,12 +838,19 @@ def prune_worktrees(project_path: str, timeout: Optional[float] = None):
             text=True,
             **({"timeout": timeout} if timeout is not None else {}),
         )
+        if result.returncode != 0:
+            # No check=True here, so a failed prune would otherwise be invisible and
+            # the sweep would report "0 reclaimed" as if nothing needed pruning.
+            stderr = (result.stderr or "").strip()
+            print(
+                "[worktree_manager] git worktree prune failed in "
+                f"{project_path}: {stderr}",
+                file=sys.stderr,
+            )
+            return
         output = (result.stdout or "").strip()
         if output:
             print(f"[worktree_manager] pruned stale worktrees:\n{output}", file=sys.stderr)
-    except subprocess.CalledProcessError as e:
-        stderr = (e.stderr or "").strip()
-        print(f"[worktree_manager] git worktree prune failed: {stderr}", file=sys.stderr)
     except subprocess.TimeoutExpired:
         print(f"[worktree_manager] git worktree prune timed out for {project_path}", file=sys.stderr)
     except FileNotFoundError:

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -598,10 +598,11 @@ def _has_unpushed_commits(
 ) -> bool:
     """Return True when removing the worktree could make commits unreachable.
 
-    Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD
-    without an upstream is safe only when another durable branch, remote, or tag reaches
-    it. Local branches without upstreams remain durable after path-based removal. Any git
-    or verification failure keeps the worktree.
+    Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD is
+    safe only when the remote default branch reaches it. This deliberately avoids an
+    all-ref containment scan, which is prohibitively expensive in repositories with many
+    refs. Local branches without upstreams remain durable after path-based removal. Any
+    git or verification failure keeps the worktree.
     """
     try:
         branch = subprocess.run(
@@ -660,16 +661,8 @@ def _has_unpushed_commits(
         return True
 
     try:
-        result = subprocess.run(
-            [
-                "git",
-                "for-each-ref",
-                "--contains=HEAD",
-                "--format=%(refname)",
-                "refs/heads",
-                "refs/remotes",
-                "refs/tags",
-            ],
+        default_branch = subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
             cwd=worktree_path,
             capture_output=True,
             text=True,
@@ -677,9 +670,24 @@ def _has_unpushed_commits(
         )
     except (OSError, subprocess.SubprocessError):
         return True
-    if result.returncode != 0:
+    if default_branch.returncode != 0:
         return True
-    return not bool(result.stdout.strip())
+
+    default_ref = default_branch.stdout.strip()
+    if not default_ref:
+        return True
+
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", "HEAD", default_ref],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            **({"timeout": _reap_timeout(deadline)} if deadline is not None else {}),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    return result.returncode != 0
 
 
 def prune_worktrees(project_path: str, timeout: Optional[float] = None):

--- a/koan/diagnostics/project_check.py
+++ b/koan/diagnostics/project_check.py
@@ -172,10 +172,13 @@ def run(koan_root: str, instance_dir: str, full: bool = False) -> List[CheckResu
 def _base_branch(koan_root: str, project_name: str, project_path: str) -> str:
     """Return the branch git prep will try to check out for this project.
 
-    Mirrors prepare_project_branch(): an explicit project-level
-    git_auto_merge.base_branch wins, otherwise the remote's default branch is
-    detected. Reporting a different branch than prep uses would make this check
-    worse than useless.
+    Mirrors prepare_project_branch(), which resolves the branch through
+    get_project_auto_merge() — so a base_branch written once under `defaults:`
+    counts exactly as much as a per-project override, and only the hardcoded
+    "main" fallback is open to auto-detection. Resolving it any other way here
+    makes the check worse than useless: it would detach a developer's worktree
+    over a branch prep never wants, while missing the collision on the branch
+    prep actually checks out.
 
     Resolution is **local only**. `/doctor` without --full keeps every network
     probe out of the default path, and detect_remote_default_branch() falls
@@ -186,18 +189,31 @@ def _base_branch(koan_root: str, project_name: str, project_path: str) -> str:
     """
     from app.git_prep import (
         _find_project_entry,
+        _has_remote_tracking_ref,
+        get_project_auto_merge,
         get_upstream_remote,
         load_projects_config,
         local_remote_default_branch,
     )
 
-    config = load_projects_config(koan_root)
-    projects = (config or {}).get("projects", {}) or {}
-    project_config = _find_project_entry(projects, project_name) or {}
-    explicit = (project_config.get("git_auto_merge", {}) or {}).get("base_branch")
-    if explicit:
-        return explicit
+    config = load_projects_config(koan_root) or {}
+    branch = get_project_auto_merge(config, project_name).get("base_branch", "main")
+
+    projects = config.get("projects", {}) or {}
+    project_am = (
+        (_find_project_entry(projects, project_name) or {}).get("git_auto_merge", {})
+        or {}
+    )
+    defaults_am = (config.get("defaults", {}) or {}).get("git_auto_merge", {}) or {}
+    configured = bool(project_am.get("base_branch") or defaults_am.get("base_branch"))
+    if configured:
+        return branch
+
     remote = get_upstream_remote(project_path, project_name, koan_root)
+    # Same gate as prep: an unconfigured "main" that exists here is kept as-is;
+    # only when it has no tracking ref does prep look up the remote's default.
+    if _has_remote_tracking_ref(remote, branch, project_path):
+        return branch
     return local_remote_default_branch(remote, project_path) or ""
 
 

--- a/koan/diagnostics/project_check.py
+++ b/koan/diagnostics/project_check.py
@@ -1,15 +1,18 @@
 """
 Kōan diagnostic — Project health checks.
 
-Validates project paths, git repo status, and remote reachability.
-Remote checks are behind the --full flag (slow).
+Validates project paths, git repo status, worktree branch ownership, and remote
+reachability. Remote checks are behind the --full flag (slow).
 """
 
+import logging
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 
-from diagnostics import CheckResult
+from diagnostics import CheckResult, FixResult
+
+logger = logging.getLogger(__name__)
 
 
 def run(koan_root: str, instance_dir: str, full: bool = False) -> List[CheckResult]:
@@ -71,6 +74,39 @@ def run(koan_root: str, instance_dir: str, full: bool = False) -> List[CheckResu
             ))
             continue
 
+        # Check the base branch is not held hostage by another worktree
+        try:
+            holder = _branch_holder(koan_root, name, str(project_path))
+        except Exception as e:
+            logger.warning(
+                "Worktree collision check failed for project %s: %s",
+                name,
+                e,
+            )
+            results.append(CheckResult(
+                name=f"project_{name}_worktree",
+                severity="error",
+                message=f"Project '{name}' worktree collision check failed: {e}",
+                hint="Check logs and project git configuration before retrying /doctor",
+            ))
+            holder = None
+        if holder:
+            branch, holder_path = holder
+            results.append(CheckResult(
+                name=f"project_{name}_worktree",
+                severity="error",
+                message=(
+                    f"Project '{name}' base branch '{branch}' is held by another "
+                    f"worktree: {holder_path}"
+                ),
+                hint=(
+                    "Missions for this project fail in git prep until the branch is "
+                    "released. Run /doctor --fix, or detach it by hand: "
+                    f"git -C {holder_path} checkout --detach"
+                ),
+                fixable=True,
+            ))
+
         # Check for uncommitted changes on main (warn only)
         try:
             result = subprocess.run(
@@ -130,4 +166,105 @@ def run(koan_root: str, instance_dir: str, full: bool = False) -> List[CheckResu
                     message=f"Project '{name}' remote check failed: {e}",
                 ))
 
+    return results
+
+
+def _base_branch(koan_root: str, project_name: str, project_path: str) -> str:
+    """Return the branch git prep will try to check out for this project.
+
+    Mirrors prepare_project_branch(): an explicit project-level
+    git_auto_merge.base_branch wins, otherwise the remote's default branch is
+    detected. Reporting a different branch than prep uses would make this check
+    worse than useless.
+    """
+    from app.git_prep import (
+        _find_project_entry,
+        detect_remote_default_branch,
+        get_upstream_remote,
+        load_projects_config,
+    )
+
+    config = load_projects_config(koan_root)
+    projects = (config or {}).get("projects", {}) or {}
+    project_config = _find_project_entry(projects, project_name) or {}
+    explicit = (project_config.get("git_auto_merge", {}) or {}).get("base_branch")
+    if explicit:
+        return explicit
+    remote = get_upstream_remote(project_path, project_name, koan_root)
+    return detect_remote_default_branch(remote, project_path)
+
+
+def _branch_holder(
+    koan_root: str, project_name: str, project_path: str,
+) -> Optional[Tuple[str, str]]:
+    """Return (branch, worktree_path) when another worktree owns the base branch.
+
+    This is the shape that took 90 consecutive missions down: an agent ran
+    `git worktree add /tmp/base140 140`, and git allows a branch in at most one
+    worktree, so the project's own checkout could not return to it. Returns None
+    when nothing holds it, or when the holder is `locked` — that is someone's
+    live workspace, and neither the check nor the fix disturbs it.
+    """
+    branch = _base_branch(koan_root, project_name, project_path)
+    if not branch:
+        return None
+    from app.git_prep import _find_branch_holder
+    holder = _find_branch_holder(project_path, branch)
+    return (branch, holder) if holder else None
+
+
+def fix(koan_root: str, instance_dir: str) -> List[FixResult]:
+    """Detach any worktree holding a project's base branch.
+
+    Detach, never remove: this frees the branch while leaving the worktree, its
+    files and any uncommitted changes exactly where they are. Reclaiming the disk
+    belongs to the bridge's foreign-worktree sweep.
+    """
+    results: List[FixResult] = []
+    try:
+        from app.projects_config import get_projects_from_config, load_projects_config
+        config = load_projects_config(koan_root)
+    except Exception as e:
+        return [FixResult(
+            name="projects_load", success=False,
+            message=f"Could not load projects config: {e}",
+        )]
+    if config is None:
+        return results
+
+    for name, path in get_projects_from_config(config):
+        if not Path(path).is_dir():
+            continue
+        try:
+            holder = _branch_holder(koan_root, name, str(path))
+        except Exception as e:
+            logger.warning(
+                "Worktree collision fix check failed for project %s: %s",
+                name,
+                e,
+            )
+            results.append(FixResult(
+                name=f"project_{name}_worktree",
+                success=False,
+                message=f"Could not check worktree collision for {name}: {e}",
+            ))
+            continue
+        if not holder:
+            continue
+        branch, holder_path = holder
+        try:
+            from app.git_prep import _release_branch_from_worktree
+            freed = _release_branch_from_worktree(holder_path, branch)
+            detail = holder_path
+        except Exception as e:
+            freed, detail = False, f"{holder_path} ({e})"
+        results.append(FixResult(
+            name=f"project_{name}_worktree",
+            success=freed,
+            message=(
+                f"Detached {detail}, releasing '{branch}' for {name}"
+                if freed else
+                f"Could not detach {detail} holding '{branch}' for {name}"
+            ),
+        ))
     return results

--- a/koan/diagnostics/project_check.py
+++ b/koan/diagnostics/project_check.py
@@ -176,12 +176,19 @@ def _base_branch(koan_root: str, project_name: str, project_path: str) -> str:
     git_auto_merge.base_branch wins, otherwise the remote's default branch is
     detected. Reporting a different branch than prep uses would make this check
     worse than useless.
+
+    Resolution is **local only**. `/doctor` without --full keeps every network
+    probe out of the default path, and detect_remote_default_branch() falls
+    through to `git ls-remote` (15s, twice) whenever refs/remotes/<remote>/HEAD is
+    unset — which a `git init` + `remote add` + `fetch` project never sets. With up
+    to 50 projects that turns an interactive command into minutes. When the ref is
+    unset we return "" and the caller skips the check rather than going to the wire.
     """
     from app.git_prep import (
         _find_project_entry,
-        detect_remote_default_branch,
         get_upstream_remote,
         load_projects_config,
+        local_remote_default_branch,
     )
 
     config = load_projects_config(koan_root)
@@ -191,7 +198,7 @@ def _base_branch(koan_root: str, project_name: str, project_path: str) -> str:
     if explicit:
         return explicit
     remote = get_upstream_remote(project_path, project_name, koan_root)
-    return detect_remote_default_branch(remote, project_path)
+    return local_remote_default_branch(remote, project_path) or ""
 
 
 def _branch_holder(

--- a/koan/diagnostics/project_check.py
+++ b/koan/diagnostics/project_check.py
@@ -7,8 +7,9 @@ reachability. Remote checks are behind the --full flag (slow).
 
 import logging
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from diagnostics import CheckResult, FixResult
 
@@ -90,19 +91,52 @@ def run(koan_root: str, instance_dir: str, full: bool = False) -> List[CheckResu
                 hint="Check logs and project git configuration before retrying /doctor",
             ))
             holder = None
-        if holder:
-            branch, holder_path = holder
+        if holder and not holder.branch:
+            # The check never ran: no configured base branch, no tracking ref for
+            # "main", and refs/remotes/<remote>/HEAD unset. Say so — otherwise a
+            # permanently disabled check is indistinguishable from a clean repo.
+            results.append(CheckResult(
+                name=f"project_{name}_worktree",
+                severity="warn",
+                message=(
+                    f"Project '{name}' worktree collision check skipped: its base "
+                    "branch is not resolvable from local refs"
+                ),
+                hint=(
+                    "Run 'git remote set-head origin -a' in the project, or set "
+                    "git_auto_merge.base_branch in projects.yaml"
+                ),
+            ))
+        elif holder and holder.locked:
+            # git prep cannot heal this one — a locked worktree is deliberately
+            # left alone — so every mission keeps failing until a human acts.
             results.append(CheckResult(
                 name=f"project_{name}_worktree",
                 severity="error",
                 message=(
-                    f"Project '{name}' base branch '{branch}' is held by another "
-                    f"worktree: {holder_path}"
+                    f"Project '{name}' base branch '{holder.branch}' is held by a "
+                    f"locked worktree: {holder.holder}"
+                ),
+                hint=(
+                    "Missions for this project fail in git prep until the branch is "
+                    "released, and a locked worktree is never detached "
+                    "automatically. Release it by hand: git worktree unlock "
+                    f"{holder.holder} && git -C {holder.holder} checkout --detach"
+                ),
+                fixable=False,
+            ))
+        elif holder:
+            results.append(CheckResult(
+                name=f"project_{name}_worktree",
+                severity="error",
+                message=(
+                    f"Project '{name}' base branch '{holder.branch}' is held by "
+                    f"another worktree: {holder.holder}"
                 ),
                 hint=(
                     "Missions for this project fail in git prep until the branch is "
                     "released. Run /doctor --fix, or detach it by hand: "
-                    f"git -C {holder_path} checkout --detach"
+                    f"git -C {holder.holder} checkout --detach"
                 ),
                 fixable=True,
             ))
@@ -217,23 +251,43 @@ def _base_branch(koan_root: str, project_name: str, project_path: str) -> str:
     return local_remote_default_branch(remote, project_path) or ""
 
 
+@dataclass
+class _BaseBranchStatus:
+    """What /doctor found about the project's base branch.
+
+    ``branch`` is empty when it could not be resolved from local refs — that is
+    reportable in itself, because the check then never runs at all.
+    """
+
+    branch: str
+    holder: str = ""
+    locked: bool = False
+
+
 def _branch_holder(
     koan_root: str, project_name: str, project_path: str,
-) -> Optional[Tuple[str, str]]:
-    """Return (branch, worktree_path) when another worktree owns the base branch.
+) -> Optional[_BaseBranchStatus]:
+    """Return what is worth reporting about the base branch, else None.
 
-    This is the shape that took 90 consecutive missions down: an agent ran
-    `git worktree add /tmp/base140 140`, and git allows a branch in at most one
-    worktree, so the project's own checkout could not return to it. Returns None
-    when nothing holds it, or when the holder is `locked` — that is someone's
-    live workspace, and neither the check nor the fix disturbs it.
+    The collision is the shape that took 90 consecutive missions down: an agent
+    ran `git worktree add /tmp/base140 140`, and git allows a branch in at most
+    one worktree, so the project's own checkout could not return to it.
+
+    Three outcomes are reportable and each needs a different message:
+    a base branch that local refs cannot resolve (the check is a no-op and the
+    operator should know why), an unlocked holder (git prep self-heals it, and
+    `--fix` can too), and a **locked** holder — the one collision nothing
+    automates away, so it must never be silently dropped. None means the base
+    branch resolved and nothing holds it.
     """
     branch = _base_branch(koan_root, project_name, project_path)
     if not branch:
+        return _BaseBranchStatus(branch="")
+    from app.git_prep import _branch_holder_worktree
+    wt = _branch_holder_worktree(project_path, branch)
+    if wt is None or not wt.path:
         return None
-    from app.git_prep import _find_branch_holder
-    holder = _find_branch_holder(project_path, branch)
-    return (branch, holder) if holder else None
+    return _BaseBranchStatus(branch=branch, holder=wt.path, locked=bool(wt.locked))
 
 
 def fix(koan_root: str, instance_dir: str) -> List[FixResult]:
@@ -272,9 +326,11 @@ def fix(koan_root: str, instance_dir: str) -> List[FixResult]:
                 message=f"Could not check worktree collision for {name}: {e}",
             ))
             continue
-        if not holder:
+        if not holder or not holder.holder or holder.locked:
+            # Nothing to detach, or a locked workspace `run()` reports but never
+            # touches.
             continue
-        branch, holder_path = holder
+        branch, holder_path = holder.branch, holder.holder
         try:
             from app.git_prep import _release_branch_from_worktree
             freed = _release_branch_from_worktree(holder_path, branch)

--- a/koan/system-prompts/_partials/implementation-workflow.md
+++ b/koan/system-prompts/_partials/implementation-workflow.md
@@ -61,3 +61,4 @@ After each commit:
     - The PR title should be concise (under 70 characters).
     - In the footer, use the actual known provider/model/HEAD/duration when available. Omit unknown metadata fields rather than guessing.
 {@include pr-submit-fork}
+{@include temp-hygiene}

--- a/koan/system-prompts/_partials/temp-hygiene.md
+++ b/koan/system-prompts/_partials/temp-hygiene.md
@@ -8,3 +8,9 @@ mission ends. ALL scratch output must be created under it:
   `d=$(mktemp -d "${TMPDIR:-/tmp}/koan-<purpose>-XXXXXX")`
 - Never hardcode bare `/tmp/...` paths or fixed filenames — multiple Kōan instances
   may share this host, and anything created outside `$TMPDIR` is never cleaned up.
+- **Never `git worktree add` outside `$TMPDIR`.** A worktree also takes exclusive
+  ownership of whatever branch you check out into it, so
+  `git worktree add /tmp/base<branch> <branch>` locks that branch away from the
+  project's own checkout and every following mission fails before it starts. If you
+  need one, put it under `$TMPDIR` and detach it (`git worktree add --detach`), then
+  `git worktree remove` it before you finish.

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4165,39 +4165,41 @@ def test_periodic_compaction_disabled_when_interval_zero():
 
 
 def test_worktree_reap_fires_on_interval():
-    with patch("app.project_explorer.get_projects",
-               return_value=[("proj", "/srv/proj")]), \
-         patch("app.worktree_manager.reap_foreign_worktrees",
-               return_value=["/tmp/review-abc"]) as mock_reap, \
+    with patch("app.awake._run_in_worker", return_value=True) as mock_worker, \
          patch("app.awake.time.time", return_value=10_000.0):
         new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
-        mock_reap.assert_called_once_with("/srv/proj")
+        mock_worker.assert_called_once_with(awake._reap_worktrees, lane="maintenance")
         assert new_ts == 10_000.0
 
 
 def test_worktree_reap_skips_before_interval():
-    with patch("app.worktree_manager.reap_foreign_worktrees") as mock_reap, \
+    with patch("app.awake._run_in_worker") as mock_worker, \
          patch("app.awake.time.time", return_value=100.0):
         new_ts = awake._maybe_reap_worktrees(last_reap=90.0, interval=3600)
-        mock_reap.assert_not_called()
+        mock_worker.assert_not_called()
         assert new_ts == 90.0
 
 
 def test_worktree_reap_disabled_when_interval_zero():
-    with patch("app.worktree_manager.reap_foreign_worktrees") as mock_reap:
+    with patch("app.awake._run_in_worker") as mock_worker:
         new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=0)
-        mock_reap.assert_not_called()
+        mock_worker.assert_not_called()
+        assert new_ts == 0.0
+
+
+def test_worktree_reap_retries_when_maintenance_lane_is_busy():
+    with patch("app.awake._run_in_worker", return_value=False) as mock_worker, \
+         patch("app.awake.time.time", return_value=10_000.0):
+        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
+        mock_worker.assert_called_once_with(awake._reap_worktrees, lane="maintenance")
         assert new_ts == 0.0
 
 
 def test_worktree_reap_survives_errors():
     """A reap failure must never take the poll loop down."""
     with patch("app.project_explorer.get_projects",
-               side_effect=RuntimeError("config gone")), \
-         patch("app.awake.time.time", return_value=10_000.0):
-        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
-        # Timestamp still advances, so a persistent failure doesn't retry every cycle.
-        assert new_ts == 10_000.0
+               side_effect=RuntimeError("config gone")):
+        awake._reap_worktrees()
 
 
 def test_worktree_reap_continues_across_projects():
@@ -4205,11 +4207,9 @@ def test_worktree_reap_continues_across_projects():
     with patch("app.project_explorer.get_projects",
                return_value=[("a", "/srv/a"), ("b", "/srv/b")]), \
          patch("app.worktree_manager.reap_foreign_worktrees",
-               side_effect=[RuntimeError("bad repo"), ["/tmp/review-b"]]) as mock_reap, \
-         patch("app.awake.time.time", return_value=10_000.0):
-        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
+               side_effect=[RuntimeError("bad repo"), ["/tmp/review-b"]]) as mock_reap:
+        awake._reap_worktrees()
         assert [c.args[0] for c in mock_reap.call_args_list] == ["/srv/a", "/srv/b"]
-        assert new_ts == 10_000.0
 
 
 def test_read_sections_cached_serves_within_ttl():

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4196,10 +4196,19 @@ def test_worktree_reap_retries_when_maintenance_lane_is_busy():
 
 
 def test_worktree_reap_survives_errors():
-    """A reap failure must never take the poll loop down."""
+    """A failed sweep must be logged, not lost to the worker thread's excepthook.
+
+    The sweep runs detached on the maintenance lane, so an escaping exception would reach
+    threading.excepthook and produce no koan log entry — a reaper that has been broken for
+    weeks would be indistinguishable from one with nothing to do.
+    """
     with patch("app.project_explorer.get_projects",
-               side_effect=RuntimeError("config gone")):
+               side_effect=RuntimeError("config gone")), \
+         patch("app.awake.log") as mock_log:
         awake._reap_worktrees()
+
+    errors = [c.args[1] for c in mock_log.call_args_list if c.args[0] == "error"]
+    assert any("config gone" in message for message in errors)
 
 
 def test_worktree_reap_continues_across_projects():

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4212,6 +4212,18 @@ def test_worktree_reap_continues_across_projects():
         assert [c.args[0] for c in mock_reap.call_args_list] == ["/srv/a", "/srv/b"]
 
 
+def test_worktree_reap_stops_after_shared_budget():
+    with patch("app.project_explorer.get_projects",
+               return_value=[("a", "/srv/a"), ("b", "/srv/b")]), \
+         patch("app.worktree_manager.reap_foreign_worktrees") as mock_reap, \
+         patch("app.awake.time.time", return_value=7200.0), \
+         patch("app.awake.time.monotonic", side_effect=[0.0, 0.0, 121.0, 121.0]):
+        awake._reap_worktrees()
+
+    mock_reap.assert_called_once()
+    assert mock_reap.call_args.kwargs["deadline"] == 120.0
+
+
 def test_read_sections_cached_serves_within_ttl():
     awake._sections_cache["ts"] = 0.0
     awake._sections_cache["value"] = None

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4212,9 +4212,14 @@ def test_worktree_reap_survives_errors():
 
 
 def test_worktree_reap_continues_across_projects():
-    """One project's failure must not stop the others being swept."""
+    """One project's failure must not stop the others being swept.
+
+    time.time() is pinned because the sweep rotates its project order by the hour, so an
+    unpinned clock makes the expected order flip every hour. 7200.0 gives rotation 0.
+    """
     with patch("app.project_explorer.get_projects",
                return_value=[("a", "/srv/a"), ("b", "/srv/b")]), \
+         patch("app.awake.time.time", return_value=7200.0), \
          patch("app.worktree_manager.reap_foreign_worktrees",
                side_effect=[RuntimeError("bad repo"), ["/tmp/review-b"]]) as mock_reap:
         awake._reap_worktrees()

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4189,10 +4189,38 @@ def test_worktree_reap_disabled_when_interval_zero():
 
 def test_worktree_reap_retries_when_maintenance_lane_is_busy():
     with patch("app.awake._run_in_worker", return_value=False) as mock_worker, \
+         patch("app.awake._worktree_reap_busy_logged_at", 10_000.0), \
          patch("app.awake.time.time", return_value=10_000.0):
         new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
         mock_worker.assert_called_once_with(awake._reap_worktrees, lane="maintenance")
         assert new_ts == 0.0
+
+
+def test_worktree_reap_reports_a_persistently_busy_maintenance_lane():
+    """A wedged sweep thread must not be silent.
+
+    Without this, a stuck maintenance worker makes reaping stop forever while the
+    logs look exactly like a healthy idle system.
+    """
+    with patch("app.awake._run_in_worker", return_value=False), \
+         patch("app.awake._worktree_reap_busy_logged_at", 0.0), \
+         patch("app.awake.time.time", return_value=10_000.0), \
+         patch("app.awake.log") as mock_log:
+        awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
+
+    errors = [c.args[1] for c in mock_log.call_args_list if c.args[0] == "error"]
+    assert any("maintenance lane is still busy" in message for message in errors)
+
+
+def test_worktree_reap_stays_quiet_when_the_lane_is_only_briefly_busy():
+    """One missed start is normal back-pressure, not a failure worth logging."""
+    with patch("app.awake._run_in_worker", return_value=False), \
+         patch("app.awake._worktree_reap_busy_logged_at", 0.0), \
+         patch("app.awake.time.time", return_value=5_000.0), \
+         patch("app.awake.log") as mock_log:
+        awake._maybe_reap_worktrees(last_reap=1_000.0, interval=3600)
+
+    assert not [c for c in mock_log.call_args_list if c.args[0] == "error"]
 
 
 def test_worktree_reap_survives_errors():

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4137,6 +4137,18 @@ def test_watchdog_skips_restart_when_worker_busy():
         assert awake._bridge_should_restart(monitor) is False
 
 
+def test_watchdog_restarts_while_maintenance_sweep_runs():
+    """A wedged maintenance sweep must not disable the memory watchdog."""
+    monitor = MagicMock()
+    monitor.sample.return_value = True
+    alive = MagicMock()
+    alive.is_alive.return_value = True
+    lanes = {"chat": None, "bg": None, "maintenance": alive}
+    with patch.dict(awake._worker_threads, lanes, clear=True):
+        assert awake._workers_idle() is True
+        assert awake._bridge_should_restart(monitor) is True
+
+
 def test_watchdog_no_monitor_never_restarts():
     assert awake._bridge_should_restart(None) is False
 

--- a/koan/tests/test_awake_worker_lanes.py
+++ b/koan/tests/test_awake_worker_lanes.py
@@ -10,7 +10,7 @@ import app.command_handlers as ch
 @pytest.fixture(autouse=True)
 def _reset_lanes():
     # Ensure each test starts with empty lanes and no leftover live thread.
-    awake._worker_threads = {"chat": None, "bg": None}
+    awake._worker_threads = {"chat": None, "bg": None, "maintenance": None}
     yield
     for t in awake._worker_threads.values():
         if t is not None and t.is_alive():
@@ -38,6 +38,28 @@ def test_chat_and_bg_run_concurrently():
     assert bg_ran.wait(timeout=2), "bg lane was blocked by busy chat lane"
 
     release_chat.set()
+
+
+def test_maintenance_does_not_block_chat():
+    """A worktree sweep must never delay an interactive reply."""
+    maintenance_started = threading.Event()
+    release_maintenance = threading.Event()
+    chat_ran = threading.Event()
+
+    def maintenance_task():
+        maintenance_started.set()
+        release_maintenance.wait(timeout=2)
+
+    def chat_task():
+        chat_ran.set()
+
+    awake._run_in_worker(maintenance_task, lane="maintenance")
+    assert maintenance_started.wait(timeout=2), "maintenance lane never started"
+
+    awake._run_in_worker(chat_task, lane="chat")
+    assert chat_ran.wait(timeout=2), "chat lane was blocked by maintenance"
+
+    release_maintenance.set()
 
 
 def test_busy_chat_lane_sends_busy_message():

--- a/koan/tests/test_diagnostics.py
+++ b/koan/tests/test_diagnostics.py
@@ -913,3 +913,28 @@ class TestProjectWorktreeCollision:
         assert "cannot inspect worktrees" in hits[0].message
         assert len(fixes) == 1 and fixes[0].success is False
         assert "cannot inspect worktrees" in fixes[0].message
+
+    def test_base_branch_resolution_stays_local(self, tmp_path):
+        """/doctor without --full must not reach the network.
+
+        A repo built with `git init` + `remote add` + `fetch` never sets
+        refs/remotes/origin/HEAD, and the full detection then falls through to
+        `git ls-remote` (15s, twice) per project. With up to 50 projects that turns
+        an interactive command into minutes, so resolution stops at local refs and
+        the check is skipped instead.
+        """
+        from diagnostics import project_check
+        repo, _ = self._repo(tmp_path)
+        with patch(
+            "app.projects_config.load_projects_config",
+            return_value={"projects": {"p": {"path": repo}}},
+        ), patch(
+            "app.projects_config.get_projects_from_config", return_value=[("p", repo)],
+        ), patch("app.git_prep.run_git") as mock_git:
+            mock_git.return_value = (1, "", "not a symbolic ref")
+            results = project_check.run("/koan", "/koan/instance")
+
+        assert [r for r in results if r.name.endswith("_worktree")] == []
+        assert not any(
+            c.args and c.args[0] == "ls-remote" for c in mock_git.call_args_list
+        )

--- a/koan/tests/test_diagnostics.py
+++ b/koan/tests/test_diagnostics.py
@@ -779,3 +779,137 @@ class TestInstanceCheckFix:
 
         results = fix(str(tmp_path), str(tmp_path / "nonexistent"))
         assert len(results) == 0
+
+
+class TestProjectWorktreeCollision:
+    """/doctor surfaces — and can repair — a base branch held by another worktree.
+
+    An agent running `git worktree add /tmp/base140 140` takes the branch away
+    from the project's own checkout. Git prep self-heals this now, but the check
+    gives an operator a way to see and clear it without waiting for a mission.
+    """
+
+    @staticmethod
+    def _repo(tmp_path):
+        """A real repo whose base branch is held by a second worktree."""
+        import subprocess
+        repo = tmp_path / "proj"
+        repo.mkdir()
+        run = lambda *a: subprocess.run(  # noqa: E731 - terse test helper
+            a, cwd=str(repo), capture_output=True, check=True,
+        )
+        subprocess.run(["git", "init", "-b", "main", str(repo)], capture_output=True, check=True)
+        run("git", "config", "user.email", "t@t")
+        run("git", "config", "user.name", "T")
+        run("git", "commit", "--allow-empty", "-m", "init")
+        run("git", "checkout", "--detach")
+        run("git", "worktree", "add", str(tmp_path / "holder"), "main")
+        return str(repo), str(tmp_path / "holder")
+
+    def _patched(self, repo):
+        """Point the diagnostic at our scratch repo with 'main' as the base."""
+        from contextlib import ExitStack
+        from unittest.mock import patch
+        stack = ExitStack()
+        stack.enter_context(patch(
+            "app.projects_config.load_projects_config",
+            return_value={"projects": {"p": {"path": repo}}},
+        ))
+        stack.enter_context(patch(
+            "app.projects_config.get_projects_from_config",
+            return_value=[("p", repo)],
+        ))
+        stack.enter_context(patch(
+            "diagnostics.project_check._base_branch", return_value="main",
+        ))
+        return stack
+
+    def test_reports_the_collision_as_fixable(self, tmp_path):
+        from diagnostics import project_check
+        repo, holder = self._repo(tmp_path)
+        with self._patched(repo):
+            results = project_check.run("/koan", "/koan/instance")
+
+        hits = [r for r in results if r.name.endswith("_worktree")]
+        assert len(hits) == 1
+        assert hits[0].severity == "error"
+        assert hits[0].fixable is True
+        assert holder in hits[0].message
+
+    def test_fix_detaches_the_holder(self, tmp_path):
+        import subprocess
+        from diagnostics import project_check
+        repo, holder = self._repo(tmp_path)
+        with self._patched(repo):
+            fixes = project_check.fix("/koan", "/koan/instance")
+
+        assert len(fixes) == 1 and fixes[0].success is True
+        # The branch is free again and the holder still exists, merely detached.
+        assert Path(holder).is_dir()
+        head = subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            cwd=holder, capture_output=True, text=True,
+        )
+        assert head.returncode != 0, "holder should be detached"
+        subprocess.run(["git", "checkout", "main"], cwd=repo, capture_output=True, check=True)
+
+    def test_fix_preserves_uncommitted_work_in_the_holder(self, tmp_path):
+        from diagnostics import project_check
+        repo, holder = self._repo(tmp_path)
+        (Path(holder) / "WIP.txt").write_text("not saved anywhere\n")
+        with self._patched(repo):
+            fixes = project_check.fix("/koan", "/koan/instance")
+
+        assert fixes[0].success is True
+        assert (Path(holder) / "WIP.txt").read_text() == "not saved anywhere\n"
+
+    def test_clean_project_reports_nothing(self, tmp_path):
+        import subprocess
+        from diagnostics import project_check
+        repo, holder = self._repo(tmp_path)
+        subprocess.run(
+            ["git", "checkout", "--detach"], cwd=holder, capture_output=True, check=True,
+        )
+        with self._patched(repo):
+            results = project_check.run("/koan", "/koan/instance")
+            fixes = project_check.fix("/koan", "/koan/instance")
+
+        assert [r for r in results if r.name.endswith("_worktree")] == []
+        assert fixes == []
+
+    def test_locked_holder_is_reported_by_neither(self, tmp_path):
+        """A locked worktree is someone's live workspace — never auto-detached."""
+        import subprocess
+        from diagnostics import project_check
+        repo, holder = self._repo(tmp_path)
+        subprocess.run(
+            ["git", "worktree", "lock", holder], cwd=repo, capture_output=True, check=True,
+        )
+        try:
+            with self._patched(repo):
+                results = project_check.run("/koan", "/koan/instance")
+                fixes = project_check.fix("/koan", "/koan/instance")
+            assert [r for r in results if r.name.endswith("_worktree")] == []
+            assert fixes == []
+        finally:
+            subprocess.run(
+                ["git", "worktree", "unlock", holder],
+                cwd=repo, capture_output=True, check=True,
+            )
+
+    def test_detection_failure_is_reported(self, tmp_path):
+        from diagnostics import project_check
+        repo, _ = self._repo(tmp_path)
+        with self._patched(repo), patch(
+            "diagnostics.project_check._branch_holder",
+            side_effect=RuntimeError("cannot inspect worktrees"),
+        ):
+            results = project_check.run("/koan", "/koan/instance")
+            fixes = project_check.fix("/koan", "/koan/instance")
+
+        hits = [r for r in results if r.name.endswith("_worktree")]
+        assert len(hits) == 1
+        assert hits[0].severity == "error"
+        assert "cannot inspect worktrees" in hits[0].message
+        assert len(fixes) == 1 and fixes[0].success is False
+        assert "cannot inspect worktrees" in fixes[0].message

--- a/koan/tests/test_diagnostics.py
+++ b/koan/tests/test_diagnostics.py
@@ -938,3 +938,91 @@ class TestProjectWorktreeCollision:
         assert not any(
             c.args and c.args[0] == "ls-remote" for c in mock_git.call_args_list
         )
+
+    @staticmethod
+    def _repo_with_two_branches(tmp_path):
+        """Repo with 'main' and 'develop', both parked in their own worktree."""
+        repo = tmp_path / "proj"
+        repo.mkdir()
+        run = lambda *a: subprocess.run(  # noqa: E731 - terse test helper
+            a, cwd=str(repo), capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "init", "-b", "main", str(repo)], capture_output=True, check=True,
+        )
+        run("git", "config", "user.email", "t@t")
+        run("git", "config", "user.name", "T")
+        run("git", "commit", "--allow-empty", "-m", "init")
+        run("git", "branch", "develop")
+        # A remote whose default branch is 'main' — the answer the check must
+        # NOT use once `defaults:` configures 'develop'.
+        run("git", "update-ref", "refs/remotes/origin/main", "HEAD")
+        run(
+            "git", "symbolic-ref", "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+        )
+        run("git", "checkout", "--detach")
+        run("git", "worktree", "add", str(tmp_path / "on-main"), "main")
+        run("git", "worktree", "add", str(tmp_path / "on-develop"), "develop")
+        return str(repo), str(tmp_path / "on-main"), str(tmp_path / "on-develop")
+
+    def _patched_config(self, repo, config):
+        from contextlib import ExitStack
+        from unittest.mock import patch
+        stack = ExitStack()
+        stack.enter_context(patch(
+            "app.projects_config.load_projects_config", return_value=config,
+        ))
+        stack.enter_context(patch(
+            "app.git_prep.load_projects_config", return_value=config,
+        ))
+        stack.enter_context(patch(
+            "app.projects_config.get_projects_from_config", return_value=[("p", repo)],
+        ))
+        return stack
+
+    def test_defaults_base_branch_is_the_branch_reported(self, tmp_path):
+        """A base_branch set only under `defaults:` is what git prep checks out.
+
+        projects_config deep-merges `defaults:` into every project entry, so
+        prepare_project_branch() wants 'develop' here. Reporting 'main' instead
+        would flag — and `--fix` would detach — a worktree that never blocked a
+        mission, while missing the one actually holding the base branch.
+        """
+        from diagnostics import project_check
+        repo, on_main, on_develop = self._repo_with_two_branches(tmp_path)
+        config = {
+            "defaults": {"git_auto_merge": {"base_branch": "develop"}},
+            "projects": {"p": {"path": repo}},
+        }
+        with self._patched_config(repo, config):
+            results = project_check.run("/koan", "/koan/instance")
+
+        hits = [r for r in results if r.name.endswith("_worktree")]
+        assert len(hits) == 1
+        assert "'develop'" in hits[0].message
+        assert on_develop in hits[0].message
+        assert on_main not in hits[0].message
+
+    def test_defaults_base_branch_does_not_detach_an_unrelated_worktree(self, tmp_path):
+        """--fix must leave the 'main' holder alone when prep wants 'develop'."""
+        from diagnostics import project_check
+        repo, on_main, on_develop = self._repo_with_two_branches(tmp_path)
+        config = {
+            "defaults": {"git_auto_merge": {"base_branch": "develop"}},
+            "projects": {"p": {"path": repo}},
+        }
+        with self._patched_config(repo, config):
+            fixes = project_check.fix("/koan", "/koan/instance")
+
+        assert len(fixes) == 1 and fixes[0].success is True
+        assert on_develop in fixes[0].message
+
+        def head_of(wt):
+            return subprocess.run(
+                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                cwd=wt, capture_output=True, text=True,
+            )
+
+        assert head_of(on_main).stdout.strip() == "main", "unrelated worktree detached"
+        assert head_of(on_develop).returncode != 0, "develop holder should be detached"

--- a/koan/tests/test_diagnostics.py
+++ b/koan/tests/test_diagnostics.py
@@ -877,8 +877,13 @@ class TestProjectWorktreeCollision:
         assert [r for r in results if r.name.endswith("_worktree")] == []
         assert fixes == []
 
-    def test_locked_holder_is_reported_by_neither(self, tmp_path):
-        """A locked worktree is someone's live workspace — never auto-detached."""
+    def test_locked_holder_is_reported_but_never_detached(self, tmp_path):
+        """A locked worktree is someone's live workspace — never auto-detached.
+
+        It is also the one collision git prep cannot heal, so every mission for
+        the project fails until a human acts: reporting it is the whole point of
+        the check.
+        """
         import subprocess
         from diagnostics import project_check
         repo, holder = self._repo(tmp_path)
@@ -889,7 +894,12 @@ class TestProjectWorktreeCollision:
             with self._patched(repo):
                 results = project_check.run("/koan", "/koan/instance")
                 fixes = project_check.fix("/koan", "/koan/instance")
-            assert [r for r in results if r.name.endswith("_worktree")] == []
+            hits = [r for r in results if r.name.endswith("_worktree")]
+            assert len(hits) == 1
+            assert hits[0].severity == "error"
+            assert hits[0].fixable is False
+            assert holder in hits[0].message
+            assert "git worktree unlock" in hits[0].hint
             assert fixes == []
         finally:
             subprocess.run(
@@ -934,10 +944,31 @@ class TestProjectWorktreeCollision:
             mock_git.return_value = (1, "", "not a symbolic ref")
             results = project_check.run("/koan", "/koan/instance")
 
-        assert [r for r in results if r.name.endswith("_worktree")] == []
         assert not any(
             c.args and c.args[0] == "ls-remote" for c in mock_git.call_args_list
         )
+        # Skipping is fine; skipping silently is not — a check that can never
+        # fire must not look like a clean bill of health.
+        hits = [r for r in results if r.name.endswith("_worktree")]
+        assert len(hits) == 1
+        assert hits[0].severity == "warn"
+        assert "skipped" in hits[0].message
+        assert "git remote set-head" in hits[0].hint
+
+    def test_unresolvable_base_branch_is_not_fixed(self, tmp_path):
+        """The skip warning is informational — --fix has nothing to detach."""
+        from diagnostics import project_check
+        repo, _ = self._repo(tmp_path)
+        with patch(
+            "app.projects_config.load_projects_config",
+            return_value={"projects": {"p": {"path": repo}}},
+        ), patch(
+            "app.projects_config.get_projects_from_config", return_value=[("p", repo)],
+        ), patch("app.git_prep.run_git") as mock_git:
+            mock_git.return_value = (1, "", "not a symbolic ref")
+            fixes = project_check.fix("/koan", "/koan/instance")
+
+        assert fixes == []
 
     @staticmethod
     def _repo_with_two_branches(tmp_path):

--- a/koan/tests/test_git_prep.py
+++ b/koan/tests/test_git_prep.py
@@ -157,6 +157,25 @@ class TestDetectRemoteDefaultBranch:
             result = detect_remote_default_branch("origin", "/proj")
         assert result == "main"
 
+    def test_resolve_returns_none_when_resolution_is_exhausted(self):
+        """The strict variant never guesses 'main' — callers must see the failure."""
+        from app.git_prep import resolve_remote_default_branch
+
+        with patch("app.git_prep.run_git", return_value=(1, "", "error")):
+            assert resolve_remote_default_branch("origin", "/proj") is None
+
+    def test_local_variant_never_touches_the_network(self):
+        """Local-only resolution reads the symbolic ref and stops there."""
+        from app.git_prep import local_remote_default_branch
+
+        def side_effect(*args, **kwargs):
+            if args[0] == "symbolic-ref":
+                return (1, "", "not a symbolic ref")
+            raise AssertionError(f"unexpected network-capable call: {args}")
+
+        with patch("app.git_prep.run_git", side_effect=side_effect):
+            assert local_remote_default_branch("origin", "/proj") is None
+
 
 # --- HTTPS token fallback helpers ---
 
@@ -1667,10 +1686,10 @@ class TestPrepareProjectBranchSelfHeal:
 class TestBaseBranchResolvedBeforeFetch:
     """A project with no pinned base branch must not pay for a doomed fetch.
 
-    `cp` sets issue_tracker.default_branch "140" but no
-    git_auto_merge.base_branch, so base_branch fell back to the generic "main"
-    and every single mission fetched a branch that does not exist before
-    discovering "140" and fetching again.
+    A project setting issue_tracker.default_branch to a release branch ("140"
+    here) but no git_auto_merge.base_branch had base_branch fall back to the
+    generic "main", so every single mission fetched a branch that does not exist
+    before discovering "140" and fetching again.
     """
 
     @staticmethod
@@ -1729,3 +1748,39 @@ class TestBaseBranchResolvedBeforeFetch:
         assert "main" in fetches[0], "configured branch must be tried first"
         assert result.success is True
         assert result.base_branch == "140"
+
+    def test_failed_detection_never_overrides_the_configured_branch(self):
+        """An unreachable remote must not promote the "main" guess to an answer.
+
+        detect_remote_default_branch() falls back to "main" when the symbolic ref
+        and ls-remote both fail. Taking that fallback as a detection would rewrite
+        a correct configured branch (say "master") to "main" and point the
+        operator's investigation at a branch they never configured, instead of at
+        the unreachable remote.
+        """
+        calls = []
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            calls.append(args)
+            if cmd == "rev-parse":
+                if "--verify" in args:
+                    return (1, "", "")  # no remote-tracking ref for the base branch
+                return (0, "feature", "")
+            if cmd in ("symbolic-ref", "ls-remote", "remote"):
+                return (1, "", "fatal: unable to access remote")
+            return (0, "", "")
+
+        stack, _ = TestPrepareProjectBranch()._patch_all(
+            run_git_side_effect=side_effect,
+            # Project entry with no git_auto_merge → the "master" base branch comes
+            # from defaults, so config_explicit is False and detection may run.
+            config={"projects": {"myproj": {}}},
+            auto_merge={"base_branch": "master"},
+        )
+        with stack:
+            result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.base_branch == "master"
+        fetches = [c for c in calls if c and c[0] == "fetch"]
+        assert fetches and "master" in fetches[0]

--- a/koan/tests/test_git_prep.py
+++ b/koan/tests/test_git_prep.py
@@ -1749,6 +1749,45 @@ class TestBaseBranchResolvedBeforeFetch:
         assert result.success is True
         assert result.base_branch == "140"
 
+    def test_defaults_branch_without_a_tracking_ref_is_still_fetched_first(self):
+        """A `defaults:` base branch is configured; an absent tracking ref is not proof.
+
+        `refs/remotes/<remote>/develop` is missing on a fresh clone until something
+        fetches it, but the branch exists on the remote. Overriding it pre-fetch with
+        the remote's default would branch the mission off the wrong base and open its
+        PR against the wrong base, until some unrelated command created the ref.
+        """
+        calls = []
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            calls.append(args)
+            if cmd == "rev-parse":
+                if "--verify" in args:
+                    return (1, "", "")  # develop has no remote-tracking ref yet
+                return (0, "feature", "")
+            if cmd == "symbolic-ref":
+                return (0, "refs/remotes/origin/main", "")
+            # The fetch of develop succeeds — the branch exists on the remote.
+            return (0, "", "")
+
+        stack, _ = TestPrepareProjectBranch()._patch_all(
+            run_git_side_effect=side_effect,
+            config={
+                "defaults": {"git_auto_merge": {"base_branch": "develop"}},
+                "projects": {"myproj": {}},
+            },
+            auto_merge={"base_branch": "develop"},
+        )
+        with stack:
+            result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is True
+        assert result.base_branch == "develop"
+        fetches = [c for c in calls if c and c[0] == "fetch"]
+        assert len(fetches) == 1, f"expected one fetch, got {len(fetches)}"
+        assert "develop" in fetches[0]
+
     def test_failed_detection_never_overrides_the_configured_branch(self):
         """An unreachable remote must not promote the "main" guess to an answer.
 

--- a/koan/tests/test_git_prep.py
+++ b/koan/tests/test_git_prep.py
@@ -529,6 +529,157 @@ def _make_run_git_side_effect(overrides=None):
     return side_effect
 
 
+# The exact stderr git emits when another worktree owns the branch. Hard-coded
+# from a live reproduction, not from memory — mis-remembering it is precisely
+# how this fault stayed invisible for 92 logged failures.
+HELD_BRANCH_STDERR = "fatal: 'main' is already used by worktree at '/tmp/base-main'"
+BRANCH_EXISTS_STDERR = "fatal: a branch named 'main' already exists"
+
+
+def _worktree(path, branch, *, is_main=False, locked=False):
+    """Build a WorktreeInfo the way list_worktrees() would."""
+    from app.worktree_manager import WorktreeInfo
+    return WorktreeInfo(
+        path=path, branch=branch, session_id="", project_path="/proj",
+        commit="abc123", is_main=is_main, locked=locked,
+    )
+
+
+def _checkout_blocked_once():
+    """run_git side effect: `checkout <base>` fails until the branch is freed.
+
+    `checkout --detach` (run in the holder) flips the gate, so the retry after a
+    successful detach succeeds — mirroring what git actually does.
+    """
+    state = {"held": True}
+
+    def side_effect(*args, **kwargs):
+        cmd = args[0] if args else ""
+        if cmd == "checkout":
+            if "--detach" in args:
+                state["held"] = False
+                return (0, "", "")
+            if "-b" in args:
+                return (1, "", BRANCH_EXISTS_STDERR)
+            if state["held"]:
+                return (1, "", HELD_BRANCH_STDERR)
+            return (0, "", "")
+        return _make_run_git_side_effect()(*args, **kwargs)
+
+    return side_effect
+
+
+class TestBranchHeldByAnotherWorktree:
+    """Prep recovers when another worktree owns the base branch.
+
+    Git checks a branch out in at most one worktree. An agent that runs
+    `git worktree add /tmp/base140 140` takes the branch away from the main
+    checkout, and every following mission dies in prep until it is given back.
+    """
+
+    def test_detaches_holder_and_retries(self):
+        """The holding worktree is detached, then checkout succeeds."""
+        holder = _worktree("/tmp/base-main", "main")
+        with patch("app.worktree_manager.list_worktrees", return_value=[holder]):
+            stack, mocks = TestPrepareProjectBranch()._patch_all(
+                run_git_side_effect=_checkout_blocked_once(),
+            )
+            with stack:
+                result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is True
+        assert result.error is None
+        assert "/tmp/base-main" in result.healed
+        # The detach ran inside the holder, never in the project.
+        detach = [
+            c for c in mocks["run_git"].call_args_list
+            if c.args[:2] == ("checkout", "--detach")
+        ]
+        assert len(detach) == 1
+        assert detach[0].kwargs["cwd"] == "/tmp/base-main"
+
+    def test_locked_holder_is_never_detached(self):
+        """A locked worktree is someone's live workspace — leave it alone."""
+        holder = _worktree("/tmp/base-main", "main", locked=True)
+        with patch("app.worktree_manager.list_worktrees", return_value=[holder]):
+            stack, mocks = TestPrepareProjectBranch()._patch_all(
+                run_git_side_effect=_checkout_blocked_once(),
+            )
+            with stack:
+                result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is False
+        assert not any(
+            c.args[:2] == ("checkout", "--detach")
+            for c in mocks["run_git"].call_args_list
+        )
+
+    def test_main_worktree_is_never_the_holder(self):
+        """The project's own checkout holding the branch is not a collision."""
+        from app.git_prep import _find_branch_holder
+        main_wt = _worktree("/proj", "main", is_main=True)
+        with patch("app.worktree_manager.list_worktrees", return_value=[main_wt]):
+            assert _find_branch_holder("/proj", "main") is None
+
+    def test_error_keeps_the_first_checkout_message(self):
+        """The fallback's error must not overwrite the one naming the holder.
+
+        Regression guard for the outage: the `checkout -b` fallback reported
+        "a branch named 'main' already exists", which replaced the only message
+        that named the blocking worktree. Both must survive.
+        """
+        holder = _worktree("/tmp/base-main", "main", locked=True)
+        with patch("app.worktree_manager.list_worktrees", return_value=[holder]):
+            stack, _ = TestPrepareProjectBranch()._patch_all(
+                run_git_side_effect=_checkout_blocked_once(),
+            )
+            with stack:
+                result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert "already used by worktree at" in result.error
+        assert "/tmp/base-main" in result.error
+        assert "already exists" in result.error
+
+    def test_no_holder_falls_back_to_creating_the_branch(self):
+        """Nothing holding the branch: the create-from-remote path is unchanged."""
+        with patch("app.worktree_manager.list_worktrees", return_value=[]):
+            side_effect = _make_run_git_side_effect({
+                "checkout": (0, "", ""),
+            })
+            stack, mocks = TestPrepareProjectBranch()._patch_all(
+                run_git_side_effect=side_effect,
+            )
+            with stack:
+                result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is True
+        assert result.healed is None
+
+    def test_detach_failure_still_reports_both_errors(self):
+        """If the detach itself fails, prep degrades to the old fallback."""
+        holder = _worktree("/tmp/base-main", "main")
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            if cmd == "checkout":
+                if "--detach" in args:
+                    return (1, "", "fatal: could not detach")
+                if "-b" in args:
+                    return (1, "", BRANCH_EXISTS_STDERR)
+                return (1, "", HELD_BRANCH_STDERR)
+            return _make_run_git_side_effect()(*args, **kwargs)
+
+        with patch("app.worktree_manager.list_worktrees", return_value=[holder]):
+            stack, _ = TestPrepareProjectBranch()._patch_all(
+                run_git_side_effect=side_effect,
+            )
+            with stack:
+                result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is False
+        assert "already used by worktree at" in result.error
+
+
 class TestPrepareProjectBranch:
     """Tests for prepare_project_branch()."""
 
@@ -1512,3 +1663,69 @@ class TestPrepareProjectBranchSelfHeal:
             prepare_project_branch("/koan", "koan", "/koan")
         mh.assert_not_called()
 
+
+class TestBaseBranchResolvedBeforeFetch:
+    """A project with no pinned base branch must not pay for a doomed fetch.
+
+    `cp` sets issue_tracker.default_branch "140" but no
+    git_auto_merge.base_branch, so base_branch fell back to the generic "main"
+    and every single mission fetched a branch that does not exist before
+    discovering "140" and fetching again.
+    """
+
+    @staticmethod
+    def _side_effect(calls, *, main_ref_exists):
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            calls.append(args)
+            if cmd == "rev-parse":
+                if "--verify" in args:
+                    ref = args[-1]
+                    exists = ref.endswith("/140") or (
+                        main_ref_exists and ref.endswith("/main")
+                    )
+                    return (0, "sha", "") if exists else (1, "", "")
+                return (0, "feature", "")
+            if cmd == "fetch":
+                target = args[-1] if args else ""
+                return (0, "", "") if target == "140" else (
+                    1, "", "fatal: couldn't find remote ref main"
+                )
+            if cmd == "symbolic-ref":
+                return (0, "refs/remotes/origin/140", "")
+            if cmd == "remote":
+                return (1, "", "no such remote")
+            return (0, "", "")
+        return side_effect
+
+    def test_detects_before_fetching_when_default_ref_is_absent(self):
+        """Only one fetch runs, and it targets the real default branch."""
+        calls = []
+        stack, _ = TestPrepareProjectBranch()._patch_all(
+            run_git_side_effect=self._side_effect(calls, main_ref_exists=False),
+        )
+        with stack:
+            result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is True
+        assert result.base_branch == "140"
+        fetches = [c for c in calls if c and c[0] == "fetch"]
+        assert len(fetches) == 1, f"expected one fetch, got {len(fetches)}"
+        assert "main" not in fetches[0]
+
+    def test_configured_branch_that_exists_is_not_second_guessed(self):
+        """A working base branch is fetched directly; no detection runs."""
+        calls = []
+        stack, _ = TestPrepareProjectBranch()._patch_all(
+            run_git_side_effect=self._side_effect(calls, main_ref_exists=True),
+        )
+        with stack:
+            result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        # The configured branch has a remote-tracking ref, so prep fetches it
+        # first rather than overriding it with a detected default. Only when
+        # that fetch fails does the pre-existing detect-after-failure path run.
+        fetches = [c for c in calls if c and c[0] == "fetch"]
+        assert "main" in fetches[0], "configured branch must be tried first"
+        assert result.success is True
+        assert result.base_branch == "140"

--- a/koan/tests/test_git_prep.py
+++ b/koan/tests/test_git_prep.py
@@ -681,6 +681,27 @@ class TestBranchHeldByAnotherWorktree:
         with patch("app.worktree_manager.list_worktrees", return_value=[main_wt]):
             assert _find_branch_holder("/proj", "main") is None
 
+    def test_symlinked_project_path_is_not_its_own_holder(self, tmp_path):
+        """A project registered under a symlink is never a holder of itself.
+
+        `git worktree list` prints the resolved path it recorded at clone time,
+        while `projects.yaml` may hold a symlinked one. Comparing them without
+        resolving symlinks makes the project's own checkout look like a foreign
+        worktree squatting on its base branch — and `--fix` would then detach
+        the live checkout.
+        """
+        from app.git_prep import _find_branch_holder
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        # is_main=False is what _parse_worktree_entry computes here: normpath
+        # does not collapse the symlink, so the two spellings differ.
+        main_wt = _worktree(str(real), "main", is_main=False)
+        with patch("app.worktree_manager.list_worktrees", return_value=[main_wt]):
+            assert _find_branch_holder(str(link), "main") is None
+
     def test_error_keeps_the_first_checkout_message(self):
         """The fallback's error must not overwrite the one naming the holder.
 

--- a/koan/tests/test_git_prep.py
+++ b/koan/tests/test_git_prep.py
@@ -633,6 +633,47 @@ class TestBranchHeldByAnotherWorktree:
             for c in mocks["run_git"].call_args_list
         )
 
+    def test_detach_is_reported_even_when_the_retry_fails(self):
+        """A detach that happened must be reported, whatever the retry does.
+
+        The detach moved someone else's worktree off the branch. If the retry
+        then dies on an unrelated fault (corrupt index), the operator still needs
+        a record of what touched their worktree.
+        """
+        holder = _worktree("/tmp/base-main", "main")
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            if cmd == "checkout":
+                if "--detach" in args:
+                    return (0, "", "")
+                # Both the retry and the -b fallback fail on a broken index.
+                return (1, "", "error: bad index file")
+            return _make_run_git_side_effect()(*args, **kwargs)
+
+        with patch("app.worktree_manager.list_worktrees", return_value=[holder]):
+            stack, _ = TestPrepareProjectBranch()._patch_all(
+                run_git_side_effect=side_effect,
+            )
+            with stack:
+                result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is False
+        assert "/tmp/base-main" in result.healed
+
+    def test_unreadable_worktree_list_is_logged(self, caplog):
+        """"We could not look" must not read like "nothing holds the branch"."""
+        import logging
+
+        from app.git_prep import _find_branch_holder
+        with patch(
+            "app.worktree_manager.list_worktrees",
+            side_effect=PermissionError("Permission denied: .git/worktrees"),
+        ), caplog.at_level(logging.WARNING):
+            assert _find_branch_holder("/proj", "main") is None
+
+        assert "Permission denied" in caplog.text
+
     def test_main_worktree_is_never_the_holder(self):
         """The project's own checkout holding the branch is not a collision."""
         from app.git_prep import _find_branch_holder

--- a/koan/tests/test_git_prep.py
+++ b/koan/tests/test_git_prep.py
@@ -1864,3 +1864,45 @@ class TestBaseBranchResolvedBeforeFetch:
         assert result.base_branch == "master"
         fetches = [c for c in calls if c and c[0] == "fetch"]
         assert fetches and "master" in fetches[0]
+
+    def test_stale_symbolic_ref_falls_back_to_the_original_base(self):
+        """A stale refs/remotes/origin/HEAD must not strand the project.
+
+        Upstream renamed `develop` → `main` and deleted `develop`, but the local
+        symbolic ref still points at `origin/develop` and no `origin/main` ref was
+        ever fetched. Resolution runs off local refs only, so it hands back the
+        dead branch; the fetch of it fails, and re-detecting yields the same stale
+        answer. Prep must still try the `main` fallback it started from, or every
+        mission on this project fails in prep until head_tracker refreshes the ref.
+        """
+        calls = []
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            calls.append(args)
+            if cmd == "rev-parse":
+                if "--verify" in args:
+                    return (1, "", "")  # neither main nor develop has a tracking ref
+                return (0, "feature", "")
+            if cmd == "symbolic-ref":
+                return (0, "refs/remotes/origin/develop", "")  # stale
+            if cmd == "fetch":
+                target = args[-1] if args else ""
+                return (0, "", "") if target == "main" else (
+                    1, "", "fatal: couldn't find remote ref develop"
+                )
+            if cmd == "remote":
+                return (1, "", "no such remote")
+            return (0, "", "")
+
+        stack, _ = TestPrepareProjectBranch()._patch_all(
+            run_git_side_effect=side_effect,
+            config={"projects": {"myproj": {}}},  # nothing configures a base branch
+        )
+        with stack:
+            result = prepare_project_branch("/proj", "myproj", "/koan")
+
+        assert result.success is True, result.error
+        assert result.base_branch == "main"
+        fetched = [c[-1] for c in calls if c and c[0] == "fetch"]
+        assert "main" in fetched, f"main was never fetched: {fetched}"

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -54,6 +54,14 @@ def git_repo(tmp_path):
         ["git", "branch", "-M", "main"],
         cwd=str(repo), capture_output=True, text=True,
     )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", "main"],
+        cwd=str(repo), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+        cwd=str(repo), capture_output=True, check=True,
+    )
     return str(repo)
 
 
@@ -411,10 +419,14 @@ class TestReapForeignWorktrees:
         foreign = self._add_foreign(git_repo, tmp_path / "review-abc", age_days=5)
         assert Path(foreign).is_dir()
 
-        reaped = reap_foreign_worktrees(git_repo)
+        with patch.object(worktree_manager.subprocess, "run", wraps=subprocess.run) as run:
+            reaped = reap_foreign_worktrees(git_repo)
 
         assert reaped == [foreign]
         assert not Path(foreign).exists()
+        commands = [call.args[0] for call in run.call_args_list]
+        assert ["git", "merge-base", "--is-ancestor", "HEAD", "origin/main"] in commands
+        assert not any(command[:2] == ["git", "for-each-ref"] for command in commands)
         # The registration must be gone too, not just the directory — leaving it behind is
         # exactly the phantom state that accumulated on the real host.
         paths = [w.path for w in list_worktrees(git_repo)]
@@ -470,6 +482,17 @@ class TestReapForeignWorktrees:
         old = time.time() - (5 * 86400)
         os.utime(Path(foreign) / "detached.txt", (old, old))
         os.utime(foreign, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_spares_detached_worktree_without_remote_default_branch(self, git_repo, tmp_path):
+        """An unresolved default branch makes detached worktree cleanup fail closed."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-no-default", age_days=5)
+        subprocess.run(
+            ["git", "symbolic-ref", "--delete", "refs/remotes/origin/HEAD"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
 
         assert reap_foreign_worktrees(git_repo) == []
         assert Path(foreign).is_dir()

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -473,8 +473,8 @@ class TestReapForeignWorktrees:
         assert reap_foreign_worktrees(git_repo) == []
         assert Path(foreign).is_dir()
 
-    def test_spares_detached_worktree_with_unique_commit(self, git_repo, tmp_path):
-        """A detached commit with no other ref must survive."""
+    def test_spares_idle_clean_detached_worktree_with_local_commit(self, git_repo, tmp_path):
+        """A clean tree can still hold committed work that exists nowhere else."""
         foreign = self._add_foreign(git_repo, tmp_path / "review-detached", age_days=5)
         (Path(foreign) / "detached.txt").write_text("unique commit\n")
         subprocess.run(["git", "add", "."], cwd=foreign, capture_output=True, check=True)
@@ -488,6 +488,27 @@ class TestReapForeignWorktrees:
 
         assert reap_foreign_worktrees(git_repo) == []
         assert Path(foreign).is_dir()
+
+    def test_spares_detached_worktree_with_uncommitted_changes(self, git_repo, tmp_path):
+        """Uncommitted changes are the signal that removal would lose real work."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-dirty", age_days=5)
+        (Path(foreign) / "detached.txt").write_text("unique commit\n")
+        subprocess.run(["git", "add", "."], cwd=foreign, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "detached work"],
+            cwd=foreign, capture_output=True, check=True,
+        )
+        # Backdate everything, including the dirty file: the activity guard runs first
+        # and would otherwise retain the worktree before the cleanliness check is reached.
+        (Path(foreign) / "in-progress.txt").write_text("not saved anywhere\n")
+        old = time.time() - (5 * 86400)
+        for name in ("detached.txt", "in-progress.txt"):
+            os.utime(Path(foreign) / name, (old, old))
+        os.utime(foreign, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+        assert (Path(foreign) / "in-progress.txt").exists()
 
     @staticmethod
     def _commit_on_remote_only_branch(repo):
@@ -528,6 +549,23 @@ class TestReapForeignWorktrees:
         """
         sha = self._commit_on_remote_only_branch(git_repo)
         foreign = self._add_foreign(git_repo, tmp_path / "review-pr", age_days=5, ref=sha)
+
+        assert reap_foreign_worktrees(git_repo) == [foreign]
+        assert not Path(foreign).exists()
+
+    def test_reaps_clean_closed_pull_request_checkout(self, git_repo, tmp_path):
+        """A PR checkout unchanged since creation remains reapable after ref deletion."""
+        sha = self._commit_on_remote_only_branch(git_repo)
+        foreign = self._add_foreign(
+            git_repo,
+            tmp_path / "review-closed",
+            age_days=5,
+            ref=sha,
+        )
+        subprocess.run(
+            ["git", "update-ref", "-d", "refs/remotes/origin/side"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
 
         assert reap_foreign_worktrees(git_repo) == [foreign]
         assert not Path(foreign).exists()
@@ -796,3 +834,82 @@ class TestWorktreeErrorPaths:
         from app.worktree_manager import _resolve_base_ref
         result = _resolve_base_ref(git_repo, "nonexistent")
         assert result in ("main", "master", "HEAD")
+
+
+class TestWorktreeOwnershipZones:
+    """Only `.worktrees/` and `.claude/worktrees/` belong to other code.
+
+    A worktree elsewhere inside the project — in practice `<project>/tmp/` — has no
+    owner: `cleanup_stale_worktrees()` only walks `.worktrees/`, and the OS temp
+    sweeper only walks the system temp directory. A blanket "skip anything inside the
+    project" rule left those unreclaimable by anything on the host.
+    """
+
+    def test_owned_directories_are_skipped(self):
+        from app.worktree_manager import _is_owned_by_other_code
+        assert _is_owned_by_other_code("/proj/.worktrees/abc", "/proj") is True
+        assert _is_owned_by_other_code("/proj/.claude/worktrees/agent-1", "/proj") is True
+
+    def test_project_tmp_is_in_scope(self):
+        from app.worktree_manager import _is_owned_by_other_code
+        assert _is_owned_by_other_code("/proj/tmp/review-123", "/proj") is False
+
+    def test_outside_the_project_is_in_scope(self):
+        from app.worktree_manager import _is_owned_by_other_code
+        assert _is_owned_by_other_code("/tmp/base140", "/proj") is False
+
+    def test_prefix_collision_is_not_owned(self):
+        """`.worktrees-backup` is not `.worktrees`."""
+        from app.worktree_manager import _is_owned_by_other_code
+        assert _is_owned_by_other_code("/proj/.worktrees-backup/x", "/proj") is False
+
+    def test_reaps_a_worktree_under_project_tmp(self, git_repo, tmp_path):
+        """The real shape: app-csf/tmp/review-* sat 34 days, reclaimable by nothing."""
+        scratch = Path(git_repo) / "tmp" / "review-inside"
+        scratch.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(scratch), "HEAD"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        old = time.time() - (5 * 86400)
+        for root, directories, files in os.walk(scratch):
+            for name in directories + files:
+                os.utime(os.path.join(root, name), (old, old))
+        os.utime(scratch, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == [str(scratch)]
+        assert not scratch.exists()
+
+    def test_spares_a_worktree_owned_by_cleanup_stale_worktrees(self, git_repo, tmp_path):
+        """`.worktrees/` belongs to cleanup_stale_worktrees(); never touch it."""
+        owned = Path(git_repo) / ".worktrees" / "session-abc"
+        owned.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(owned), "HEAD"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        old = time.time() - (5 * 86400)
+        for root, directories, files in os.walk(owned):
+            for name in directories + files:
+                os.utime(os.path.join(root, name), (old, old))
+        os.utime(owned, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert owned.is_dir()
+
+    def test_spares_a_harness_worktree(self, git_repo, tmp_path):
+        """`.claude/worktrees/` belongs to the Claude Code harness."""
+        owned = Path(git_repo) / ".claude" / "worktrees" / "agent-abc"
+        owned.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(owned), "HEAD"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        old = time.time() - (5 * 86400)
+        for root, directories, files in os.walk(owned):
+            for name in directories + files:
+                os.utime(os.path.join(root, name), (old, old))
+        os.utime(owned, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert owned.is_dir()

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -401,10 +401,10 @@ class TestReapForeignWorktrees:
     """
 
     @staticmethod
-    def _add_foreign(repo, path, age_days=0.0):
+    def _add_foreign(repo, path, age_days=0.0, ref="HEAD"):
         """Register a worktree outside the project, optionally backdated."""
         subprocess.run(
-            ["git", "worktree", "add", "--detach", str(path), "HEAD"],
+            ["git", "worktree", "add", "--detach", str(path), ref],
             cwd=repo, capture_output=True, check=True,
         )
         if age_days:
@@ -425,7 +425,10 @@ class TestReapForeignWorktrees:
         assert reaped == [foreign]
         assert not Path(foreign).exists()
         commands = [call.args[0] for call in run.call_args_list]
-        assert ["git", "merge-base", "--is-ancestor", "HEAD", "origin/main"] in commands
+        assert [
+            "git", "rev-list", "--max-count=1", "HEAD",
+            "--not", "--branches", "--tags", "--remotes",
+        ] in commands
         assert not any(command[:2] == ["git", "for-each-ref"] for command in commands)
         # The registration must be gone too, not just the directory — leaving it behind is
         # exactly the phantom state that accumulated on the real host.
@@ -486,16 +489,64 @@ class TestReapForeignWorktrees:
         assert reap_foreign_worktrees(git_repo) == []
         assert Path(foreign).is_dir()
 
-    def test_spares_detached_worktree_without_remote_default_branch(self, git_repo, tmp_path):
-        """An unresolved default branch makes detached worktree cleanup fail closed."""
+    @staticmethod
+    def _commit_on_remote_only_branch(repo):
+        """Return a SHA reachable *only* from refs/remotes/origin/side.
+
+        This is the shape of a real review checkout: `git worktree add /tmp/review-<sha>
+        <sha>` at a pull-request head. The commit is durable on its remote branch but is
+        not an ancestor of the default branch, and no local branch or tag holds it.
+        """
+        subprocess.run(
+            ["git", "checkout", "-b", "side"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        (Path(repo) / "pr.txt").write_text("pull request head\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "pr head"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/side", sha],
+            cwd=repo, capture_output=True, check=True,
+        )
+        subprocess.run(["git", "checkout", "main"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(["git", "branch", "-D", "side"], cwd=repo, capture_output=True, check=True)
+        return sha
+
+    def test_reaps_detached_worktree_at_unmerged_pull_request_head(self, git_repo, tmp_path):
+        """The population the reaper exists for: a review checkout at an open PR's head.
+
+        The commit is durable on origin/side, so removing the worktree loses nothing — but
+        it is not an ancestor of the default branch. Testing reachability from the default
+        branch alone would retain every review worktree forever.
+        """
+        sha = self._commit_on_remote_only_branch(git_repo)
+        foreign = self._add_foreign(git_repo, tmp_path / "review-pr", age_days=5, ref=sha)
+
+        assert reap_foreign_worktrees(git_repo) == [foreign]
+        assert not Path(foreign).exists()
+
+    def test_reaps_detached_worktree_without_remote_default_branch(self, git_repo, tmp_path):
+        """Cleanup must not depend on refs/remotes/origin/HEAD, which is often unset.
+
+        A plain `git clone` leaves it unset whenever the remote's HEAD is unresolvable, and
+        `git init` + `remote add` + `fetch` never sets it at all. Making it a precondition
+        turned the whole sweep into a no-op on those hosts.
+        """
         foreign = self._add_foreign(git_repo, tmp_path / "review-no-default", age_days=5)
         subprocess.run(
             ["git", "symbolic-ref", "--delete", "refs/remotes/origin/HEAD"],
             cwd=git_repo, capture_output=True, check=True,
         )
 
-        assert reap_foreign_worktrees(git_repo) == []
-        assert Path(foreign).is_dir()
+        assert reap_foreign_worktrees(git_repo) == [foreign]
+        assert not Path(foreign).exists()
 
     def test_ignores_project_owned_worktrees(self, git_repo):
         """`.worktrees/` belongs to cleanup_stale_worktrees(); don't poach it."""

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -750,8 +750,32 @@ class TestWorktreeErrorPaths:
             remove_worktree(git_repo, session_id=wt.session_id)
         assert "git branch -D failed" in capsys.readouterr().err
 
-    def test_list_worktrees_empty_on_error(self, tmp_path):
+    def test_list_worktrees_empty_on_error(self, tmp_path, capsys):
+        """An inspection failure returns [] — but says so.
+
+        Callers treat this list as proof that no worktree holds a branch, so a
+        silent [] made "git could not tell us" look like "nothing holds it", which
+        is how a blocking worktree stayed invisible for 90 missions.
+        """
         assert list_worktrees(str(tmp_path)) == []
+        assert "git worktree list failed" in capsys.readouterr().err
+
+    def test_list_worktrees_reports_a_timeout(self, git_repo, capsys):
+        with patch("app.worktree_manager.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("git", 15)):
+            assert list_worktrees(git_repo, timeout=15) == []
+        assert "git worktree list timed out" in capsys.readouterr().err
+
+    def test_retain_reason_is_logged_when_a_check_cannot_run(self, tmp_path, capsys):
+        """A guard that fails toward retention must name the reason.
+
+        Otherwise "kept because work would be lost" and "kept because the check
+        could not run" are indistinguishable, and a reaper that has silently
+        reverted to retain-everything looks like one with nothing to do.
+        """
+        from app.worktree_manager import _has_unpushed_commits
+        assert _has_unpushed_commits(str(tmp_path)) is True
+        assert "retain (HEAD ref check failed)" in capsys.readouterr().err
 
     def test_list_worktrees_parses_session(self, git_repo):
         wt = create_worktree(git_repo)
@@ -776,10 +800,17 @@ class TestWorktreeErrorPaths:
             cleanup_stale_worktrees(git_repo, active_session_ids=[])
         assert "stale worktree cleanup error" in capsys.readouterr().err
 
-    def test_prune_handles_called_process_error(self, git_repo, capsys):
-        def bad_run(cmd, **kw):
-            raise subprocess.CalledProcessError(1, cmd, stderr="prune fail")
-        with patch("app.worktree_manager.subprocess.run", side_effect=bad_run):
+    def test_prune_reports_a_nonzero_exit(self, git_repo, capsys):
+        """A failed prune must not pass for a clean one.
+
+        prune runs without check=True, so the exit code is the only signal; when it
+        was ignored, phantom worktree registrations persisted while the sweep still
+        reported "0 reclaimed" as though nothing needed pruning.
+        """
+        failed = subprocess.CompletedProcess(
+            [], returncode=1, stdout="", stderr="prune fail",
+        )
+        with patch("app.worktree_manager.subprocess.run", return_value=failed):
             prune_worktrees(git_repo)
         assert "worktree prune failed" in capsys.readouterr().err
 

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -11,6 +11,8 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+import app.worktree_manager as worktree_manager
+
 from app.worktree_manager import (
     WorktreeInfo,
     create_worktree,
@@ -537,6 +539,49 @@ class TestReapForeignWorktrees:
 
         assert reap_foreign_worktrees(git_repo, max_age_days=2) == []
         assert reap_foreign_worktrees(git_repo, max_age_days=0.5) == [foreign]
+
+    def test_expired_budget_keeps_foreign_worktree(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-expired", age_days=5)
+
+        assert reap_foreign_worktrees(
+            git_repo,
+            deadline=time.monotonic() - 1,
+        ) == []
+        assert Path(foreign).is_dir()
+
+    def test_timed_out_activity_check_keeps_foreign_worktree(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-timeout", age_days=5)
+
+        with patch.object(
+            worktree_manager.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("git", 15),
+        ):
+            assert worktree_manager._has_recent_worktree_activity(
+                foreign,
+                time.time() - 86400,
+                deadline=time.monotonic() + 60,
+            ) is True
+        assert Path(foreign).is_dir()
+
+    def test_incomplete_removal_is_not_reported_as_reaped(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-remove-timeout", age_days=5)
+
+        with patch.object(worktree_manager, "remove_worktree"):
+            assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_rotates_foreign_candidates_in_dry_run(self, git_repo, tmp_path):
+        first = self._add_foreign(git_repo, tmp_path / "review-a", age_days=5)
+        second = self._add_foreign(git_repo, tmp_path / "review-b", age_days=5)
+
+        reaped = reap_foreign_worktrees(
+            git_repo,
+            dry_run=True,
+            start_index=1,
+        )
+
+        assert reaped == [second, first]
 
 
 class TestWorktreeLockedParsing:

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -642,13 +642,13 @@ class TestReapForeignWorktrees:
         assert readme.read_text() == "edited, never committed\n"
 
     def test_spares_dirty_in_project_worktree_on_local_branch(self, git_repo, tmp_path):
-        """A hand-made in-project worktree is where a human parks WIP.
+        """An in-scope scratch worktree still gets the dirty guard.
 
-        `<project>/wt/feature-x` on a local branch with no upstream: the branch keeps HEAD
+        `<project>/tmp/wip` on a local branch with no upstream: the branch keeps HEAD
         reachable, so nothing about *commits* blocks removal — but the uncommitted edits
         exist nowhere else, and the sweep runs unattended on an hourly timer.
         """
-        wip = Path(git_repo) / "wt" / "feature-x"
+        wip = Path(git_repo) / "tmp" / "wip"
         subprocess.run(
             ["git", "worktree", "add", "-b", "feature-x", str(wip)],
             cwd=git_repo, capture_output=True, check=True,
@@ -911,31 +911,38 @@ class TestWorktreeErrorPaths:
 
 
 class TestWorktreeOwnershipZones:
-    """Only `.worktrees/` and `.claude/worktrees/` belong to other code.
+    """Inside a project, only `<project>/tmp/` is in scope.
 
-    A worktree elsewhere inside the project — in practice `<project>/tmp/` — has no
-    owner: `cleanup_stale_worktrees()` only walks `.worktrees/`, and the OS temp
-    sweeper only walks the system temp directory. A blanket "skip anything inside the
-    project" rule left those unreclaimable by anything on the host.
+    A scratch checkout there has no owner: `cleanup_stale_worktrees()` only walks
+    `.worktrees/`, and the OS temp sweeper only walks the system temp directory, so a
+    blanket "skip anything inside the project" rule left those unreclaimable by
+    anything on the host. Everywhere else in-project is somebody's workspace and stays
+    out of reach of an unattended `--force`.
     """
 
     def test_owned_directories_are_skipped(self):
-        from app.worktree_manager import _is_owned_by_other_code
-        assert _is_owned_by_other_code("/proj/.worktrees/abc", "/proj") is True
-        assert _is_owned_by_other_code("/proj/.claude/worktrees/agent-1", "/proj") is True
+        from app.worktree_manager import _is_in_scope
+        assert _is_in_scope("/proj/.worktrees/abc", "/proj") is False
+        assert _is_in_scope("/proj/.claude/worktrees/agent-1", "/proj") is False
 
     def test_project_tmp_is_in_scope(self):
-        from app.worktree_manager import _is_owned_by_other_code
-        assert _is_owned_by_other_code("/proj/tmp/review-123", "/proj") is False
+        from app.worktree_manager import _is_in_scope
+        assert _is_in_scope("/proj/tmp/review-123", "/proj") is True
+
+    def test_hand_made_in_project_workspace_is_out_of_scope(self):
+        """`<project>/wt/feature-x` is a human's workspace, not scratch."""
+        from app.worktree_manager import _is_in_scope
+        assert _is_in_scope("/proj/wt/feature-x", "/proj") is False
 
     def test_outside_the_project_is_in_scope(self):
-        from app.worktree_manager import _is_owned_by_other_code
-        assert _is_owned_by_other_code("/tmp/base140", "/proj") is False
+        from app.worktree_manager import _is_in_scope
+        assert _is_in_scope("/tmp/base140", "/proj") is True
 
-    def test_prefix_collision_is_not_owned(self):
-        """`.worktrees-backup` is not `.worktrees`."""
-        from app.worktree_manager import _is_owned_by_other_code
-        assert _is_owned_by_other_code("/proj/.worktrees-backup/x", "/proj") is False
+    def test_prefix_collision_is_not_scratch(self):
+        """`tmpfiles` is not `tmp`, and `.worktrees-backup` is not `.worktrees`."""
+        from app.worktree_manager import _is_in_scope
+        assert _is_in_scope("/proj/tmpfiles/x", "/proj") is False
+        assert _is_in_scope("/proj/.worktrees-backup/x", "/proj") is False
 
     def test_reaps_a_worktree_under_project_tmp(self, git_repo, tmp_path):
         """The real shape: app-csf/tmp/review-* sat 34 days, reclaimable by nothing."""
@@ -953,6 +960,40 @@ class TestWorktreeOwnershipZones:
 
         assert reap_foreign_worktrees(git_repo) == [str(scratch)]
         assert not scratch.exists()
+
+    def test_spares_a_hand_made_worktree_holding_only_ignored_files(
+        self, git_repo, tmp_path
+    ):
+        """Gitignored local-only files are invisible to every retention guard.
+
+        `<project>/wt/feature-x`: everything tracked is committed and pushed, the tree
+        has been idle for days, and the branch has no upstream — so `git status
+        --porcelain`, the `--exclude-standard` activity scan and the upstream check all
+        report "nothing here". Only the `.env.local` / `dev.db` a developer left behind
+        would have been lost, and `git worktree remove --force` gives no way back.
+        """
+        (Path(git_repo) / ".gitignore").write_text(".env.local\ndev.db\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "ignore local state"], cwd=git_repo, check=True,
+            capture_output=True,
+        )
+        wip = Path(git_repo) / "wt" / "feature-x"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "feature-x", str(wip)],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        (wip / ".env.local").write_text("TOKEN=secret\n")
+        (wip / "dev.db").write_text("local database\n")
+        old = time.time() - (5 * 86400)
+        for root, directories, files in os.walk(wip):
+            for name in directories + files:
+                os.utime(os.path.join(root, name), (old, old))
+        os.utime(wip, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert (wip / ".env.local").read_text() == "TOKEN=secret\n"
+        assert (wip / "dev.db").read_text() == "local database\n"
 
     def test_spares_a_worktree_owned_by_cleanup_stale_worktrees(self, git_repo, tmp_path):
         """`.worktrees/` belongs to cleanup_stale_worktrees(); never touch it."""

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -624,17 +624,60 @@ class TestReapForeignWorktrees:
         assert reap_foreign_worktrees(git_repo, dry_run=True) == [foreign]
         assert Path(foreign).is_dir()
 
-    def test_reaps_incidentally_dirty_worktree(self, git_repo, tmp_path):
-        """Reviews leave edits behind (a regenerated lockfile); that must not block reap."""
+    def test_spares_dirty_worktree_even_when_head_is_durable(self, git_repo, tmp_path):
+        """Removal is `--force`; a dirty tree loses uncommitted work with no recovery.
+
+        HEAD here is the default branch's tip — as durable as a commit gets — so the
+        reachability guard says "removal loses nothing". Cleanliness is the separate
+        question, and it is what decides this case.
+        """
         foreign = self._add_foreign(git_repo, tmp_path / "review-dirty", age_days=5)
         readme = Path(foreign) / "README.md"
-        readme.write_text("touched by review\n")
+        readme.write_text("edited, never committed\n")
         old = time.time() - (5 * 86400)
         os.utime(readme, (old, old))
         os.utime(foreign, (old, old))
 
-        assert reap_foreign_worktrees(git_repo) == [foreign]
-        assert not Path(foreign).exists()
+        assert reap_foreign_worktrees(git_repo) == []
+        assert readme.read_text() == "edited, never committed\n"
+
+    def test_spares_dirty_in_project_worktree_on_local_branch(self, git_repo, tmp_path):
+        """A hand-made in-project worktree is where a human parks WIP.
+
+        `<project>/wt/feature-x` on a local branch with no upstream: the branch keeps HEAD
+        reachable, so nothing about *commits* blocks removal — but the uncommitted edits
+        exist nowhere else, and the sweep runs unattended on an hourly timer.
+        """
+        wip = Path(git_repo) / "wt" / "feature-x"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "feature-x", str(wip)],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        (wip / "README.md").write_text("three days of unsaved work\n")
+        old = time.time() - (5 * 86400)
+        for root, directories, files in os.walk(wip):
+            for name in directories + files:
+                os.utime(os.path.join(root, name), (old, old))
+        os.utime(wip, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert (wip / "README.md").read_text() == "three days of unsaved work\n"
+
+    def test_reaps_idle_clean_in_project_worktree_on_local_branch(self, git_repo, tmp_path):
+        """The dirty guard must not make every in-project worktree immortal."""
+        scratch = Path(git_repo) / "tmp" / "scratch"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "scratch", str(scratch)],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        old = time.time() - (5 * 86400)
+        for root, directories, files in os.walk(scratch):
+            for name in directories + files:
+                os.utime(os.path.join(root, name), (old, old))
+        os.utime(scratch, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == [str(scratch)]
+        assert not scratch.exists()
 
     def test_spares_recent_tracked_file_edit(self, git_repo, tmp_path):
         """Editing an existing file does not update root mtime, but remains live work."""

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -57,9 +57,14 @@ awake.py (loop, ~3s poll)
 - **Bounded maintenance.** A foreign-worktree sweep has a fixed two-minute total
   deadline and a 15-second Git-command cap. Expired or timed-out safety checks
   retain worktrees and defer them to a later rotating sweep.
-- **Detached worktree safety.** A detached foreign worktree is removed only when its
-  HEAD is an ancestor of `origin/HEAD`. The check MUST use bounded ancestry verification,
-  not an all-ref containment scan; an unavailable default-branch pointer retains it.
+- **Detached worktree safety.** A detached foreign worktree is removed only when its HEAD
+  is already contained in a durable ref — any local branch, tag, or remote-tracking ref —
+  because those keep the commits reachable after the worktree's path is removed. Reachability
+  from the default branch alone is NOT sufficient: review worktrees sit at pull-request head
+  commits, which are durable on their remote branch yet never ancestors of the default branch,
+  so a default-branch test would retain every one of them forever. The check MUST use a single
+  bounded revision walk rather than a per-ref containment scan, and any git failure retains
+  the worktree.
 - **Chat is resilient to API contention (#1084).** While a mission runs, the agent loop
   and the bridge invoke the AI CLI concurrently against the same account (the default
   provider takes no cross-invocation lock), so a chat call can return an empty response or

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -30,6 +30,7 @@ awake.py (loop, ~3s poll)
   │                    mission → queue to missions.md
   ├─ command_handlers.py: /help /stop /pause /resume /skill ... + skill dispatch
   ├─ flush outbox.md → Telegram (atomic staging via outbox-sending.md)
+  └─ maintenance worker: long-running housekeeping outside the poll loop
   └─ bridge_state.py: shared config/paths/registries (avoids circular imports)
 ```
 
@@ -50,6 +51,9 @@ awake.py (loop, ~3s poll)
 
 - **Two-process isolation.** The bridge and the agent loop share *only* files in
   `instance/` (atomic writes). The bridge must never call agent-loop internals directly.
+- **Inbound responsiveness.** Repository maintenance, including foreign-worktree
+  reaping, MUST run on the bridge's maintenance worker lane rather than its poll
+  loop, so it cannot delay inbound commands or outbox flushing.
 - **Chat is resilient to API contention (#1084).** While a mission runs, the agent loop
   and the bridge invoke the AI CLI concurrently against the same account (the default
   provider takes no cross-invocation lock), so a chat call can return an empty response or

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -57,6 +57,9 @@ awake.py (loop, ~3s poll)
 - **Bounded maintenance.** A foreign-worktree sweep has a fixed two-minute total
   deadline and a 15-second Git-command cap. Expired or timed-out safety checks
   retain worktrees and defer them to a later rotating sweep.
+- **Detached worktree safety.** A detached foreign worktree is removed only when its
+  HEAD is an ancestor of `origin/HEAD`. The check MUST use bounded ancestry verification,
+  not an all-ref containment scan; an unavailable default-branch pointer retains it.
 - **Chat is resilient to API contention (#1084).** While a mission runs, the agent loop
   and the bridge invoke the AI CLI concurrently against the same account (the default
   provider takes no cross-invocation lock), so a chat call can return an empty response or

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -54,6 +54,9 @@ awake.py (loop, ~3s poll)
 - **Inbound responsiveness.** Repository maintenance, including foreign-worktree
   reaping, MUST run on the bridge's maintenance worker lane rather than its poll
   loop, so it cannot delay inbound commands or outbox flushing.
+- **Bounded maintenance.** A foreign-worktree sweep has a fixed two-minute total
+  deadline and a 15-second Git-command cap. Expired or timed-out safety checks
+  retain worktrees and defer them to a later rotating sweep.
 - **Chat is resilient to API contention (#1084).** While a mission runs, the agent loop
   and the bridge invoke the AI CLI concurrently against the same account (the default
   provider takes no cross-invocation lock), so a chat call can return an empty response or

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -4,7 +4,7 @@ title: "Component Spec — Telegram Bridge"
 description: "Design contract for the Telegram bridge process that classifies human messages into chat vs. mission, dispatches commands/skills, and flushes the agent's outbox crash-safely."
 tags: [bridge]
 created: 2026-06-27
-updated: 2026-08-31
+updated: 2026-09-02
 ---
 
 # Component Spec — Telegram Bridge
@@ -57,16 +57,24 @@ awake.py (loop, ~3s poll)
 - **Bounded maintenance.** A foreign-worktree sweep has a fixed two-minute total
   deadline and a 15-second Git-command cap. Expired or timed-out safety checks
   retain worktrees and defer them to a later rotating sweep.
+- **A dirty worktree is never reaped.** Removal is `git worktree remove --force`, which
+  deletes uncommitted work with no recovery path, so cleanliness MUST be checked for
+  *every* candidate — on a branch or detached, reachable or not — and not merely as a
+  tie-breaker on the unreachable-detached path. Commit reachability answers "would commits
+  be lost"; it says nothing about the working tree, and a hand-made in-project worktree on
+  a local branch (`<project>/wt/feature-x`) is precisely where a human parks WIP. The sweep
+  runs unattended on an hourly timer, so this guard is the only thing standing between it
+  and unrecoverable loss. Retaining a leaked-but-dirty worktree costs disk, which is
+  recoverable and logged; the inverse is not.
 - **Detached worktree safety.** Reachability alone MUST NOT decide retention. A detached
   foreign worktree sits at a pull-request head commit, which is durable on its remote branch
   only while that PR is open; once the PR is squash-merged or closed the remote branch is
   deleted and no durable ref reaches that commit any more. Retaining on unreachability
   therefore makes every *completed* review immortal — unbounded growth, not safety. A detached
   worktree that no durable ref reaches is removed only when its HEAD still equals the commit
-  recorded when the worktree was created **and** its working tree is clean. A changed HEAD may
-  contain committed but never-pushed work; a dirty tree contains uncommitted work. The
-  reachability probe MUST use a single bounded revision walk rather than a per-ref containment
-  scan, and any git or reflog failure retains the worktree.
+  recorded when the worktree was created: a changed HEAD may contain committed but
+  never-pushed work. The reachability probe MUST use a single bounded revision walk rather
+  than a per-ref containment scan, and any git or reflog failure retains the worktree.
 - **Worktree ownership zones.** The sweep MUST NOT reclaim worktrees owned by other code:
   `<project>/.worktrees/` belongs to `worktree_manager.cleanup_stale_worktrees()`, and
   `<project>/.claude/worktrees/` belongs to the Claude Code harness. Everything else — a
@@ -139,10 +147,16 @@ awake.py (loop, ~3s poll)
   one poll cycle (`_read_sections_cached`). A `MemoryMonitor` watchdog
   (`memory_monitor.bridge:` sub-block, **enabled by default**, threshold
   600 MB; set `enabled: false` to opt out) samples RSS once per poll cycle
-  and, **only when no worker lane is busy**, self-restarts via
+  and, **only when no user-facing worker lane is busy**, self-restarts via
   `reexec_bridge()` (`os.execv`, same PID) as a backstop. The watchdog must
   never restart mid-worker, and a baseline-safety guard refuses to arm when
-  the threshold isn't safely above the current RSS.
+  the threshold isn't safely above the current RSS. The **maintenance lane is
+  excluded from that gate**: it carries idempotent, restart-safe internal work
+  with no human waiting on it, and a task wedged past its own timeout (a git
+  child in uninterruptible I/O outlives a Python-level `kill()`) would
+  otherwise disable the watchdog permanently and silently — trading a clean
+  re-exec for the OOM kill the watchdog exists to prevent. Only lanes tied to
+  a pending human reply may hold back a restart.
 - **Idempotent lifecycle notices dedupe across incarnations (#2426).** The
   provider's flood suppression (`notify.py`) only spans a single long-lived
   process, so when the agent loop / bridge (re)starts several times in a short

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -61,8 +61,8 @@ awake.py (loop, ~3s poll)
   deletes uncommitted work with no recovery path, so cleanliness MUST be checked for
   *every* candidate — on a branch or detached, reachable or not — and not merely as a
   tie-breaker on the unreachable-detached path. Commit reachability answers "would commits
-  be lost"; it says nothing about the working tree, and a hand-made in-project worktree on
-  a local branch (`<project>/wt/feature-x`) is precisely where a human parks WIP. The sweep
+  be lost"; it says nothing about the working tree, and a scratch worktree on a local
+  branch (`<project>/tmp/wip`) still holds edits that exist nowhere else. The sweep
   runs unattended on an hourly timer, so this guard is the only thing standing between it
   and unrecoverable loss. Retaining a leaked-but-dirty worktree costs disk, which is
   recoverable and logged; the inverse is not.
@@ -75,13 +75,18 @@ awake.py (loop, ~3s poll)
   recorded when the worktree was created: a changed HEAD may contain committed but
   never-pushed work. The reachability probe MUST use a single bounded revision walk rather
   than a per-ref containment scan, and any git or reflog failure retains the worktree.
-- **Worktree ownership zones.** The sweep MUST NOT reclaim worktrees owned by other code:
-  `<project>/.worktrees/` belongs to `worktree_manager.cleanup_stale_worktrees()`, and
-  `<project>/.claude/worktrees/` belongs to the Claude Code harness. Everything else — a
-  worktree outside the project directory, or a scratch worktree under `<project>/tmp/` — has
-  no owner and is in scope. A blanket "skip anything inside the project directory" rule is
-  NOT sufficient: it leaves `<project>/tmp/` worktrees unreclaimable by any process on the
-  host, because the OS temp sweeper does not reach inside a project either.
+- **Worktree scope zones.** Outside the project directory every registered worktree is in
+  scope — nothing else on the host reclaims one. Inside it, only `<project>/tmp/` is: those
+  scratch checkouts have no owner (`worktree_manager.cleanup_stale_worktrees()` walks
+  `.worktrees/` only, the Claude Code harness owns `.claude/worktrees/`, and the OS temp
+  sweeper does not reach inside a project), so a blanket "skip anything inside the project
+  directory" rule leaves them unreclaimable by any process on the host. Every other
+  in-project path — a hand-made `<project>/wt/feature-x` — MUST stay out of scope. The
+  retention guards all ask git, and git is silent about the gitignored `.env.local` or
+  `dev.db` a human workspace keeps: `git status --porcelain` omits ignored files, the
+  activity scan uses `--exclude-standard`, and a local branch with no upstream reports
+  nothing unpushed. Such a tree looks empty to every guard, and `--force` removal of it is
+  unrecoverable, so scope — not cleanliness — is what protects it.
 - **Chat is resilient to API contention (#1084).** While a mission runs, the agent loop
   and the bridge invoke the AI CLI concurrently against the same account (the default
   provider takes no cross-invocation lock), so a chat call can return an empty response or

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -57,14 +57,23 @@ awake.py (loop, ~3s poll)
 - **Bounded maintenance.** A foreign-worktree sweep has a fixed two-minute total
   deadline and a 15-second Git-command cap. Expired or timed-out safety checks
   retain worktrees and defer them to a later rotating sweep.
-- **Detached worktree safety.** A detached foreign worktree is removed only when its HEAD
-  is already contained in a durable ref — any local branch, tag, or remote-tracking ref —
-  because those keep the commits reachable after the worktree's path is removed. Reachability
-  from the default branch alone is NOT sufficient: review worktrees sit at pull-request head
-  commits, which are durable on their remote branch yet never ancestors of the default branch,
-  so a default-branch test would retain every one of them forever. The check MUST use a single
-  bounded revision walk rather than a per-ref containment scan, and any git failure retains
-  the worktree.
+- **Detached worktree safety.** Reachability alone MUST NOT decide retention. A detached
+  foreign worktree sits at a pull-request head commit, which is durable on its remote branch
+  only while that PR is open; once the PR is squash-merged or closed the remote branch is
+  deleted and no durable ref reaches that commit any more. Retaining on unreachability
+  therefore makes every *completed* review immortal — unbounded growth, not safety. A detached
+  worktree that no durable ref reaches is removed only when its HEAD still equals the commit
+  recorded when the worktree was created **and** its working tree is clean. A changed HEAD may
+  contain committed but never-pushed work; a dirty tree contains uncommitted work. The
+  reachability probe MUST use a single bounded revision walk rather than a per-ref containment
+  scan, and any git or reflog failure retains the worktree.
+- **Worktree ownership zones.** The sweep MUST NOT reclaim worktrees owned by other code:
+  `<project>/.worktrees/` belongs to `worktree_manager.cleanup_stale_worktrees()`, and
+  `<project>/.claude/worktrees/` belongs to the Claude Code harness. Everything else — a
+  worktree outside the project directory, or a scratch worktree under `<project>/tmp/` — has
+  no owner and is in scope. A blanket "skip anything inside the project directory" rule is
+  NOT sufficient: it leaves `<project>/tmp/` worktrees unreclaimable by any process on the
+  host, because the OS temp sweeper does not reach inside a project either.
 - **Chat is resilient to API contention (#1084).** While a mission runs, the agent loop
   and the bridge invoke the AI CLI concurrently against the same account (the default
   provider takes no cross-invocation lock), so a chat call can return an empty response or

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -124,6 +124,20 @@ workflows.
   because git cannot stash a conflicted tree and the next step resets to the
   remote base anyway. A **conflict-free** dirty tree is never discarded — the
   stash data-loss guard still holds for genuine uncommitted work.
+- **A held base branch is recoverable, not fatal.** Git checks a branch out in at
+  most one worktree, so any other worktree holding the base branch blocks the main
+  checkout for as long as it holds it. Prep MUST detect this and **detach** the
+  holding worktree — freeing the branch without deleting anything or disturbing its
+  uncommitted work — then retry the checkout once. Reclaiming that worktree's disk is
+  the bridge sweep's job, not prep's: prep runs unattended before every mission, so a
+  false positive must never be able to destroy an agent's in-flight work. A worktree
+  git reports as `locked` is never touched.
+- **The first checkout error is never discarded.** When `git checkout <base>` fails and
+  a fallback runs, the fallback's stderr MUST NOT overwrite the original. A branch held
+  by another worktree and a branch missing locally are different faults with different
+  fixes, and only the first message names the holding path. Origin: 92 logged prep
+  failures reported `a branch named 'X' already exists` — the fallback's error — while
+  the real cause, `is already used by worktree at ...`, never once reached the log.
 
 ### Mission status indicators (koan/mission)
 

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -4,7 +4,7 @@ title: "Component Spec — Git & GitHub"
 description: "Design contract for everything touching git history or the GitHub API: branch/PR creation, sync, webhook/notification handling, and rebase/recreate/CI-fix workflows."
 tags: [git-github]
 created: 2026-06-27
-updated: 2026-08-14
+updated: 2026-09-02
 ---
 
 # Component Spec — Git & GitHub

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -38,7 +38,7 @@ workflows.
 | `force_push_guard.py` | Post-force-push content-preservation harness for the rebase pipeline. `observe_remote_head()` snapshots the remote branch tip (and fetches its objects) immediately before **every** pipeline push (main push and private-gate re-pushes — the gate feeds its observations back via `push_state`) and again on a `--force-with-lease` rejection, so the tip the plain `--force` fallback clobbers is still nameable; it returns `None` (not `""`) when the lookup itself failed, so "could not look" stays distinguishable from "nothing was there" and surfaces as an unverified check; observations are scoped to the remote whose push succeeded; `verify_content_preserved()` compares the pre-rebase PR head against the **required last successfully pushed SHA** (never bare local HEAD; absent ⇒ guard skipped): `git cherry` patch-id screening plus a separate `rev-list --merges` pass for merge commits (invisible to `cherry`, dropped by a plain rebase — screened through their `--cc` combined diff), each refined by content-level cross-checks (byte-identical files at both heads, or an old→pushed diff that removes none of the commit's added lines — so upstream squash-merges and context-line drift count as preserved, while identical text elsewhere in a file cannot mask a revert), a file-level dropped-changes check, clobbered mid-pipeline pushes, and a post-push `ls-remote` race check. Anything unverifiable (git failure, deletion-only commit) is reported, never cleared. Per-commit analysis is capped (`_MAX_ANALYZED`) with the cap reported, never silent. `build_push_warning()` renders the findings as one amber/red `build_alert()` callout with the recoverable pre-rebase SHA (full SHA, actual push remote) and a shell-quoted, SHA-derived recovery command carrying no PR-controlled text. Best-effort by contract: any internal failure degrades to "no findings" and never blocks a push or fails the mission. |
 | `head_tracker.py` | Detects remote HEAD change (master→main), throttled 12h, state in `.head-tracker.json`. |
 | `github_url_parser.py` | Single PR/issue URL parsing path. |
-| `git_prep.py::prepare_project_branch()` | Pre-mission: fetch → **self-heal interrupted merge/rebase** → stash → checkout base → ff-only/reset to `<remote>/<base>`. Non-fatal; returns `PrepResult`. |
+| `git_prep.py::prepare_project_branch()` | Pre-mission: **resolve base branch** → fetch → **self-heal interrupted merge/rebase** → stash → checkout base → ff-only/reset to `<remote>/<base>`. Non-fatal; returns `PrepResult`. |
 
 ## Invariants
 
@@ -124,6 +124,15 @@ workflows.
   because git cannot stash a conflicted tree and the next step resets to the
   remote base anyway. A **conflict-free** dirty tree is never discarded — the
   stash data-loss guard still holds for genuine uncommitted work.
+- **Base-branch resolution never dead-ends on one candidate.** When nothing configured
+  a base branch, prep MAY resolve the remote's real default before fetching rather than
+  paying for a doomed fetch of the generic `main` fallback — but that resolution reads
+  `refs/remotes/<remote>/HEAD` without touching the network, so an upstream rename leaves
+  it pointing at a branch that no longer exists. Prep MUST therefore still try the value
+  it started from when the resolved branch's fetch fails. A resolution step that can only
+  narrow the candidates turns a stale local ref into every-mission prep failure until
+  `head_tracker.py` refreshes it (throttled to 12h). A failed resolution stays `None` and
+  is never promoted to an override of a configured branch.
 - **A held base branch is recoverable, not fatal.** Git checks a branch out in at
   most one worktree, so any other worktree holding the base branch blocks the main
   checkout for as long as it holds it. Prep MUST detect this and **detach** the

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -4,7 +4,7 @@ title: "Component Spec — Git & GitHub"
 description: "Design contract for everything touching git history or the GitHub API: branch/PR creation, sync, webhook/notification handling, and rebase/recreate/CI-fix workflows."
 tags: [git-github]
 created: 2026-06-27
-updated: 2026-09-02
+updated: 2026-09-08
 ---
 
 # Component Spec — Git & GitHub
@@ -132,6 +132,13 @@ workflows.
   the bridge sweep's job, not prep's: prep runs unattended before every mission, so a
   false positive must never be able to destroy an agent's in-flight work. A worktree
   git reports as `locked` is never touched.
+- **What prep cannot heal, `/doctor` MUST report.** A `locked` holder is the one
+  collision no automation resolves — every mission for that project keeps failing —
+  so the diagnostic reports it as a non-fixable error naming the unlock command,
+  while `--fix` still leaves it alone. The same applies when the base branch cannot
+  be resolved from local refs: the check is skipped, and the skip is reported. A
+  diagnostic that stays green on a project where nothing can run is worse than no
+  diagnostic.
 - **The first checkout error is never discarded.** When `git checkout <base>` fails and
   a fallback runs, the fallback's stderr MUST NOT overwrite the original. A branch held
   by another worktree and a branch missing locally are different faults with different


### PR DESCRIPTION
## Summary

Three related worktree fixes, all triggered by one production outage (92 consecutive
mission failures) plus a reaper that reported "0 reclaimed" every hour for days:

- **git prep self-heals a held base branch** (`koan/app/git_prep.py`) — git allows a
  branch in at most one worktree, so an agent-created `git worktree add /tmp/base140 140`
  locked the project's own checkout out of its base branch. Prep now detects the holder
  and runs `git checkout --detach` there (detach, never remove: files and uncommitted
  work stay put), then retries the checkout once. A `locked` holder is never touched.
  The first checkout error is also no longer overwritten by the `checkout -b` fallback's
  `a branch named 'X' already exists` — only the original message names the holding path.
- **Pre-fetch base-branch resolution** — when nothing configured a base branch and the
  hardcoded `main` fallback has no tracking ref, resolve the remote's real default before
  fetching instead of paying for a doomed fetch first. `resolve_remote_default_branch()`
  returns `None` on exhausted resolution, so a failed detection can never be promoted to
  an authoritative override of a configured branch.
- **Bounded, non-blocking foreign-worktree sweep** (`koan/app/awake.py`,
  `koan/app/worktree_manager.py`) — the hourly sweep moves to a new single-flight
  `maintenance` worker lane (2-minute budget, 15 s per git command, project rotation), so
  it never delays the poll loop. Detached-HEAD retention stops being permanent: a single
  bounded `rev-list --max-count=1 HEAD --not --branches --tags --remotes` walk replaces
  the per-ref containment scan, and a closed-PR checkout still at its creation commit is
  reclaimable. Every candidate is dirty-checked (`--force` removal), scope is narrowed to
  outside-the-project plus `<project>/tmp/`, and every retained worktree logs its reason.
- **`/doctor` reports the same collision** (`koan/diagnostics/project_check.py`), resolved
  **locally only** — no network probe outside `--full`. `/doctor --fix` performs the same
  detach.
- System prompt now forbids `git worktree add` outside `$TMPDIR`, which is where the leak
  came from.

Docs and durable specs updated: `docs/operations/troubleshooting.md` (sweep scope, what it
keeps, `git worktree lock` opt-out, auto-detach under "Branch conflicts"),
`docs/architecture/daemon.md` (maintenance lane), `specs/components/bridge.md`,
`specs/components/git-github.md`.

## Testing

- `make lint`
- `make test` — new coverage in `koan/tests/test_git_prep.py`,
  `koan/tests/test_worktree_manager.py` (real-git: locked holder, dirty tree, unmerged PR
  head, closed PR after ref deletion, missing `refs/remotes/origin/HEAD`),
  `koan/tests/test_diagnostics.py`, `koan/tests/test_awake.py`,
  `koan/tests/test_awake_worker_lanes.py` (maintenance lane never blocks chat).

## Declarations

- [x] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: prep may now detach a worktree holding the base branch, and
  the sweep's scope/retention contract changes (`specs/components/git-github.md`,
  `specs/components/bridge.md`).
