### PR TITLE
fix(skills): ignore multiline slash-command footer text

### DIFF
--- a/koan/app/command_handlers.py
+++ b/koan/app/command_handlers.py
@@ -8,6 +8,7 @@ to avoid circular imports with awake.py.
 """
 
 import contextlib
+import re
 import time
 from typing import Callable, Optional
 
@@ -36,6 +37,12 @@ from app.utils import (
 # Must be a valid Telegram ReactionTypeEmoji — ✅ (U+2705) is NOT in that set
 # and yields "Bad Request: REACTION_INVALID", so use 👍 which is whitelisted.
 ACK_EMOJI = "👍"
+
+# Client attribution footer appended on its own trailing line by some messaging
+# clients (e.g. Slack's "*Sent using* @Claude"). Anchored at line start and
+# allowed to carry markdown emphasis, so a user's prose that merely mentions the
+# phrase mid-sentence is never mistaken for a footer.
+_CLIENT_FOOTER_RE = re.compile(r"^\s*\*?Sent using\*?\b.*$")
 
 # Callbacks injected by awake.py at startup to avoid circular imports
 _handle_chat_cb: Optional[Callable] = None
@@ -233,12 +240,14 @@ def handle_command(text: str):
     # span multiple lines, so don't blanket-truncate to the first line — only
     # strip a trailing footer line so it isn't consumed as a positional argument
     # when handlers call args.split() (which splits on newlines too).
+    # A footer is only ever a *trailing* line after real content, so require a
+    # preceding line: a single-line command that merely mentions the phrase keeps
+    # its args. The rstrip drops the blank line Slack leaves before the footer.
     # Scoped here (not in SkillContext) so in-process GitHub/Jira custom-skill
     # dispatch can still pass multi-line context (see external_skill_dispatch).
     _lines = command_args.splitlines()
-    if _lines and "Sent using" in _lines[-1]:
-        _lines = _lines[:-1]
-    command_args = "\n".join(_lines)
+    if len(_lines) > 1 and _CLIENT_FOOTER_RE.match(_lines[-1]):
+        command_args = "\n".join(_lines[:-1]).rstrip()
 
     # Aliases are handled by the skill registry (SKILL.md aliases: field)
     # No hardcoded alias remapping needed here.

--- a/koan/app/command_handlers.py
+++ b/koan/app/command_handlers.py
@@ -228,6 +228,18 @@ def handle_command(text: str):
     command_name = parts[0][1:].lower()  # strip the /
     command_args = parts[1] if len(parts) > 1 else ""
 
+    # A messaging client may append a footer attribution on a later line
+    # (e.g. Slack's "*Sent using* @Claude"). Commands/missions may legitimately
+    # span multiple lines, so don't blanket-truncate to the first line — only
+    # strip a trailing footer line so it isn't consumed as a positional argument
+    # when handlers call args.split() (which splits on newlines too).
+    # Scoped here (not in SkillContext) so in-process GitHub/Jira custom-skill
+    # dispatch can still pass multi-line context (see external_skill_dispatch).
+    _lines = command_args.splitlines()
+    if _lines and "Sent using" in _lines[-1]:
+        _lines = _lines[:-1]
+    command_args = "\n".join(_lines)
+
     # Aliases are handled by the skill registry (SKILL.md aliases: field)
     # No hardcoded alias remapping needed here.
 

--- a/koan/tests/test_command_handlers.py
+++ b/koan/tests/test_command_handlers.py
@@ -778,11 +778,69 @@ class TestDispatchSkill:
 
         with patch("app.command_handlers.execute_skill", return_value="done") as mock_exec:
             handle_command(
-                "/add webpros-cpanel/ea-re2c\n*Sent using* @Claude"
+                "/add my-org/my-toolkit\n*Sent using* @Claude"
             )
 
         captured_args = mock_exec.call_args[0][1].args
-        assert captured_args == "webpros-cpanel/ea-re2c"
+        assert captured_args == "my-org/my-toolkit"
+
+    def test_blank_line_before_footer_is_trimmed(
+        self, patch_bridge_state, mock_send, mock_registry
+    ):
+        """Slack leaves a blank line in front of the footer — don't keep it."""
+        from app.command_handlers import handle_command
+        from app.skills import Skill
+
+        skill = MagicMock(spec=Skill)
+        skill.worker = False
+        mock_registry.find_by_command.return_value = skill
+
+        with patch("app.command_handlers.execute_skill", return_value="done") as mock_exec:
+            handle_command("/add my-org/my-toolkit\n\n*Sent using* @Claude")
+
+        captured_args = mock_exec.call_args[0][1].args
+        assert captured_args == "my-org/my-toolkit"
+
+    def test_single_line_args_mentioning_footer_phrase_preserved(
+        self, patch_bridge_state, mock_send, mock_registry
+    ):
+        """A one-line command whose text mentions the phrase keeps its args.
+
+        Without the "requires a preceding line" guard, `/idea log which
+        messages were Sent using the fallback provider` would dispatch with
+        empty args and the user's text would vanish.
+        """
+        from app.command_handlers import handle_command
+        from app.skills import Skill
+
+        skill = MagicMock(spec=Skill)
+        skill.worker = False
+        mock_registry.find_by_command.return_value = skill
+
+        text = "log which messages were Sent using the fallback provider"
+        with patch("app.command_handlers.execute_skill", return_value="done") as mock_exec:
+            handle_command(f"/idea {text}")
+
+        captured_args = mock_exec.call_args[0][1].args
+        assert captured_args == text
+
+    def test_multiline_args_final_line_mentioning_phrase_preserved(
+        self, patch_bridge_state, mock_send, mock_registry
+    ):
+        """A real final line that merely mentions the phrase is not a footer."""
+        from app.command_handlers import handle_command
+        from app.skills import Skill
+
+        skill = MagicMock(spec=Skill)
+        skill.worker = False
+        mock_registry.find_by_command.return_value = skill
+
+        text = "step 1\nlog which messages were Sent using the fallback provider"
+        with patch("app.command_handlers.execute_skill", return_value="done") as mock_exec:
+            handle_command(f"/add {text}")
+
+        captured_args = mock_exec.call_args[0][1].args
+        assert captured_args == text
 
     def test_multiline_args_preserved_without_footer(
         self, patch_bridge_state, mock_send, mock_registry

--- a/koan/tests/test_command_handlers.py
+++ b/koan/tests/test_command_handlers.py
@@ -761,6 +761,46 @@ class TestDispatchSkill:
             handle_command("/anantys.review")
             mock_exec.assert_called_once()
 
+    def test_multiline_args_stripped_footer(self, patch_bridge_state, mock_send, mock_registry):
+        """A client 'Sent using' footer line must not leak into ctx.args.
+
+        The Slack/Claude 'send message' integration appends an attribution
+        line (*Sent using* @Claude). A mission may span multiple lines, so only
+        a trailing 'Sent using' footer is stripped — other multi-line content is
+        preserved (issue #54).
+        """
+        from app.command_handlers import handle_command
+        from app.skills import Skill
+
+        skill = MagicMock(spec=Skill)
+        skill.worker = False
+        mock_registry.find_by_command.return_value = skill
+
+        with patch("app.command_handlers.execute_skill", return_value="done") as mock_exec:
+            handle_command(
+                "/add webpros-cpanel/ea-re2c\n*Sent using* @Claude"
+            )
+
+        captured_args = mock_exec.call_args[0][1].args
+        assert captured_args == "webpros-cpanel/ea-re2c"
+
+    def test_multiline_args_preserved_without_footer(
+        self, patch_bridge_state, mock_send, mock_registry
+    ):
+        """Multi-line mission text (no footer) is preserved, not truncated."""
+        from app.command_handlers import handle_command
+        from app.skills import Skill
+
+        skill = MagicMock(spec=Skill)
+        skill.worker = False
+        mock_registry.find_by_command.return_value = skill
+
+        with patch("app.command_handlers.execute_skill", return_value="done") as mock_exec:
+            handle_command("/add step 1\nstep 2\ndo the thing")
+
+        captured_args = mock_exec.call_args[0][1].args
+        assert captured_args == "step 1\nstep 2\ndo the thing"
+
 
 # ---------------------------------------------------------------------------
 # Test: cli_skill dispatch (queue as mission instead of inline execution)

--- a/koan/tests/test_external_skill_dispatch.py
+++ b/koan/tests/test_external_skill_dispatch.py
@@ -221,8 +221,8 @@ class TestTryDispatchCustomHandler:
 
     def test_multiline_context_and_appended_key_preserved(self, tmp_path):
         """Custom dispatch delivers multi-line context plus the appended Jira
-        key — first-line truncation is scoped to the Telegram ingress and must
-        not drop GitHub/Jira's multi-paragraph context feature."""
+        key — footer stripping is scoped to the Telegram ingress and must not
+        affect GitHub/Jira's multi-paragraph context feature."""
         handler_src = (
             "def handle(ctx):\n"
             "    return f'got:{ctx.args}'\n"

--- a/koan/tests/test_external_skill_dispatch.py
+++ b/koan/tests/test_external_skill_dispatch.py
@@ -219,6 +219,24 @@ class TestTryDispatchCustomHandler:
 
         assert reply == "got:PROJ-1 please"
 
+    def test_multiline_context_and_appended_key_preserved(self, tmp_path):
+        """Custom dispatch delivers multi-line context plus the appended Jira
+        key — first-line truncation is scoped to the Telegram ingress and must
+        not drop GitHub/Jira's multi-paragraph context feature."""
+        handler_src = (
+            "def handle(ctx):\n"
+            "    return f'got:{ctx.args}'\n"
+        )
+        skill = _make_custom_skill(tmp_path, handler_src)
+
+        reply = try_dispatch_custom_handler(
+            skill, "my_fix", "step 1\nstep 2\ndo the thing",
+            source="github",
+            github_body="tracked in JIRA JIRA-5",
+        )
+
+        assert reply == "got:step 1\nstep 2\ndo the thing JIRA-5"
+
     def test_returns_empty_string_when_handler_returns_none(self, tmp_path):
         # Handler returning None means "no user-visible reply" — caller should
         # still see "dispatched" (empty string) rather than None (fallthrough).

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -4,7 +4,7 @@ title: "Component Spec — Skills System"
 description: "Documents the skills system that discovers, routes, and executes `/command` skills (SKILL.md contract, dispatch, the new-skill checklist, and the eval harness)."
 tags: [skills]
 created: 2026-06-27
-updated: 2026-07-26
+updated: 2026-09-01
 ---
 
 # Component Spec — Skills System
@@ -62,6 +62,14 @@ koan/skills/core/<name>/
 - **Names/aliases/dirs use underscores, never hyphens** — Telegram truncates at `-`.
 - **No hardcoded skill-name lists in `koan/app/`.** When core must recognize a specific
   custom skill, drive it off SKILL.md frontmatter flags (see `collect_forward_result_markers`).
+- **A bare `args.split()` may consume a client footer as a positional argument.**
+  Messaging providers may append a footer/signature on the last line (e.g. Slack's
+  `*Sent using* @Claude`). The Telegram ingress (`handle_command`) strips a trailing line
+  containing `Sent using` before constructing `SkillContext` — it does **not** blanket-truncate,
+  so multi-line mission text is preserved. Telegram handlers must not expect footer text in
+  `args`. The in-process GitHub/Jira custom-skill dispatch (`external_skill_dispatch`) does
+  **not** strip — multi-line @mention context and the appended Jira key must still reach the
+  handler unchanged.
 - **Skill stdout is DATA.** Runners emit structured transcripts; `mission_executor`
   passes `trust_stdout=False` so transcripts aren't misread as CLI errors.
 - **No private identifiers leak** into core skills, tests, or docs — use generic

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -64,9 +64,12 @@ koan/skills/core/<name>/
   custom skill, drive it off SKILL.md frontmatter flags (see `collect_forward_result_markers`).
 - **A bare `args.split()` may consume a client footer as a positional argument.**
   Messaging providers may append a footer/signature on the last line (e.g. Slack's
-  `*Sent using* @Claude`). The Telegram ingress (`handle_command`) strips a trailing line
-  containing `Sent using` before constructing `SkillContext` — it does **not** blanket-truncate,
-  so multi-line mission text is preserved. Telegram handlers must not expect footer text in
+  `*Sent using* @Claude`). The Telegram ingress (`handle_command`) strips the last line before
+  constructing `SkillContext` only when args span more than one line **and** that line matches
+  the anchored footer shape (`^\s*\*?Sent using\*?\b`), then right-strips the remainder to drop
+  the blank line clients leave in front of the footer. It does **not** blanket-truncate, and a
+  single-line command — or a real final line — that merely mentions the phrase mid-sentence
+  keeps its text. Telegram handlers must not expect footer text in
   `args`. The in-process GitHub/Jira custom-skill dispatch (`external_skill_dispatch`) does
   **not** strip — multi-line @mention context and the appended Jira key must still reach the
   handler unchanged.


### PR DESCRIPTION
Messaging clients (e.g. Slack's '*Sent using* @Claude') append a footer on the last line. Strip only a trailing 'Sent using' footer in the Telegram ingress so it isn't consumed as a positional argument by args.split(), while preserving legitimate multi-line mission text and the in-process GitHub/Jira multi-line @mention context.

<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
