### PR TITLE
feat(cli): add spec-driven REST client

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,4 +1,13 @@
-# Community CLI wrappers (`bin/`)
+# Checkout-local command-line tools (`bin/`)
+
+## REST client
+
+`koan-cli` is a spec-driven client for Kōan's REST API. It reads the committed
+OpenAPI document, manages secure named profiles, and exposes every documented
+operation. It is independent from the provider wrappers below; do not set it as
+`KOAN_CLAUDE_CLI_PATH`. See the [Kōan REST CLI guide](../docs/users/koan-cli.md).
+
+## Community provider wrappers
 
 These are small, self-contained wrapper scripts that make Koan's **Claude
 provider** drive an alternative model backend, without any Koan code changes.

--- a/bin/koan-cli
+++ b/bin/koan-cli
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Run Kōan's REST CLI directly from a source checkout."""
+
+import sys
+from pathlib import Path
+
+
+repository = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repository / "koan"))
+
+from app.cli.main import main
+
+
+raise SystemExit(main())

--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -4,7 +4,7 @@ title: "REST API"
 description: "Documents Kōan's optional, token-authenticated HTTP control layer (missions, projects, pause/resume, config, admin, usage/metrics/logs endpoints), its generated OpenAPI spec + drift guard, and its security model."
 tags: [operations]
 created: 2026-05-31
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # REST API
@@ -136,10 +136,14 @@ but **only when an API-defining file changes** (`koan/app/api/**`, `koan/openapi
 CI time on it. If the check
 fails, the log tells you to run `make openapi` and commit the result.
 
-> **Scope (iteration 1):** the document precisely covers **paths, methods, path parameters,
-> and bearer-auth security** for every route. Per-operation request/response **body** schemas
-> are a planned enrichment and are not yet included. Two known non-`200` successes are
-> reflected: `POST /v1/missions` → `202`, `POST /v1/projects` → `201`.
+> **Request coverage:** the generated document covers paths, methods, path
+> parameters, bearer-auth security, JSON request bodies, and query parameters
+> for every current route. Body schemas and query declarations live beside
+> their Flask views through `openapi_operation()`, while
+> `app.api.openapi_gen` reads those declarations from the registered route.
+> Response body schemas remain a planned enrichment and are not included in
+> this iteration. Two known non-`200` successes remain explicit:
+> `POST /v1/missions` → `202` and `POST /v1/projects` → `201`.
 
 ---
 

--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -4,7 +4,7 @@ title: "REST API"
 description: "Documents Kōan's optional, token-authenticated HTTP control layer (missions, projects, pause/resume, config, admin, usage/metrics/logs endpoints), its generated OpenAPI spec + drift guard, and its security model."
 tags: [operations]
 created: 2026-05-31
-updated: 2026-07-10
+updated: 2026-09-08
 ---
 
 # REST API
@@ -69,6 +69,17 @@ Authorization: Bearer <your-token>
 | `403` | Token present but incorrect |
 
 Token comparison uses `hmac.compare_digest` to prevent timing attacks. If no token is configured, **all authenticated requests return 403** — the server never accepts unauthenticated control requests.
+
+---
+
+## Command-line client
+
+[`bin/koan-cli`](../../bin/koan-cli) is the checkout-local REST client. It
+reads this repository's committed OpenAPI document at runtime, supports all
+documented operations, and retains generic JSON/query flags while body and
+query schemas are being enriched. See the
+[Kōan REST CLI](../users/koan-cli.md) guide for secure profiles, examples,
+output guarantees, and exit codes.
 
 ---
 

--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -4,7 +4,7 @@ title: "REST API"
 description: "Documents Kōan's optional, token-authenticated HTTP control layer (missions, projects, pause/resume, config, admin, usage/metrics/logs endpoints), its generated OpenAPI spec + drift guard, and its security model."
 tags: [operations]
 created: 2026-05-31
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # REST API
@@ -144,6 +144,11 @@ fails, the log tells you to run `make openapi` and commit the result.
 > Response body schemas remain a planned enrichment and are not included in
 > this iteration. Two known non-`200` successes remain explicit:
 > `POST /v1/missions` → `202` and `POST /v1/projects` → `201`.
+>
+> **Destructive operations** declare themselves the same way: a view marked
+> `openapi_operation(destructive=True)` emits `x-koan-destructive: true`, which
+> clients (the CLI) use to decide what needs confirmation. Like the auth marker,
+> it lives beside the route and never in a client-side path list.
 
 ---
 

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -1,5 +1,6 @@
 # Users
 
+* [Kōan REST CLI](koan-cli.md) - Configure and use bin/koan-cli to call every operation in Kōan's token-authenticated REST API.
 * [KOAN.md — koan-only project instructions](koan-md.md) - Documents the optional project-root KOAN.md file and the .koan/ directory (a second .koan/KOAN.md, per-skill .koan/skills/<skill>/*.md hooks, and a structured .koan/config.yaml with review.always_check): koan-only steering injected into the autonomous agent's system prompt but never loaded by interactive Claude Code sessions, with precedence rules, the 16k-char cap, and this repo's dogfood layout.
 * [Model Configuration](model-configuration.md) - Explains how to configure which model handles each Koan role (mission, chat, lightweight, fallback, etc.) per provider via `config.yaml`, including resolution order and CLI-provider-per-role routing.
 * [Onboarding Guide](onboarding.md) - Documents the interactive 12-step onboarding wizard that sets up a new Koan instance, its resumability, personality presets, and non-interactive/CI mode.

--- a/docs/users/koan-cli.md
+++ b/docs/users/koan-cli.md
@@ -35,10 +35,12 @@ bin/koan-cli --profile prod status
 
 Settings resolve in this order:
 
-1. `--profile` and `--base-url` command-line options.
-2. Non-empty `KOAN_PROFILE`, `KOAN_BASE_URL`, and `KOAN_API_TOKEN` values.
-3. Values in the selected profile.
-4. The first server URL in `koan/openapi.yaml` for the base URL.
+1. `--profile`, `--base-url`, and `--timeout` command-line options.
+2. Non-empty `KOAN_PROFILE`, `KOAN_BASE_URL`, `KOAN_API_TOKEN`, and
+   `KOAN_TIMEOUT` values.
+3. Values in the selected profile (`base_url`, `token`, `timeout`).
+4. The first server URL in `koan/openapi.yaml` for the base URL, and a
+   120-second response timeout.
 
 Empty environment values are ignored. Without any configuration, the public
 `health` command uses the specification's default local server and needs no
@@ -78,6 +80,38 @@ Each OpenAPI `operationId` also works as a hidden root-level alias for scripts
 that prefer specification identifiers. Public command names and aliases are
 validated at startup so ambiguous specification changes fail locally.
 
+Most command names come from the path, not the method. When one path exposes
+two methods that would otherwise share a name, each gains a `-<method>` suffix
+(`admin pause-get`, `admin pause-post`) instead of aborting the whole client.
+Collection and item paths keep their readable names: `missions list`,
+`missions create`, `missions get`, `missions update`, `missions delete`.
+
+## Response timeout
+
+`--timeout SECONDS` bounds how long the client waits for a response. The
+default is 120 seconds because several handlers do their work synchronously
+inside the request — `admin update` runs `git fetch` plus `git pull`, and
+`projects create` clones a repository.
+
+```bash
+bin/koan-cli --timeout 600 admin update --yes
+KOAN_TIMEOUT=600 bin/koan-cli admin update --yes
+```
+
+`configure` does not write a timeout. Add `timeout = 600` under a profile
+section by hand to make a larger budget the default for that profile.
+
+A timeout is reported distinctly from a failed request, because the server may
+already have applied a non-idempotent operation:
+
+```
+no response within 120s: HTTPConnectionPool(...): Read timed out.
+POST http://127.0.0.1:8420/v1/update may still have been applied; verify before
+retrying, or raise --timeout.
+```
+
+Check the outcome before retrying such a command.
+
 ## Generic input
 
 Every operation accepts JSON through `--data`, from either inline text or an
@@ -96,10 +130,19 @@ schemas, and will override a generic query value with the same name. The typed
 flags use clean metavars (`COMMAND`, `TEXT`, `PROJECT`, …) and their `--help`
 shows the schema's description where the spec provides one.
 
+A flag whose schema is an `object` or `array` takes JSON (metavar `JSON`) and
+is parsed before dispatch, so a structured field arrives as structure rather
+than as a quoted string. Invalid JSON, or JSON of the wrong shape, fails
+locally without sending a request:
+
+```bash
+bin/koan-cli projects update my-toolkit --patch '{"focus": true}'
+```
+
 Path parameters are positional and percent-encoded before dispatch:
 
 ```bash
-bin/koan-cli projects update my-toolkit --data '{"auto_merge":false}'
+bin/koan-cli projects update my-toolkit --data '{"patch":{"focus":false}}'
 ```
 
 ## Raw requests
@@ -148,3 +191,7 @@ bin/koan-cli missions delete MISSION_ID --yes
   `api.enabled`, configure a generated token, then run `make api`.
 - Invalid JSON, malformed query pairs, and missing required values fail locally
   without sending a request.
+- `no response within Ns` means the request was delivered but no reply arrived.
+  Verify the server-side outcome, then retry with a larger `--timeout`.
+- `saved; cannot reach <url>: <error>` names the transport failure, so a
+  malformed URL or a TLS problem is distinguishable from a stopped server.

--- a/docs/users/koan-cli.md
+++ b/docs/users/koan-cli.md
@@ -4,7 +4,7 @@ title: "Kōan REST CLI"
 description: "Configure and use bin/koan-cli to call every operation in Kōan's token-authenticated REST API, with self-documenting --help."
 tags: [users]
 created: 2026-09-08
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Kōan REST CLI
@@ -44,7 +44,16 @@ Settings resolve in this order:
 
 `configure` uses the same ladder to pick which profile it writes and which
 base URL it offers as the prompt default, so `KOAN_PROFILE=prod koan-cli
-configure` writes `[prod]`, not `[default]`.
+configure` writes `[prod]`, not `[default]`. Re-running it **edits** that
+profile rather than resetting it: the stored `base_url` is the prompt default,
+and an empty token entry keeps the token already stored, so correcting one
+field never discards the other. A profile that ends up with no token at all is
+reported as a failure with a nonzero exit code.
+
+Naming a profile that does not exist is an error, whether it comes from
+`--profile` or `KOAN_PROFILE` — the CLI never quietly falls back to `default`
+and sends the request to the wrong agent. Only an unnamed `default` may be
+absent.
 
 Empty environment values are ignored. Without any configuration, the public
 `health` command uses the specification's default local server and needs no
@@ -177,9 +186,11 @@ Non-JSON response bodies are wrapped in a JSON object.
 | `3` | Not found (`404`) |
 | `4` | Server error (`5xx`) |
 
-All DELETE requests plus restart, shutdown, update, and release-update requests
-are destructive. They prompt when stdin is a TTY and require `--yes` in
-non-interactive scripts.
+Every DELETE request is destructive, as is any operation the specification
+marks with `x-koan-destructive` — currently restart, shutdown, update, and
+release-update. The marker is emitted from the view itself, so a renamed route
+keeps its guard. Destructive requests prompt when stdin is a TTY and require
+`--yes` in non-interactive scripts.
 
 ```bash
 bin/koan-cli missions delete MISSION_ID --yes

--- a/docs/users/koan-cli.md
+++ b/docs/users/koan-cli.md
@@ -42,6 +42,10 @@ Settings resolve in this order:
 4. The first server URL in `koan/openapi.yaml` for the base URL, and a
    120-second response timeout.
 
+`configure` uses the same ladder to pick which profile it writes and which
+base URL it offers as the prompt default, so `KOAN_PROFILE=prod koan-cli
+configure` writes `[prod]`, not `[default]`.
+
 Empty environment values are ignored. Without any configuration, the public
 `health` command uses the specification's default local server and needs no
 token:

--- a/docs/users/koan-cli.md
+++ b/docs/users/koan-cli.md
@@ -1,7 +1,7 @@
 ---
 type: doc
 title: "Kōan REST CLI"
-description: "Configure and use bin/koan-cli to call every operation in Kōan's token-authenticated REST API."
+description: "Configure and use bin/koan-cli to call every operation in Kōan's token-authenticated REST API, with self-documenting --help."
 tags: [users]
 created: 2026-09-08
 updated: 2026-09-09
@@ -55,16 +55,24 @@ the corresponding nonzero exit code.
 
 ## Generated commands
 
-Commands follow the API resources. Discover the available roots and leaf
-commands with `--help`:
+Commands follow the API resources. `--help` is generated from the OpenAPI
+document, so every root, group, and leaf carries a one-line description pulled
+from its view's summary, and every spec-described flag shows its help text:
 
 ```bash
-bin/koan-cli --help
-bin/koan-cli missions --help
+bin/koan-cli --help              # every root command, plus global examples
+bin/koan-cli missions --help     # every leaf, plus group examples
+bin/koan-cli missions create --help  # per-flag help and the command XOR text note
 bin/koan-cli missions list -q status=pending
 bin/koan-cli missions get MISSION_ID
 bin/koan-cli observability logs
 ```
+
+Because the help is derived from the spec, a new endpoint is documented in the
+CLI for free as soon as its view docstring and `koan/openapi.yaml` land. Bodies
+declared with `anyOf` (for example `POST /v1/missions`, where `command` and
+`text` are mutually exclusive) render that constraint in prose on the command's
+`--help`.
 
 Each OpenAPI `operationId` also works as a hidden root-level alias for scripts
 that prefer specification identifiers. Public command names and aliases are
@@ -83,10 +91,10 @@ bin/koan-cli missions list -q status=pending -q project=my-toolkit
 ```
 
 Duplicate generic query keys use the last value. Schema-derived typed flags
-will appear automatically when the OpenAPI document contains request or query
-schemas, and will override a generic query value with the same name. The
-current committed specification only describes path parameters, so generic
-input remains the request-body and query interface today.
+appear automatically when the OpenAPI document contains request or query
+schemas, and will override a generic query value with the same name. The typed
+flags use clean metavars (`COMMAND`, `TEXT`, `PROJECT`, …) and their `--help`
+shows the schema's description where the spec provides one.
 
 Path parameters are positional and percent-encoded before dispatch:
 

--- a/docs/users/koan-cli.md
+++ b/docs/users/koan-cli.md
@@ -1,0 +1,142 @@
+---
+type: doc
+title: "Kōan REST CLI"
+description: "Configure and use bin/koan-cli to call every operation in Kōan's token-authenticated REST API."
+tags: [users]
+created: 2026-09-08
+updated: 2026-09-09
+---
+
+# Kōan REST CLI
+
+`bin/koan-cli` reads `koan/openapi.yaml` at runtime and exposes every
+documented REST operation without requiring package installation. Enable and
+start the API first, as described in the [REST API guide](../operations/rest-api.md).
+
+## Configure
+
+Create or update the default profile interactively:
+
+```bash
+bin/koan-cli configure
+```
+
+Profiles are stored in `~/.config/koan-cli.cfg`. The CLI creates this file with
+mode `0600` and also accepts an existing mode-`0400` file. It refuses a
+group- or world-readable file and prints the exact `chmod 600` repair command.
+Tokens never belong in command-line arguments.
+
+Create or select another profile by putting global options before the command:
+
+```bash
+bin/koan-cli --profile prod configure
+bin/koan-cli --profile prod status
+```
+
+Settings resolve in this order:
+
+1. `--profile` and `--base-url` command-line options.
+2. Non-empty `KOAN_PROFILE`, `KOAN_BASE_URL`, and `KOAN_API_TOKEN` values.
+3. Values in the selected profile.
+4. The first server URL in `koan/openapi.yaml` for the base URL.
+
+Empty environment values are ignored. Without any configuration, the public
+`health` command uses the specification's default local server and needs no
+token:
+
+```bash
+bin/koan-cli health
+```
+
+Configuration always saves before verification. Verification checks public
+health for reachability, then authenticated status to confirm the token; a
+stopped server does not discard the saved profile. Failed verification returns
+the corresponding nonzero exit code.
+
+## Generated commands
+
+Commands follow the API resources. Discover the available roots and leaf
+commands with `--help`:
+
+```bash
+bin/koan-cli --help
+bin/koan-cli missions --help
+bin/koan-cli missions list -q status=pending
+bin/koan-cli missions get MISSION_ID
+bin/koan-cli observability logs
+```
+
+Each OpenAPI `operationId` also works as a hidden root-level alias for scripts
+that prefer specification identifiers. Public command names and aliases are
+validated at startup so ambiguous specification changes fail locally.
+
+## Generic input
+
+Every operation accepts JSON through `--data`, from either inline text or an
+`@`-prefixed file, plus repeatable query pairs through `-q` or `--query`. This
+includes GET requests.
+
+```bash
+bin/koan-cli missions create --data '{"command":"/review https://github.com/org/repo/pull/42"}'
+bin/koan-cli missions create --data @request.json
+bin/koan-cli missions list -q status=pending -q project=my-toolkit
+```
+
+Duplicate generic query keys use the last value. Schema-derived typed flags
+will appear automatically when the OpenAPI document contains request or query
+schemas, and will override a generic query value with the same name. The
+current committed specification only describes path parameters, so generic
+input remains the request-body and query interface today.
+
+Path parameters are positional and percent-encoded before dispatch:
+
+```bash
+bin/koan-cli projects update my-toolkit --data '{"auto_merge":false}'
+```
+
+## Raw requests
+
+Use `raw` for debugging or for a server endpoint newer than the checked-out
+specification:
+
+```bash
+bin/koan-cli raw GET /v1/status
+bin/koan-cli raw POST /v1/missions --data @request.json -q trace=test
+```
+
+Raw requests require authentication except exactly `GET /v1/health`. A raw
+path must begin with `/`.
+
+## Output and exit codes
+
+Successful responses go to stdout as valid JSON. Output is pretty-printed on a
+TTY and compact when piped; `--pretty` and `--compact` override detection.
+HTTP error bodies and local diagnostics go to stderr, leaving stdout empty.
+Non-JSON response bodies are wrapped in a JSON object.
+
+| Code | Meaning |
+|---|---|
+| `0` | HTTP success |
+| `1` | Local/usage error or other 4xx response |
+| `2` | Authentication failure (`401` or `403`) |
+| `3` | Not found (`404`) |
+| `4` | Server error (`5xx`) |
+
+All DELETE requests plus restart, shutdown, update, and release-update requests
+are destructive. They prompt when stdin is a TTY and require `--yes` in
+non-interactive scripts.
+
+```bash
+bin/koan-cli missions delete MISSION_ID --yes
+```
+
+## Troubleshooting
+
+- `authentication required` means the selected profile has no token. Run
+  `bin/koan-cli configure` or set `KOAN_API_TOKEN`.
+- `token was rejected` means health succeeded but authenticated status returned
+  `401` or `403`. Generate a matching token with `make api-token`.
+- A connection-refused diagnostic lists the API setup sequence: enable
+  `api.enabled`, configure a generated token, then run `make api`.
+- Invalid JSON, malformed query pairs, and missing required values fail locally
+  without sending a request.

--- a/koan/app/api/__init__.py
+++ b/koan/app/api/__init__.py
@@ -52,6 +52,7 @@ def create_app(koan_root: Path = None, instance_dir: Path = None) -> Flask:
     # Health endpoint — unauthenticated liveness probe
     @app.route("/v1/health")
     def health():
+        """Liveness probe; public, no token required."""
         try:
             from app import __version__
             version = __version__

--- a/koan/app/api/openapi_gen.py
+++ b/koan/app/api/openapi_gen.py
@@ -23,6 +23,8 @@ import yaml
 from flask import Flask
 
 from app.api.openapi_metadata import (
+    DESTRUCTIVE_ATTR,
+    DESTRUCTIVE_EXTENSION,
     QUERY_PARAMETERS_ATTR,
     REQUEST_REQUIRED_ATTR,
     REQUEST_SCHEMA_ATTR,
@@ -129,6 +131,7 @@ def build_spec(app: Flask) -> dict:
         path_params = _path_params(openapi_path)
         query_params = getattr(view, QUERY_PARAMETERS_ATTR, ())
         request_schema = getattr(view, REQUEST_SCHEMA_ATTR, None)
+        destructive = bool(getattr(view, DESTRUCTIVE_ATTR, False))
 
         for method in methods:
             m = method.lower()
@@ -159,6 +162,8 @@ def build_spec(app: Flask) -> dict:
                         },
                     },
                 }
+            if destructive:
+                operation[DESTRUCTIVE_EXTENSION] = True
             if not secured:
                 # Override the global bearerAuth requirement — this route is public.
                 operation["security"] = []

--- a/koan/app/api/openapi_gen.py
+++ b/koan/app/api/openapi_gen.py
@@ -59,6 +59,18 @@ SUCCESS_STATUS = {
     ("post", "/v1/projects"): "201",
 }
 
+# One-line human summary per API tag (blueprint / command group). Feeds the
+# OpenAPI ``tags[].description``, which the CLI surfaces as group-level --help.
+# This is the single source for group help — keep each entry a short sentence.
+TAG_DESCRIPTIONS = {
+    "admin": "Config, pause/resume, restart, update and shutdown",
+    "health": "Liveness probe (no token required)",
+    "missions": "Queue, inspect, reorder and delete missions",
+    "observability": "Logs, metrics and usage",
+    "projects": "List, add, update and remove watched projects",
+    "status": "Current agent state, execution and mission counters",
+}
+
 _PATH_PARAM_RE = re.compile(r"<(?:[^:<>]+:)?([^<>]+)>")
 
 
@@ -153,6 +165,7 @@ def build_spec(app: Flask) -> dict:
 
             paths.setdefault(openapi_path, {})[m] = operation
 
+    sorted_tags = sorted(tags)
     return {
         "openapi": OPENAPI_VERSION,
         "info": {
@@ -165,7 +178,10 @@ def build_spec(app: Flask) -> dict:
         },
         "servers": [{"url": "http://127.0.0.1:8420", "description": "Default loopback bind"}],
         "security": [{"bearerAuth": []}],
-        "tags": [{"name": t} for t in sorted(tags)],
+        "tags": [
+            ({"name": t, "description": TAG_DESCRIPTIONS[t]} if t in TAG_DESCRIPTIONS else {"name": t})
+            for t in sorted_tags
+        ],
         "paths": paths,
         "components": {
             "securitySchemes": {

--- a/koan/app/api/openapi_gen.py
+++ b/koan/app/api/openapi_gen.py
@@ -179,7 +179,11 @@ def build_spec(app: Flask) -> dict:
         "servers": [{"url": "http://127.0.0.1:8420", "description": "Default loopback bind"}],
         "security": [{"bearerAuth": []}],
         "tags": [
-            ({"name": t, "description": TAG_DESCRIPTIONS[t]} if t in TAG_DESCRIPTIONS else {"name": t})
+            (
+                {"name": t, "description": TAG_DESCRIPTIONS[t]}
+                if t in TAG_DESCRIPTIONS
+                else {"name": t}
+            )
             for t in sorted_tags
         ],
         "paths": paths,

--- a/koan/app/api/openapi_gen.py
+++ b/koan/app/api/openapi_gen.py
@@ -1,9 +1,8 @@
 """Generate the OpenAPI document for the Kōan REST API from the live Flask app.
 
-The document is **derived** from the app's route table — it can only describe
-routes that are actually registered, so it cannot drift from the code. Auth
-requirements come from the ``require_token`` decorator marker
-(``_koan_requires_token``), not a hand-maintained allow-list.
+The document is **derived** from the app's route table and request metadata
+attached to registered views. Auth requirements come from the ``require_token``
+decorator marker (``_koan_requires_token``), not a hand-maintained allow-list.
 
 Usage::
 
@@ -17,10 +16,17 @@ See specs/005-openapi-enforcement/ and docs/operations/rest-api.md.
 import argparse
 import re
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 import yaml
 from flask import Flask
+
+from app.api.openapi_metadata import (
+    QUERY_PARAMETERS_ATTR,
+    REQUEST_REQUIRED_ATTR,
+    REQUEST_SCHEMA_ATTR,
+)
 
 # The API contract version (matches the /v1 URL prefix). Pinned deliberately so
 # that bumping app.__version__ on a release does NOT cause spurious spec drift.
@@ -91,7 +97,7 @@ def _tag(endpoint: str) -> str:
 def build_spec(app: Flask) -> dict:
     """Build the OpenAPI 3.1 document (as a plain dict) from ``app``'s route table.
 
-    Pure with respect to the route table: equal route tables yield equal dicts.
+    Pure with respect to registered routes and their attached metadata.
     """
     paths: dict = {}
     tags: set = set()
@@ -108,7 +114,9 @@ def build_spec(app: Flask) -> dict:
         secured = bool(getattr(view, "_koan_requires_token", False))
         tag = _tag(rule.endpoint)
         tags.add(tag)
-        params = _path_params(openapi_path)
+        path_params = _path_params(openapi_path)
+        query_params = getattr(view, QUERY_PARAMETERS_ATTR, ())
+        request_schema = getattr(view, REQUEST_SCHEMA_ATTR, None)
 
         for method in methods:
             m = method.lower()
@@ -127,8 +135,18 @@ def build_spec(app: Flask) -> dict:
                 "tags": [tag],
                 "responses": responses,
             }
-            if params:
-                operation["parameters"] = params
+            parameters = [*deepcopy(path_params), *deepcopy(query_params)]
+            if parameters:
+                operation["parameters"] = parameters
+            if request_schema is not None:
+                operation["requestBody"] = {
+                    "required": bool(getattr(view, REQUEST_REQUIRED_ATTR, True)),
+                    "content": {
+                        "application/json": {
+                            "schema": deepcopy(request_schema),
+                        },
+                    },
+                }
             if not secured:
                 # Override the global bearerAuth requirement — this route is public.
                 operation["security"] = []

--- a/koan/app/api/openapi_metadata.py
+++ b/koan/app/api/openapi_metadata.py
@@ -26,6 +26,8 @@ def openapi_operation(
     query_parameters: tuple[dict, ...] = (),
 ) -> Callable:
     """Attach request-side OpenAPI metadata to a Flask view."""
+    if request_schema is None and not request_required:
+        raise ValueError("request_required has no effect without request_schema")
 
     def decorate(view):
         if request_schema is not None:

--- a/koan/app/api/openapi_metadata.py
+++ b/koan/app/api/openapi_metadata.py
@@ -1,0 +1,38 @@
+"""Route-adjacent metadata consumed by the OpenAPI generator."""
+
+from collections.abc import Callable
+from typing import Any
+
+REQUEST_SCHEMA_ATTR = "_koan_openapi_request_schema"
+REQUEST_REQUIRED_ATTR = "_koan_openapi_request_required"
+QUERY_PARAMETERS_ATTR = "_koan_openapi_query_parameters"
+
+
+def query_parameter(name: str, schema: dict[str, Any], description: str) -> dict:
+    """Build one optional OpenAPI query-parameter declaration."""
+    return {
+        "name": name,
+        "in": "query",
+        "required": False,
+        "description": description,
+        "schema": schema,
+    }
+
+
+def openapi_operation(
+    *,
+    request_schema: dict[str, Any] | None = None,
+    request_required: bool = True,
+    query_parameters: tuple[dict, ...] = (),
+) -> Callable:
+    """Attach request-side OpenAPI metadata to a Flask view."""
+
+    def decorate(view):
+        if request_schema is not None:
+            setattr(view, REQUEST_SCHEMA_ATTR, request_schema)
+            setattr(view, REQUEST_REQUIRED_ATTR, request_required)
+        if query_parameters:
+            setattr(view, QUERY_PARAMETERS_ATTR, query_parameters)
+        return view
+
+    return decorate

--- a/koan/app/api/openapi_metadata.py
+++ b/koan/app/api/openapi_metadata.py
@@ -6,6 +6,11 @@ from typing import Any
 REQUEST_SCHEMA_ATTR = "_koan_openapi_request_schema"
 REQUEST_REQUIRED_ATTR = "_koan_openapi_request_required"
 QUERY_PARAMETERS_ATTR = "_koan_openapi_query_parameters"
+DESTRUCTIVE_ATTR = "_koan_openapi_destructive"
+# Vendor extension the generator emits for a destructive view. Clients (the REST
+# CLI) read it instead of maintaining their own method/path allow-list, the same
+# way auth is derived from the require_token marker.
+DESTRUCTIVE_EXTENSION = "x-koan-destructive"
 
 
 def query_parameter(name: str, schema: dict[str, Any], description: str) -> dict:
@@ -24,8 +29,14 @@ def openapi_operation(
     request_schema: dict[str, Any] | None = None,
     request_required: bool = True,
     query_parameters: tuple[dict, ...] = (),
+    destructive: bool = False,
 ) -> Callable:
-    """Attach request-side OpenAPI metadata to a Flask view."""
+    """Attach request-side OpenAPI metadata to a Flask view.
+
+    ``destructive=True`` marks an operation whose effect a client must confirm
+    before sending. It travels with the view, so renaming a route can never
+    silently drop the guard.
+    """
     if request_schema is None and not request_required:
         raise ValueError("request_required has no effect without request_schema")
 
@@ -35,6 +46,8 @@ def openapi_operation(
             setattr(view, REQUEST_REQUIRED_ATTR, request_required)
         if query_parameters:
             setattr(view, QUERY_PARAMETERS_ATTR, query_parameters)
+        if destructive:
+            setattr(view, DESTRUCTIVE_ATTR, True)
         return view
 
     return decorate

--- a/koan/app/api/routes_admin.py
+++ b/koan/app/api/routes_admin.py
@@ -113,6 +113,7 @@ def get_config():
 
 
 @bp.route("/v1/restart", methods=["POST"])
+@openapi_operation(destructive=True)
 @require_token
 def restart():
     """Request a full agent restart."""
@@ -128,6 +129,7 @@ def restart():
 
 
 @bp.route("/v1/shutdown", methods=["POST"])
+@openapi_operation(destructive=True)
 @require_token
 def shutdown():
     """Gracefully stop the agent."""
@@ -141,6 +143,7 @@ def shutdown():
 
 
 @bp.route("/v1/update", methods=["POST"])
+@openapi_operation(destructive=True)
 @require_token
 def update():
     """Pull upstream changes and restart."""
@@ -158,6 +161,7 @@ def update():
 
 
 @bp.route("/v1/update_release", methods=["POST"])
+@openapi_operation(destructive=True)
 @require_token
 def update_release():
     """Check out the latest tagged release and restart."""

--- a/koan/app/api/routes_admin.py
+++ b/koan/app/api/routes_admin.py
@@ -66,6 +66,7 @@ def _mask_secrets(obj, depth: int = 0):
 @openapi_operation(request_schema=_PAUSE_SCHEMA, request_required=False)
 @require_token
 def pause():
+    """Pause the agent, optionally for a duration like \"2h\" or \"30m\"."""
     data = request.get_json(silent=True) or {}
     duration_str = data.get("duration", "").strip()
 
@@ -89,6 +90,7 @@ def pause():
 @bp.route("/v1/resume", methods=["POST"])
 @require_token
 def resume():
+    """Resume the agent after a pause."""
     from app.pause_manager import remove_pause
     remove_pause(str(_koan_root()))
     return jsonify({"status": "resumed"})
@@ -97,6 +99,7 @@ def resume():
 @bp.route("/v1/config", methods=["GET"])
 @require_token
 def get_config():
+    """Get the effective config, with secrets masked out."""
     from app.utils import load_config
     from app.utils import get_known_projects
     try:
@@ -112,6 +115,7 @@ def get_config():
 @bp.route("/v1/restart", methods=["POST"])
 @require_token
 def restart():
+    """Request a full agent restart."""
     # Route through request_restart() so both per-consumer markers are written
     # and the restart actually fires. Touching legacy .koan-restart was a
     # no-op — no consumer polls it.
@@ -126,6 +130,7 @@ def restart():
 @bp.route("/v1/shutdown", methods=["POST"])
 @require_token
 def shutdown():
+    """Gracefully stop the agent."""
     from app.signals import STOP_FILE
     stop_file = _koan_root() / STOP_FILE
     try:
@@ -138,6 +143,7 @@ def shutdown():
 @bp.route("/v1/update", methods=["POST"])
 @require_token
 def update():
+    """Pull upstream changes and restart."""
     try:
         from app.update_manager import check_update_safety, pull_upstream
         safety_msg = check_update_safety(_koan_root())
@@ -154,6 +160,7 @@ def update():
 @bp.route("/v1/update_release", methods=["POST"])
 @require_token
 def update_release():
+    """Check out the latest tagged release and restart."""
     try:
         from app.update_manager import checkout_latest_tag
         result = checkout_latest_tag(_koan_root())

--- a/koan/app/api/routes_admin.py
+++ b/koan/app/api/routes_admin.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation
 
 bp = Blueprint("admin", __name__)
 
@@ -23,6 +24,16 @@ _SECRET_SUBSTRINGS = (
     "signing_key",
     "encryption_key",
 )
+
+_PAUSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "duration": {
+            "type": "string",
+            "description": "Duration such as 2h, 30m, or 1h30m; omit for indefinite.",
+        },
+    },
+}
 
 
 def _koan_root() -> Path:
@@ -52,6 +63,7 @@ def _mask_secrets(obj, depth: int = 0):
 
 
 @bp.route("/v1/pause", methods=["POST"])
+@openapi_operation(request_schema=_PAUSE_SCHEMA, request_required=False)
 @require_token
 def pause():
     data = request.get_json(silent=True) or {}

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -162,6 +162,7 @@ def _find_pending_position(content: str, stored_text: str):
 @openapi_operation(query_parameters=_LIST_MISSIONS_QUERY_PARAMETERS)
 @require_token
 def list_missions_route():
+    """List missions, newest first, optionally filtered."""
     status_filter = request.args.get("status")
     project_filter = request.args.get("project")
     records = list_missions(_instance_dir(), status_filter, project_filter)
@@ -178,6 +179,7 @@ def list_missions_route():
 @openapi_operation(request_schema=_CREATE_MISSION_SCHEMA)
 @require_token
 def create_mission():
+    """Queue a new mission."""
     data = request.get_json(silent=True) or {}
     try:
         text, project, urgent = _validate_mission_body(data)
@@ -197,6 +199,7 @@ def create_mission():
 @openapi_operation(request_schema=_REORDER_MISSION_SCHEMA)
 @require_token
 def reorder_mission_route():
+    """Move a pending mission to a new position."""
     data = request.get_json(silent=True)
     if data is None:
         return jsonify(
@@ -253,6 +256,7 @@ def reorder_mission_route():
 @bp.route("/v1/missions/<mission_id>", methods=["GET"])
 @require_token
 def get_mission_route(mission_id: str):
+    """Fetch one mission by id."""
     rec = get_mission(_instance_dir(), mission_id)
     if rec is None:
         return jsonify({"error": {"code": "not_found", "message": "Mission not found"}}), 404
@@ -289,6 +293,7 @@ def get_mission_route(mission_id: str):
 @bp.route("/v1/missions/<mission_id>/result", methods=["GET"])
 @require_token
 def get_mission_result_route(mission_id: str):
+    """Fetch a finished mission's result."""
     if get_mission(_instance_dir(), mission_id) is None:
         return jsonify({"error": {"code": "not_found", "message": "Mission not found"}}), 404
     # reconcile so a just-completed mission gets its result attached first
@@ -304,6 +309,7 @@ def get_mission_result_route(mission_id: str):
 @bp.route("/v1/missions/<mission_id>", methods=["DELETE"])
 @require_token
 def delete_mission(mission_id: str):
+    """Remove a pending mission."""
     rec = get_mission(_instance_dir(), mission_id)
     if rec is None:
         return jsonify({"error": {"code": "not_found", "message": "Mission not found"}}), 404
@@ -341,6 +347,7 @@ def delete_mission(mission_id: str):
 @openapi_operation(request_schema=_EDIT_MISSION_SCHEMA)
 @require_token
 def edit_mission(mission_id: str):
+    """Change a pending mission."""
     rec = get_mission(_instance_dir(), mission_id)
     if rec is None:
         return jsonify({"error": {"code": "not_found", "message": "Mission not found"}}), 404

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation, query_parameter
 from app.api.mission_index import (
     _normalize_for_match,
     cancel_mission,
@@ -21,6 +22,76 @@ bp = Blueprint("missions", __name__)
 
 # Validate command-style missions
 _COMMAND_RE = re.compile(r"^/[a-zA-Z0-9_]+")
+
+_CREATE_MISSION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "Slash-command mission; takes precedence over text.",
+        },
+        "text": {
+            "type": "string",
+            "description": "Free-form mission text.",
+        },
+        "project": {
+            "type": "string",
+            "description": "Optional project name added as a project tag.",
+        },
+        "urgent": {
+            "type": "boolean",
+            "default": False,
+            "description": "Insert the mission at the front of the pending queue.",
+        },
+    },
+    "anyOf": [
+        {
+            "required": ["command"],
+            "properties": {"command": {"pattern": r"\S"}},
+        },
+        {
+            "required": ["text"],
+            "properties": {"text": {"pattern": r"\S"}},
+        },
+    ],
+}
+
+_REORDER_MISSION_SCHEMA = {
+    "type": "object",
+    "required": ["mission_id", "target_position"],
+    "properties": {
+        "mission_id": {"type": "string", "pattern": r"\S"},
+        "target_position": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "One-indexed position in the pending queue.",
+        },
+    },
+}
+
+_EDIT_MISSION_SCHEMA = {
+    "type": "object",
+    "required": ["text"],
+    "properties": {
+        "text": {"type": "string", "pattern": r"\S"},
+    },
+}
+
+_LIST_MISSIONS_QUERY_PARAMETERS = (
+    query_parameter(
+        "status",
+        {
+            "type": "string",
+            "enum": ["pending", "in_progress", "done", "failed", "removed"],
+        },
+        "Restrict results to one mission status.",
+    ),
+    query_parameter(
+        "project",
+        {"type": "string"},
+        "Restrict results to one project.",
+    ),
+)
 
 
 def _instance_dir() -> Path:
@@ -88,6 +159,7 @@ def _find_pending_position(content: str, stored_text: str):
 
 
 @bp.route("/v1/missions", methods=["GET"])
+@openapi_operation(query_parameters=_LIST_MISSIONS_QUERY_PARAMETERS)
 @require_token
 def list_missions_route():
     status_filter = request.args.get("status")
@@ -103,6 +175,7 @@ def list_missions_route():
 
 
 @bp.route("/v1/missions", methods=["POST"])
+@openapi_operation(request_schema=_CREATE_MISSION_SCHEMA)
 @require_token
 def create_mission():
     data = request.get_json(silent=True) or {}
@@ -121,6 +194,7 @@ def create_mission():
 
 
 @bp.route("/v1/missions/reorder", methods=["POST"])
+@openapi_operation(request_schema=_REORDER_MISSION_SCHEMA)
 @require_token
 def reorder_mission_route():
     data = request.get_json(silent=True)
@@ -264,6 +338,7 @@ def delete_mission(mission_id: str):
 
 
 @bp.route("/v1/missions/<mission_id>", methods=["PATCH"])
+@openapi_operation(request_schema=_EDIT_MISSION_SCHEMA)
 @require_token
 def edit_mission(mission_id: str):
     rec = get_mission(_instance_dir(), mission_id)

--- a/koan/app/api/routes_observability.py
+++ b/koan/app/api/routes_observability.py
@@ -130,6 +130,7 @@ def _int_param(name: str, default: str) -> int:
 @openapi_operation(query_parameters=_USAGE_QUERY_PARAMETERS)
 @require_token
 def usage():
+    """Daily agent usage totals, optionally split by project."""
     from app.usage_service import build_usage_payload
 
     try:
@@ -152,6 +153,7 @@ def usage():
 @openapi_operation(query_parameters=_METRICS_QUERY_PARAMETERS)
 @require_token
 def metrics():
+    """Mission throughput and success metrics over a window."""
     from app.mission_metrics import (
         compute_global_metrics,
         compute_project_metrics,
@@ -189,6 +191,7 @@ def metrics():
 @openapi_operation(query_parameters=_LOGS_QUERY_PARAMETERS)
 @require_token
 def logs():
+    """Tail recent agent logs, optionally filtered by source."""
     from app.log_reader import read_logs
 
     source = request.args.get("source", "all")

--- a/koan/app/api/routes_observability.py
+++ b/koan/app/api/routes_observability.py
@@ -5,8 +5,104 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation, query_parameter
+from app.log_reader import LOG_DEFAULT_LIMIT, LOG_MAX_LIMIT
 
 bp = Blueprint("observability", __name__)
+
+_USAGE_DEFAULT_DAYS = 7
+_USAGE_DEFAULT_OFFSET = 0
+_USAGE_MIN_DAYS = 1
+_USAGE_MAX_DAYS = 100
+_METRICS_DEFAULT_DAYS = 30
+_METRICS_MIN_DAYS = 0
+_METRICS_MAX_DAYS = 365
+
+_USAGE_QUERY_PARAMETERS = (
+    query_parameter(
+        "days",
+        {
+            "type": "integer",
+            "default": _USAGE_DEFAULT_DAYS,
+            "minimum": _USAGE_MIN_DAYS,
+            "maximum": _USAGE_MAX_DAYS,
+        },
+        "Window length; values are clamped to the documented range.",
+    ),
+    query_parameter(
+        "offset",
+        {
+            "type": "integer",
+            "default": _USAGE_DEFAULT_OFFSET,
+            "minimum": 0,
+        },
+        "Shift the window back by this many granularity units.",
+    ),
+    query_parameter(
+        "granularity",
+        {
+            "type": "string",
+            "enum": ["day", "week", "month"],
+            "default": "day",
+        },
+        "Series bucketing granularity.",
+    ),
+    query_parameter(
+        "stacked",
+        {"type": "boolean", "default": False},
+        "Include a per-project series breakdown.",
+    ),
+    query_parameter(
+        "project",
+        {"type": "string"},
+        "Restrict totals and series to one project.",
+    ),
+)
+
+_METRICS_QUERY_PARAMETERS = (
+    query_parameter(
+        "days",
+        {
+            "type": "integer",
+            "default": _METRICS_DEFAULT_DAYS,
+            "minimum": _METRICS_MIN_DAYS,
+            "maximum": _METRICS_MAX_DAYS,
+        },
+        "Lookback window; values are clamped to the documented range.",
+    ),
+    query_parameter(
+        "project",
+        {"type": "string"},
+        "Return metrics and trend for one project.",
+    ),
+)
+
+_LOGS_QUERY_PARAMETERS = (
+    query_parameter(
+        "source",
+        {
+            "type": "string",
+            "enum": ["run", "awake", "all"],
+            "default": "all",
+        },
+        "Log source to read.",
+    ),
+    query_parameter(
+        "limit",
+        {
+            "type": "integer",
+            "default": LOG_DEFAULT_LIMIT,
+            "minimum": 1,
+            "maximum": LOG_MAX_LIMIT,
+        },
+        "Maximum lines returned per source.",
+    ),
+    query_parameter(
+        "q",
+        {"type": "string"},
+        "Case-insensitive substring filter.",
+    ),
+)
 
 
 def _instance_dir() -> Path:
@@ -31,13 +127,14 @@ def _int_param(name: str, default: str) -> int:
 
 
 @bp.route("/v1/usage")
+@openapi_operation(query_parameters=_USAGE_QUERY_PARAMETERS)
 @require_token
 def usage():
     from app.usage_service import build_usage_payload
 
     try:
-        days = _int_param("days", "7")
-        offset = _int_param("offset", "0")
+        days = _int_param("days", str(_USAGE_DEFAULT_DAYS))
+        offset = _int_param("offset", str(_USAGE_DEFAULT_OFFSET))
     except _BadParam as e:
         return jsonify({"error": {"code": "invalid_request", "message": str(e)}}), 422
     stacked = request.args.get("stacked", "false").lower() in ("true", "1", "yes")
@@ -52,6 +149,7 @@ def usage():
 
 
 @bp.route("/v1/metrics")
+@openapi_operation(query_parameters=_METRICS_QUERY_PARAMETERS)
 @require_token
 def metrics():
     from app.mission_metrics import (
@@ -61,7 +159,13 @@ def metrics():
     )
 
     try:
-        days = max(0, min(_int_param("days", "30"), 365))
+        days = max(
+            _METRICS_MIN_DAYS,
+            min(
+                _int_param("days", str(_METRICS_DEFAULT_DAYS)),
+                _METRICS_MAX_DAYS,
+            ),
+        )
     except _BadParam as e:
         return jsonify({"error": {"code": "invalid_request", "message": str(e)}}), 422
     project = request.args.get("project", "")
@@ -82,9 +186,10 @@ def metrics():
 
 
 @bp.route("/v1/logs")
+@openapi_operation(query_parameters=_LOGS_QUERY_PARAMETERS)
 @require_token
 def logs():
-    from app.log_reader import LOG_DEFAULT_LIMIT, read_logs
+    from app.log_reader import read_logs
 
     source = request.args.get("source", "all")
     try:

--- a/koan/app/api/routes_projects.py
+++ b/koan/app/api/routes_projects.py
@@ -6,10 +6,48 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation
 
 log = logging.getLogger("koan.api")
 
 bp = Blueprint("projects", __name__)
+
+_ADD_PROJECT_SCHEMA = {
+    "type": "object",
+    "required": ["github_url"],
+    "properties": {
+        "github_url": {"type": "string", "pattern": r"\S"},
+        "name": {"type": "string"},
+    },
+}
+
+_PATCH_PROJECT_SCHEMA = {
+    "type": "object",
+    "required": ["patch"],
+    "properties": {
+        "patch": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "cli_provider": {"type": "string"},
+                "autoreview": {"type": "boolean"},
+                "focus": {"type": "boolean"},
+                "exploration": {"type": "boolean"},
+                "rtk": {"type": "boolean"},
+                "devcontainer": {"type": "boolean"},
+                "max_open_prs": {"type": "integer"},
+                "max_pending_branches": {"type": "integer"},
+                "github_url": {"type": "string"},
+                "git_auto_merge.enabled": {"type": "boolean"},
+                "git_auto_merge.base_branch": {"type": "string"},
+                "git_auto_merge.strategy": {
+                    "type": "string",
+                    "enum": ["squash", "merge", "rebase"],
+                },
+            },
+        },
+    },
+}
 
 
 def _koan_root() -> Path:
@@ -76,6 +114,7 @@ def list_projects():
 
 
 @bp.route("/v1/projects", methods=["POST"])
+@openapi_operation(request_schema=_ADD_PROJECT_SCHEMA)
 @require_token
 def add_project():
     data = request.get_json(silent=True) or {}
@@ -104,6 +143,7 @@ def delete_project(name: str):
 
 
 @bp.route("/v1/projects/<name>", methods=["PATCH"])
+@openapi_operation(request_schema=_PATCH_PROJECT_SCHEMA)
 @require_token
 def patch_project(name: str):
     from app.projects_config import apply_project_patch

--- a/koan/app/api/routes_projects.py
+++ b/koan/app/api/routes_projects.py
@@ -94,6 +94,7 @@ def _run_skill(command: str, args: str = "") -> tuple:
 @bp.route("/v1/projects", methods=["GET"])
 @require_token
 def list_projects():
+    """List watched projects."""
     from app.utils import get_known_projects
     projects = get_known_projects()
     result = []
@@ -117,6 +118,7 @@ def list_projects():
 @openapi_operation(request_schema=_ADD_PROJECT_SCHEMA)
 @require_token
 def add_project():
+    """Add a project to watch."""
     data = request.get_json(silent=True) or {}
     github_url = data.get("github_url", "").strip()
     if not github_url:
@@ -136,6 +138,7 @@ def add_project():
 @bp.route("/v1/projects/<name>", methods=["DELETE"])
 @require_token
 def delete_project(name: str):
+    """Remove a watched project."""
     ok, result = _run_skill("delete_project", name)
     if not ok:
         return jsonify({"error": {"code": "skill_error", "message": result}}), 500
@@ -146,6 +149,7 @@ def delete_project(name: str):
 @openapi_operation(request_schema=_PATCH_PROJECT_SCHEMA)
 @require_token
 def patch_project(name: str):
+    """Update a watched project's configuration."""
     from app.projects_config import apply_project_patch
 
     data = request.get_json(silent=True)

--- a/koan/app/api/routes_status.py
+++ b/koan/app/api/routes_status.py
@@ -130,6 +130,7 @@ def _execution_truth(agent: dict, missions: dict, koan_root: Path) -> dict:
 @bp.route("/v1/status")
 @require_token
 def status():
+    """Get current agent state, execution and mission counters."""
     agent = _get_agent_state()
     missions = _mission_counts()
     return jsonify(

--- a/koan/app/cli/__init__.py
+++ b/koan/app/cli/__init__.py
@@ -1,0 +1,21 @@
+"""Public contracts shared by the Kōan REST CLI."""
+
+EXIT_OK = 0
+EXIT_LOCAL = 1
+EXIT_AUTH = 2
+EXIT_NOT_FOUND = 3
+EXIT_SERVER = 4
+
+
+class CliError(Exception):
+    """A local CLI or configuration error safe to print to stderr."""
+
+
+__all__ = [
+    "CliError",
+    "EXIT_AUTH",
+    "EXIT_LOCAL",
+    "EXIT_NOT_FOUND",
+    "EXIT_OK",
+    "EXIT_SERVER",
+]

--- a/koan/app/cli/commands.py
+++ b/koan/app/cli/commands.py
@@ -1,0 +1,260 @@
+"""Generate CLI arguments and convert them into transport-neutral requests."""
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from app.cli import CliError
+from app.cli.spec import Operation
+
+
+DESTRUCTIVE = {
+    ("POST", "/v1/restart"),
+    ("POST", "/v1/shutdown"),
+    ("POST", "/v1/update"),
+    ("POST", "/v1/update_release"),
+}
+
+
+class CliArgumentParser(argparse.ArgumentParser):
+    """Argument parser whose usage errors follow the CLI exit contract."""
+
+    def error(self, message):
+        self.print_usage()
+        self.exit(1, f"{self.prog}: error: {message}\n")
+
+
+def _boolean(value: str) -> bool:
+    normalized = value.lower()
+    if normalized in {"1", "true", "yes"}:
+        return True
+    if normalized in {"0", "false", "no"}:
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def _schema_type(schema: dict[str, Any]):
+    return {
+        "integer": int,
+        "number": float,
+        "boolean": _boolean,
+    }.get(schema.get("type"), str)
+
+
+def _add_common_request_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--data", help="JSON text or @path, valid for every method")
+    parser.add_argument(
+        "-q", "--query", action="append", default=[], metavar="KEY=VALUE"
+    )
+    parser.add_argument("--yes", action="store_true")
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--compact", action="store_true")
+    output.add_argument("--pretty", action="store_true")
+
+
+def _configure_operation_parser(
+    parser: argparse.ArgumentParser,
+    operation: Operation,
+) -> None:
+    for parameter in operation.parameters:
+        if parameter.location == "path":
+            parser.add_argument(parameter.name)
+        elif parameter.location == "query":
+            parser.add_argument(
+                f"--{parameter.name.replace('_', '-')}",
+                dest=f"_query_{parameter.name}",
+                type=_schema_type(parameter.schema),
+            )
+    properties = (operation.body_schema or {}).get("properties", {})
+    for name, schema in properties.items():
+        parser.add_argument(
+            f"--{name.replace('_', '-')}",
+            dest=f"_body_{name}",
+            type=_schema_type(schema),
+        )
+    _add_common_request_flags(parser)
+    parser.set_defaults(_operation=operation)
+
+
+def build_parser(operations: list[Operation]) -> CliArgumentParser:
+    parser = CliArgumentParser(prog="koan-cli")
+    parser.add_argument("--profile")
+    parser.add_argument("--base-url")
+    roots = parser.add_subparsers(dest="_root", required=True)
+
+    configure = roots.add_parser("configure")
+    configure.set_defaults(_builtin="configure")
+
+    raw = roots.add_parser("raw")
+    raw.add_argument("raw_method")
+    raw.add_argument("raw_path")
+    _add_common_request_flags(raw)
+    raw.set_defaults(_builtin="raw")
+
+    groups = {}
+    for operation in sorted(operations, key=lambda item: item.command):
+        if len(operation.command) == 1:
+            leaf = roots.add_parser(operation.command[0])
+        else:
+            group_name, leaf_name = operation.command
+            if group_name not in groups:
+                group = roots.add_parser(group_name)
+                groups[group_name] = group.add_subparsers(
+                    dest=f"_{group_name}_command",
+                    required=True,
+                )
+            leaf = groups[group_name].add_parser(leaf_name)
+        _configure_operation_parser(leaf, operation)
+    return parser
+
+
+def expand_alias(argv: list[str], operations: list[Operation]) -> list[str]:
+    if not argv:
+        return argv
+    index = 0
+    while index < len(argv):
+        value = argv[index]
+        if value in {"--profile", "--base-url"}:
+            index += 2
+            continue
+        if value.startswith("--profile=") or value.startswith("--base-url="):
+            index += 1
+            continue
+        break
+    if index >= len(argv):
+        return argv
+    aliases = {operation.operation_id: operation.command for operation in operations}
+    command = aliases.get(argv[index])
+    if command is None:
+        return argv
+    return [*argv[:index], *command, *argv[index + 1 :]]
+
+
+@dataclass(frozen=True)
+class RequestPlan:
+    method: str
+    url: str
+    query: dict[str, Any]
+    body: Any
+    has_body: bool
+    requires_auth: bool
+    destructive: bool
+
+
+def _load_json(value: str) -> Any:
+    if value.startswith("@"):
+        try:
+            text = Path(value[1:]).read_text()
+        except OSError as exc:
+            raise CliError(f"cannot read --data file {value[1:]}: {exc}") from exc
+    else:
+        text = value
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise CliError(f"invalid JSON for --data: {exc.msg}") from exc
+
+
+def _query_pairs(values: list[str]) -> dict[str, str]:
+    result = {}
+    for value in values:
+        if "=" not in value:
+            raise CliError(f"query value must be KEY=VALUE: {value}")
+        key, item = value.split("=", 1)
+        if not key:
+            raise CliError("query key cannot be empty")
+        result[key] = item
+    return result
+
+
+def _render_path(operation: Operation, args: argparse.Namespace) -> str:
+    path = operation.path
+    for parameter in operation.parameters:
+        if parameter.location == "path":
+            encoded = quote(str(getattr(args, parameter.name)), safe="")
+            path = path.replace(f"{{{parameter.name}}}", encoded)
+    if re.search(r"{[^{}]+}", path):
+        raise CliError(f"unresolved path parameter in {path}")
+    return path
+
+
+def build_operation_request(
+    operation: Operation,
+    args: argparse.Namespace,
+    base_url: str,
+) -> RequestPlan:
+    query = _query_pairs(args.query)
+    for parameter in operation.parameters:
+        if parameter.location != "query":
+            continue
+        value = vars(args).get(f"_query_{parameter.name}")
+        if value is not None:
+            query[parameter.name] = value
+        if parameter.required and parameter.name not in query:
+            raise CliError(f"missing required query parameter: {parameter.name}")
+
+    has_body = args.data is not None
+    body = _load_json(args.data) if has_body else {}
+    body_values = {
+        name: value
+        for name in (operation.body_schema or {}).get("properties", {})
+        if (value := vars(args).get(f"_body_{name}")) is not None
+    }
+    if body_values:
+        if has_body and not isinstance(body, dict):
+            raise CliError("typed body flags cannot be merged into non-object JSON")
+        body.update(body_values)
+        has_body = True
+
+    required = set((operation.body_schema or {}).get("required", []))
+    missing = required - set(body) if isinstance(body, dict) else required
+    if operation.body_required and not has_body:
+        raise CliError("this operation requires a JSON request body")
+    if missing:
+        raise CliError(f"missing required body field: {sorted(missing)[0]}")
+
+    rendered = _render_path(operation, args)
+    return RequestPlan(
+        method=operation.method,
+        url=f"{base_url.rstrip('/')}/{rendered.lstrip('/')}",
+        query=query,
+        body=body,
+        has_body=has_body,
+        requires_auth=operation.requires_auth,
+        destructive=is_destructive(operation.method, operation.path),
+    )
+
+
+def is_destructive(method: str, path: str) -> bool:
+    normalized = (method.upper(), path.split("?", 1)[0])
+    return normalized[0] == "DELETE" or normalized in DESTRUCTIVE
+
+
+def build_raw_request(
+    method: str,
+    path: str,
+    base_url: str,
+    *,
+    data: str | None,
+    query: list[str],
+) -> RequestPlan:
+    method = method.upper()
+    if not method.isalpha():
+        raise CliError(f"invalid HTTP method: {method}")
+    if not path.startswith("/"):
+        raise CliError("raw path must start with /")
+    return RequestPlan(
+        method=method,
+        url=f"{base_url.rstrip('/')}/{path.lstrip('/')}",
+        query=_query_pairs(query),
+        body=_load_json(data) if data is not None else None,
+        has_body=data is not None,
+        requires_auth=not (
+            method == "GET" and path.split("?", 1)[0] == "/v1/health"
+        ),
+        destructive=is_destructive(method, path),
+    )

--- a/koan/app/cli/commands.py
+++ b/koan/app/cli/commands.py
@@ -9,7 +9,62 @@ from typing import Any
 from urllib.parse import quote
 
 from app.cli import CliError
-from app.cli.spec import Operation
+from app.cli.spec import Operation, load_tag_descriptions
+
+# One executable example per group, shown in that group's --help epilog.
+GROUP_EXAMPLES = {
+    "missions": [
+        "koan-cli missions list --status pending",
+        'koan-cli missions create --text "fix the flaky test" --project koan',
+        'koan-cli missions create --command "/fix 1234"',
+        "koan-cli missions get 42",
+        "koan-cli missions delete 42 --yes",
+    ],
+    "projects": [
+        "koan-cli projects list --pretty",
+        'koan-cli projects create --github_url https://github.com/acme/my-toolkit',
+        "koan-cli projects update my-toolkit",
+    ],
+    "observability": [
+        "koan-cli observability usage --days 30",
+        "koan-cli observability metrics --pretty",
+        "koan-cli observability logs --limit 200",
+    ],
+    "admin": [
+        "koan-cli admin config",
+        "koan-cli admin pause",
+        "koan-cli admin resume",
+        "koan-cli admin restart --yes",
+        "koan-cli admin shutdown --yes",
+    ],
+    "health": ["koan-cli health"],
+    "status": ["koan-cli status"],
+}
+
+
+def _example_epilog(examples: list[str]) -> str | None:
+    if not examples:
+        return None
+    return "examples:\n  " + "\n  ".join(examples)
+
+
+def _first_examples() -> list[str]:
+    examples = []
+    examples.append("koan-cli status")
+    examples.append('koan-cli missions create --text "review PR 42" --project koan')
+    examples.append("koan-cli projects list --pretty")
+    examples.append("koan-cli raw GET /v1/metrics")
+    return examples
+
+
+def _root_epilog() -> str:
+    lines = ["examples:"] + [f"  {line}" for line in _first_examples()]
+    lines.append("")
+    lines.append(
+        "The bearer token comes from KOAN_API_TOKEN or the profile. Run "
+        "`koan-cli configure` to write one."
+    )
+    return "\n".join(lines)
 
 
 DESTRUCTIVE = {
@@ -20,8 +75,21 @@ DESTRUCTIVE = {
 }
 
 
+class _RawHelp(argparse.RawDescriptionHelpFormatter):
+    """Help formatter that preserves newlines in help/description/epilog.
+
+    The group and root epilogs are hand-formatted, multi-line example blocks
+    (and the ``anyOf`` note appends a line to a generated description); the
+    default formatter would collapse them onto one line.
+    """
+
+
 class CliArgumentParser(argparse.ArgumentParser):
     """Argument parser whose usage errors follow the CLI exit contract."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("formatter_class", _RawHelp)
+        super().__init__(*args, **kwargs)
 
     def error(self, message):
         self.print_usage()
@@ -48,12 +116,57 @@ def _schema_type(schema: dict[str, Any]):
 def _add_common_request_flags(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--data", help="JSON text or @path, valid for every method")
     parser.add_argument(
-        "-q", "--query", action="append", default=[], metavar="KEY=VALUE"
+        "-q",
+        "--query",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Raw query parameter, repeated for each KEY=VALUE pair.",
     )
-    parser.add_argument("--yes", action="store_true")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Skip the confirmation prompt on destructive requests. "
+            "Required when stdin is not a TTY."
+        ),
+    )
     output = parser.add_mutually_exclusive_group()
-    output.add_argument("--compact", action="store_true")
-    output.add_argument("--pretty", action="store_true")
+    output.add_argument(
+        "--compact", action="store_true", help="Force single-line JSON (default when piped)."
+    )
+    output.add_argument(
+        "--pretty", action="store_true", help="Force indented JSON (default on a TTY)."
+    )
+
+
+def _metavar(schema: dict[str, Any], fallback: str) -> str:
+    if schema.get("type") == "boolean":
+        return "true|false"
+    return str(schema.get("title") or fallback).upper()
+
+
+def _required_note(schema: dict | None) -> str | None:
+    """Render an ``anyOf`` body schema as an argparse description note.
+
+    The CLI renders each ``anyOf`` branch's properties as independent flags, so
+    a schema like ``command XOR text`` cannot express its exclusivity in the
+    parser itself. State it in prose on the leaf's description instead.
+    """
+    if not schema:
+        return None
+    branches = schema.get("anyOf")
+    if not isinstance(branches, list) or not branches:
+        return None
+    labels = []
+    for branch in branches:
+        required = branch.get("required")
+        if isinstance(required, list) and len(required) == 1:
+            labels.append(required[0])
+    if len(labels) == len(branches) and len(labels) > 1:
+        flags = ", ".join("--" + label.replace("_", "-") for label in labels)
+        return f"Provide exactly one of {flags}."
+    return None
 
 
 def _configure_operation_parser(
@@ -62,12 +175,18 @@ def _configure_operation_parser(
 ) -> None:
     for parameter in operation.parameters:
         if parameter.location == "path":
-            parser.add_argument(parameter.name)
+            parser.add_argument(
+                parameter.name,
+                metavar=parameter.name.replace("_", "-").upper(),
+                help=parameter.description or None,
+            )
         elif parameter.location == "query":
             parser.add_argument(
                 f"--{parameter.name.replace('_', '-')}",
                 dest=f"_query_{parameter.name}",
                 type=_schema_type(parameter.schema),
+                metavar=_metavar(parameter.schema, parameter.name),
+                help=parameter.description or None,
             )
     properties = (operation.body_schema or {}).get("properties", {})
     for name, schema in properties.items():
@@ -75,40 +194,82 @@ def _configure_operation_parser(
             f"--{name.replace('_', '-')}",
             dest=f"_body_{name}",
             type=_schema_type(schema),
+            metavar=_metavar(schema, name),
+            help=schema.get("description") or None,
         )
+
+    note = _required_note(operation.body_schema)
+    if note:
+        base = parser.description.rstrip(".") if parser.description else ""
+        parser.description = f"{base}. {note}" if base else note
     _add_common_request_flags(parser)
     parser.set_defaults(_operation=operation)
 
 
-def build_parser(operations: list[Operation]) -> CliArgumentParser:
+def build_parser(
+    operations: list[Operation],
+    spec: dict[str, Any] | None = None,
+) -> CliArgumentParser:
     parser = CliArgumentParser(prog="koan-cli")
+    parser.description = "Command-line client for the Kōan REST API."
     parser.add_argument("--profile")
     parser.add_argument("--base-url")
     roots = parser.add_subparsers(dest="_root", required=True)
 
-    configure = roots.add_parser("configure")
+    configure = roots.add_parser(
+        "configure",
+        help="Write a named profile to the config file.",
+        description=(
+            "Write base URL and bearer token to a named profile in the config file."
+        ),
+    )
     configure.set_defaults(_builtin="configure")
 
-    raw = roots.add_parser("raw")
-    raw.add_argument("raw_method")
-    raw.add_argument("raw_path")
+    raw = roots.add_parser(
+        "raw",
+        help="Send an arbitrary METHOD/PATH request.",
+        description="Send an arbitrary HTTP request to the Kōan REST API.",
+    )
+    raw.add_argument("raw_method", metavar="METHOD")
+    raw.add_argument("raw_path", metavar="PATH")
     _add_common_request_flags(raw)
     raw.set_defaults(_builtin="raw")
+
+    tag_descriptions = load_tag_descriptions(spec or {})
+
+    def _tag_description(tagname: str) -> str | None:
+        return tag_descriptions.get(tagname) or None
 
     groups = {}
     for operation in sorted(operations, key=lambda item: item.command):
         if len(operation.command) == 1:
-            leaf = roots.add_parser(operation.command[0])
+            leaf = roots.add_parser(
+                operation.command[0],
+                help=operation.summary,
+                description=operation.description or operation.summary,
+                epilog=_example_epilog(GROUP_EXAMPLES.get(operation.command[0])),
+            )
         else:
             group_name, leaf_name = operation.command
             if group_name not in groups:
-                group = roots.add_parser(group_name)
+                group = roots.add_parser(
+                    group_name,
+                    help=_tag_description(group_name) or operation.summary,
+                    description=_tag_description(group_name) or operation.summary,
+                    epilog=_example_epilog(GROUP_EXAMPLES.get(group_name)),
+                )
                 groups[group_name] = group.add_subparsers(
                     dest=f"_{group_name}_command",
                     required=True,
                 )
-            leaf = groups[group_name].add_parser(leaf_name)
+            leaf = groups[group_name].add_parser(
+                leaf_name,
+                help=operation.summary,
+                description=operation.description or operation.summary,
+            )
         _configure_operation_parser(leaf, operation)
+
+    parser.epilog = _root_epilog()
     return parser
 
 

--- a/koan/app/cli/commands.py
+++ b/koan/app/cli/commands.py
@@ -23,8 +23,8 @@ GROUP_EXAMPLES = {
     ],
     "projects": [
         "koan-cli projects list --pretty",
-        'koan-cli projects create --github_url https://github.com/acme/my-toolkit',
-        "koan-cli projects update my-toolkit",
+        "koan-cli projects create --github-url https://github.com/acme/my-toolkit",
+        "koan-cli projects update my-toolkit --patch '{\"focus\": true}'",
     ],
     "observability": [
         "koan-cli observability usage --days 30",

--- a/koan/app/cli/commands.py
+++ b/koan/app/cli/commands.py
@@ -68,12 +68,18 @@ def _root_epilog() -> str:
     return "\n".join(lines)
 
 
-DESTRUCTIVE = {
-    ("POST", "/v1/restart"),
-    ("POST", "/v1/shutdown"),
-    ("POST", "/v1/update"),
-    ("POST", "/v1/update_release"),
-}
+def destructive_targets(operations: list[Operation]) -> frozenset[tuple[str, str]]:
+    """Collect ``(METHOD, path)`` pairs the specification marks destructive.
+
+    Destructiveness is a property of the operation, exactly like auth: a route
+    rename moves the marker with the route instead of silently dropping a
+    hardcoded entry, so ``raw`` keeps confirming what the generated commands do.
+    """
+    return frozenset(
+        (operation.method, operation.path)
+        for operation in operations
+        if operation.destructive
+    )
 
 
 class _RawHelp(argparse.RawDescriptionHelpFormatter):
@@ -426,13 +432,18 @@ def build_operation_request(
         body=body,
         has_body=has_body,
         requires_auth=operation.requires_auth,
-        destructive=is_destructive(operation.method, operation.path),
+        destructive=operation.destructive,
     )
 
 
-def is_destructive(method: str, path: str) -> bool:
+def is_destructive(
+    method: str,
+    path: str,
+    targets: frozenset[tuple[str, str]] = frozenset(),
+) -> bool:
+    """Classify a raw ``METHOD path`` against the specification's markers."""
     normalized = (method.upper(), path.split("?", 1)[0])
-    return normalized[0] == "DELETE" or normalized in DESTRUCTIVE
+    return normalized[0] == "DELETE" or normalized in targets
 
 
 def build_raw_request(
@@ -442,6 +453,7 @@ def build_raw_request(
     *,
     data: str | None,
     query: list[str],
+    destructive: frozenset[tuple[str, str]] = frozenset(),
 ) -> RequestPlan:
     method = method.upper()
     if not method.isalpha():
@@ -457,5 +469,5 @@ def build_raw_request(
         requires_auth=not (
             method == "GET" and path.split("?", 1)[0] == "/v1/health"
         ),
-        destructive=is_destructive(method, path),
+        destructive=is_destructive(method, path, destructive),
     )

--- a/koan/app/cli/commands.py
+++ b/koan/app/cli/commands.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 from app.cli import CliError
+from app.cli.config import DEFAULT_TIMEOUT
 from app.cli.spec import Operation, load_tag_descriptions
 
 # One executable example per group, shown in that group's --help epilog.
@@ -105,7 +106,30 @@ def _boolean(value: str) -> bool:
     raise argparse.ArgumentTypeError("expected true or false")
 
 
+def _structured(schema: dict[str, Any]):
+    """Build an argparse type that parses one JSON object/array flag value.
+
+    Falling back to ``str`` here would transmit ``--patch '{"focus": true}'`` as
+    a JSON *string*, which no object-typed server field can ever accept.
+    """
+    expected = dict if schema.get("type") == "object" else list
+
+    def parse(value: str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise argparse.ArgumentTypeError(f"expected JSON: {exc.msg}") from exc
+        if not isinstance(parsed, expected):
+            raise argparse.ArgumentTypeError(f"expected a JSON {schema['type']}")
+        return parsed
+
+    parse.__name__ = schema.get("type", "json")
+    return parse
+
+
 def _schema_type(schema: dict[str, Any]):
+    if schema.get("type") in {"object", "array"}:
+        return _structured(schema)
     return {
         "integer": int,
         "number": float,
@@ -143,6 +167,8 @@ def _add_common_request_flags(parser: argparse.ArgumentParser) -> None:
 def _metavar(schema: dict[str, Any], fallback: str) -> str:
     if schema.get("type") == "boolean":
         return "true|false"
+    if schema.get("type") in {"object", "array"}:
+        return "JSON"
     return str(schema.get("title") or fallback).upper()
 
 
@@ -214,6 +240,15 @@ def build_parser(
     parser.description = "Command-line client for the Kōan REST API."
     parser.add_argument("--profile")
     parser.add_argument("--base-url")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        metavar="SECONDS",
+        help=(
+            "Seconds to wait for a response. Overrides KOAN_TIMEOUT and the "
+            f"profile's timeout key (default {DEFAULT_TIMEOUT:g})."
+        ),
+    )
     roots = parser.add_subparsers(dest="_root", required=True)
 
     configure = roots.add_parser(
@@ -279,10 +314,10 @@ def expand_alias(argv: list[str], operations: list[Operation]) -> list[str]:
     index = 0
     while index < len(argv):
         value = argv[index]
-        if value in {"--profile", "--base-url"}:
+        if value in {"--profile", "--base-url", "--timeout"}:
             index += 2
             continue
-        if value.startswith("--profile=") or value.startswith("--base-url="):
+        if value.split("=", 1)[0] in {"--profile", "--base-url", "--timeout"}:
             index += 1
             continue
         break
@@ -371,12 +406,15 @@ def build_operation_request(
         body.update(body_values)
         has_body = True
 
-    required = set((operation.body_schema or {}).get("required", []))
-    missing = required - set(body) if isinstance(body, dict) else required
     if operation.body_required and not has_body:
         raise CliError("this operation requires a JSON request body")
-    if missing:
-        raise CliError(f"missing required body field: {sorted(missing)[0]}")
+    # schema.required lists what must be present *if* a body is sent; it does
+    # not make an optional requestBody mandatory.
+    if has_body:
+        required = set((operation.body_schema or {}).get("required", []))
+        missing = required - set(body) if isinstance(body, dict) else required
+        if missing:
+            raise CliError(f"missing required body field: {sorted(missing)[0]}")
 
     rendered = _render_path(operation, args)
     return RequestPlan(

--- a/koan/app/cli/commands.py
+++ b/koan/app/cli/commands.py
@@ -157,7 +157,9 @@ def _add_common_request_flags(parser: argparse.ArgumentParser) -> None:
     )
     output = parser.add_mutually_exclusive_group()
     output.add_argument(
-        "--compact", action="store_true", help="Force single-line JSON (default when piped)."
+        "--compact",
+        action="store_true",
+        help="Force single-line JSON (default when piped).",
     )
     output.add_argument(
         "--pretty", action="store_true", help="Force indented JSON (default on a TTY)."

--- a/koan/app/cli/config.py
+++ b/koan/app/cli/config.py
@@ -46,6 +46,35 @@ def _parse_timeout(value: str, source: str) -> float:
     return timeout
 
 
+def resolve_profile(
+    *,
+    cli_profile: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Resolve the profile name: flag, then environment, then ``default``."""
+    env = os.environ if environ is None else environ
+    return (cli_profile or "").strip() or _nonempty(env, "KOAN_PROFILE") or "default"
+
+
+def resolve_base_url(
+    *,
+    cli_base_url: str | None = None,
+    section: Mapping[str, str] | None = None,
+    environ: Mapping[str, str] | None = None,
+    fallback: str = "",
+) -> str:
+    """Resolve the base URL: flag, environment, stored profile, then fallback."""
+    env = os.environ if environ is None else environ
+    stored = str(section.get("base_url", "")).strip() if section is not None else ""
+    value = (
+        (cli_base_url or "").strip()
+        or _nonempty(env, "KOAN_BASE_URL")
+        or stored
+        or fallback
+    )
+    return value.rstrip("/")
+
+
 def resolve_timeout(
     *,
     cli_timeout: float | None = None,
@@ -91,20 +120,20 @@ def load_settings(
     environ: Mapping[str, str] | None = None,
 ) -> Settings:
     env = os.environ if environ is None else environ
-    profile = (cli_profile or "").strip() or _nonempty(env, "KOAN_PROFILE") or "default"
+    profile = resolve_profile(cli_profile=cli_profile, environ=env)
     parser = _read_config(path)
     if parser.sections() and profile not in parser:
         raise CliError(f"unknown profile {profile!r} in {path}")
     section = parser[profile] if profile in parser else {}
-    base_url = (
-        (cli_base_url or "").strip()
-        or _nonempty(env, "KOAN_BASE_URL")
-        or str(section.get("base_url", "")).strip()
-        or server_default
+    base_url = resolve_base_url(
+        cli_base_url=cli_base_url,
+        section=section,
+        environ=env,
+        fallback=server_default,
     )
     token = _nonempty(env, "KOAN_API_TOKEN") or str(section.get("token", "")).strip()
     timeout = resolve_timeout(cli_timeout=cli_timeout, section=section, environ=env)
-    return Settings(profile, base_url.rstrip("/"), token, timeout)
+    return Settings(profile, base_url, token, timeout)
 
 
 def write_profile(path: Path, profile: str, base_url: str, token: str) -> None:

--- a/koan/app/cli/config.py
+++ b/koan/app/cli/config.py
@@ -1,0 +1,110 @@
+"""Secure named profile storage and REST CLI setting resolution."""
+
+import configparser
+import os
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from app.cli import CliError
+
+
+CONFIG_PATH = Path.home() / ".config" / "koan-cli.cfg"
+ALLOWED_MODES = {0o600, 0o400}
+
+
+@dataclass(frozen=True)
+class Settings:
+    profile: str
+    base_url: str
+    token: str
+
+
+def _nonempty(mapping: Mapping[str, str], name: str) -> str | None:
+    value = mapping.get(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _read_config(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser(interpolation=None)
+    if not path.exists():
+        return parser
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode not in ALLOWED_MODES:
+        raise CliError(
+            f"refusing insecure config {path} (mode {mode:04o}); "
+            f"run: chmod 600 {path}"
+        )
+    try:
+        with path.open() as stream:
+            parser.read_file(stream)
+    except (OSError, configparser.Error) as exc:
+        raise CliError(f"cannot read config {path}: {exc}") from exc
+    return parser
+
+
+def load_settings(
+    path: Path,
+    server_default: str,
+    *,
+    cli_profile: str | None = None,
+    cli_base_url: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Settings:
+    env = os.environ if environ is None else environ
+    profile = (cli_profile or "").strip() or _nonempty(env, "KOAN_PROFILE") or "default"
+    parser = _read_config(path)
+    if parser.sections() and profile not in parser:
+        raise CliError(f"unknown profile {profile!r} in {path}")
+    section = parser[profile] if profile in parser else {}
+    base_url = (
+        (cli_base_url or "").strip()
+        or _nonempty(env, "KOAN_BASE_URL")
+        or str(section.get("base_url", "")).strip()
+        or server_default
+    )
+    token = _nonempty(env, "KOAN_API_TOKEN") or str(section.get("token", "")).strip()
+    return Settings(profile, base_url.rstrip("/"), token)
+
+
+def write_profile(path: Path, profile: str, base_url: str, token: str) -> None:
+    profile = profile.strip()
+    if not profile:
+        raise CliError("profile name cannot be empty")
+    parser = _read_config(path)
+    if profile not in parser:
+        try:
+            parser.add_section(profile)
+        except ValueError as exc:
+            raise CliError(f"invalid profile name: {profile!r}") from exc
+    parser[profile]["base_url"] = base_url.strip().rstrip("/")
+    parser[profile]["token"] = token.strip()
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            dir=path.parent,
+            text=True,
+        )
+    except OSError as exc:
+        raise CliError(f"cannot create config {path}: {exc}") from exc
+
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(fd, "w") as stream:
+            os.fchmod(stream.fileno(), 0o600)
+            parser.write(stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        raise CliError(f"cannot write config {path}: {exc}") from exc
+    finally:
+        temporary_path.unlink(missing_ok=True)

--- a/koan/app/cli/config.py
+++ b/koan/app/cli/config.py
@@ -13,6 +13,11 @@ from app.cli import CliError
 
 CONFIG_PATH = Path.home() / ".config" / "koan-cli.cfg"
 ALLOWED_MODES = {0o600, 0o400}
+# Several handlers run their work synchronously inside the request: POST
+# /v1/update shells out to git fetch + git pull, POST /v1/projects clones a
+# repository. A budget under those routinely reports a completed, non-idempotent
+# action as a failure, so default well above them and let the operator raise it.
+DEFAULT_TIMEOUT = 120.0
 
 
 @dataclass(frozen=True)
@@ -20,6 +25,7 @@ class Settings:
     profile: str
     base_url: str
     token: str
+    timeout: float = DEFAULT_TIMEOUT
 
 
 def _nonempty(mapping: Mapping[str, str], name: str) -> str | None:
@@ -28,6 +34,33 @@ def _nonempty(mapping: Mapping[str, str], name: str) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def _parse_timeout(value: str, source: str) -> float:
+    try:
+        timeout = float(value)
+    except ValueError as exc:
+        raise CliError(f"invalid {source}: {value!r} is not a number") from exc
+    if timeout <= 0:
+        raise CliError(f"invalid {source}: {value!r} must be greater than zero")
+    return timeout
+
+
+def resolve_timeout(
+    *,
+    cli_timeout: float | None = None,
+    section: Mapping[str, str] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> float:
+    """Resolve the response timeout: flag, then environment, then profile."""
+    env = os.environ if environ is None else environ
+    if cli_timeout is not None:
+        return _parse_timeout(str(cli_timeout), "--timeout")
+    if (raw := _nonempty(env, "KOAN_TIMEOUT")) is not None:
+        return _parse_timeout(raw, "KOAN_TIMEOUT")
+    if section is not None and (raw := _nonempty(section, "timeout")) is not None:
+        return _parse_timeout(raw, "profile timeout")
+    return DEFAULT_TIMEOUT
 
 
 def _read_config(path: Path) -> configparser.ConfigParser:
@@ -54,6 +87,7 @@ def load_settings(
     *,
     cli_profile: str | None = None,
     cli_base_url: str | None = None,
+    cli_timeout: float | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> Settings:
     env = os.environ if environ is None else environ
@@ -69,7 +103,8 @@ def load_settings(
         or server_default
     )
     token = _nonempty(env, "KOAN_API_TOKEN") or str(section.get("token", "")).strip()
-    return Settings(profile, base_url.rstrip("/"), token)
+    timeout = resolve_timeout(cli_timeout=cli_timeout, section=section, environ=env)
+    return Settings(profile, base_url.rstrip("/"), token, timeout)
 
 
 def write_profile(path: Path, profile: str, base_url: str, token: str) -> None:

--- a/koan/app/cli/config.py
+++ b/koan/app/cli/config.py
@@ -110,6 +110,26 @@ def _read_config(path: Path) -> configparser.ConfigParser:
     return parser
 
 
+def read_profile(
+    path: Path,
+    profile: str,
+    *,
+    required: bool = False,
+) -> dict[str, str]:
+    """Return one stored profile's keys, ``{}`` when it is absent.
+
+    ``required`` makes an absent profile an error: an explicitly named profile
+    that silently falls back to defaults would send the request to the wrong
+    agent and report success.
+    """
+    parser = _read_config(path)
+    if profile in parser:
+        return dict(parser[profile])
+    if required:
+        raise CliError(f"unknown profile {profile!r} in {path}")
+    return {}
+
+
 def load_settings(
     path: Path,
     server_default: str,
@@ -121,10 +141,10 @@ def load_settings(
 ) -> Settings:
     env = os.environ if environ is None else environ
     profile = resolve_profile(cli_profile=cli_profile, environ=env)
-    parser = _read_config(path)
-    if parser.sections() and profile not in parser:
-        raise CliError(f"unknown profile {profile!r} in {path}")
-    section = parser[profile] if profile in parser else {}
+    explicit = bool(
+        (cli_profile or "").strip() or _nonempty(env, "KOAN_PROFILE")
+    )
+    section = read_profile(path, profile, required=explicit)
     base_url = resolve_base_url(
         cli_base_url=cli_base_url,
         section=section,

--- a/koan/app/cli/http.py
+++ b/koan/app/cli/http.py
@@ -175,7 +175,14 @@ def verify_configuration(
             exit_for_status(health.status_code),
         )
     if not token:
-        return VerificationResult("reachable; no token configured", EXIT_OK)
+        # A profile without a token cannot call anything but health. Reporting
+        # success here makes a wiped credential indistinguishable from a
+        # working one to any script keying off the exit code.
+        return VerificationResult(
+            "reachable; no token configured — every authenticated command "
+            "will fail until one is set",
+            EXIT_LOCAL,
+        )
 
     try:
         status = session.request(

--- a/koan/app/cli/http.py
+++ b/koan/app/cli/http.py
@@ -17,7 +17,7 @@ from app.cli import (
     CliError,
 )
 from app.cli.commands import RequestPlan
-from app.cli.config import Settings
+from app.cli.config import DEFAULT_TIMEOUT, Settings
 
 
 @dataclass(frozen=True)
@@ -105,7 +105,7 @@ def execute(
     headers = {"Accept": "application/json"}
     if settings.token:
         headers["Authorization"] = f"Bearer {settings.token}"
-    kwargs = {"params": plan.query, "headers": headers, "timeout": 10}
+    kwargs = {"params": plan.query, "headers": headers, "timeout": settings.timeout}
     if plan.has_body:
         kwargs["json"] = plan.body
 
@@ -119,6 +119,19 @@ def execute(
             print("3. Start the server with make api", file=stderr)
         else:
             print(f"request failed: {exc}", file=stderr)
+        return EXIT_LOCAL
+    except requests.Timeout as exc:
+        # The request was delivered; only the response is missing. Say so, or a
+        # script keying off the exit code re-issues a non-idempotent operation.
+        print(
+            f"no response within {settings.timeout:g}s: {exc}",
+            file=stderr,
+        )
+        print(
+            f"{plan.method} {plan.url} may still have been applied; "
+            "verify before retrying, or raise --timeout.",
+            file=stderr,
+        )
         return EXIT_LOCAL
     except requests.RequestException as exc:
         print(f"request failed: {exc}", file=stderr)
@@ -141,15 +154,20 @@ def verify_configuration(
     base_url: str,
     token: str,
     session=requests,
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> VerificationResult:
     try:
         health = session.request(
             "GET",
             f"{base_url.rstrip('/')}/v1/health",
-            timeout=10,
+            timeout=timeout,
         )
-    except requests.RequestException:
-        return VerificationResult("saved; server unreachable", EXIT_LOCAL)
+    except requests.RequestException as exc:
+        # A malformed URL and a TLS failure are RequestExceptions too; reporting
+        # every one as "unreachable" sends the operator to start a server that
+        # was never the problem.
+        return VerificationResult(f"saved; cannot reach {base_url}: {exc}", EXIT_LOCAL)
 
     if not health.ok:
         return VerificationResult(
@@ -164,11 +182,11 @@ def verify_configuration(
             "GET",
             f"{base_url.rstrip('/')}/v1/status",
             headers={"Authorization": f"Bearer {token}"},
-            timeout=10,
+            timeout=timeout,
         )
-    except requests.RequestException:
+    except requests.RequestException as exc:
         return VerificationResult(
-            "reachable; authentication probe failed to connect",
+            f"reachable; authentication probe failed: {exc}",
             EXIT_LOCAL,
         )
 

--- a/koan/app/cli/http.py
+++ b/koan/app/cli/http.py
@@ -1,0 +1,182 @@
+"""HTTP transport, confirmation, output, and configuration probes."""
+
+import errno
+import json
+import sys
+from dataclasses import dataclass
+from typing import TextIO
+
+import requests
+
+from app.cli import (
+    EXIT_AUTH,
+    EXIT_LOCAL,
+    EXIT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_SERVER,
+    CliError,
+)
+from app.cli.commands import RequestPlan
+from app.cli.config import Settings
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    message: str
+    exit_code: int
+
+
+def exit_for_status(status: int) -> int:
+    if 200 <= status < 300:
+        return EXIT_OK
+    if status in {401, 403}:
+        return EXIT_AUTH
+    if status == 404:
+        return EXIT_NOT_FOUND
+    if status >= 500:
+        return EXIT_SERVER
+    return EXIT_LOCAL
+
+
+def confirm_destructive(
+    plan: RequestPlan,
+    *,
+    yes: bool,
+    stdin: TextIO = sys.stdin,
+    stderr: TextIO = sys.stderr,
+) -> None:
+    if not plan.destructive or yes:
+        return
+    if not getattr(stdin, "isatty", lambda: False)():
+        raise CliError("destructive request requires --yes when stdin is not a TTY")
+    print(f"Confirm {plan.method} {plan.url}? [y/N] ", end="", file=stderr)
+    if stdin.readline().strip().lower() not in {"y", "yes"}:
+        raise CliError("aborted")
+
+
+def _json_payload(response):
+    try:
+        return response.json()
+    except ValueError:
+        return {"body": response.text}
+
+
+def _is_connection_refused(exc: BaseException) -> bool:
+    pending = [exc]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, OSError) and current.errno == errno.ECONNREFUSED:
+            return True
+        if "refused" in str(current).lower():
+            return True
+        pending.extend(
+            item
+            for item in getattr(current, "args", ())
+            if isinstance(item, BaseException)
+        )
+        cause = current.__cause__ or current.__context__
+        if cause is not None:
+            pending.append(cause)
+    return False
+
+
+def execute(
+    plan: RequestPlan,
+    settings: Settings,
+    session=requests,
+    *,
+    compact: bool = False,
+    pretty: bool = False,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    if plan.requires_auth and not settings.token:
+        print(
+            "authentication required; run `koan-cli configure` or set "
+            "KOAN_API_TOKEN",
+            file=stderr,
+        )
+        return EXIT_LOCAL
+
+    headers = {"Accept": "application/json"}
+    if settings.token:
+        headers["Authorization"] = f"Bearer {settings.token}"
+    kwargs = {"params": plan.query, "headers": headers, "timeout": 10}
+    if plan.has_body:
+        kwargs["json"] = plan.body
+
+    try:
+        response = session.request(plan.method, plan.url, **kwargs)
+    except requests.ConnectionError as exc:
+        if _is_connection_refused(exc):
+            print(f"connection refused: {plan.url}", file=stderr)
+            print("1. Set api.enabled: true in instance/config.yaml", file=stderr)
+            print("2. Run make api-token and configure the token", file=stderr)
+            print("3. Start the server with make api", file=stderr)
+        else:
+            print(f"request failed: {exc}", file=stderr)
+        return EXIT_LOCAL
+    except requests.RequestException as exc:
+        print(f"request failed: {exc}", file=stderr)
+        return EXIT_LOCAL
+
+    payload = _json_payload(response)
+    code = exit_for_status(response.status_code)
+    target = stdout if code == EXIT_OK else stderr
+    indent = (
+        2
+        if pretty
+        or (not compact and getattr(stdout, "isatty", lambda: False)())
+        else None
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=indent), file=target)
+    return code
+
+
+def verify_configuration(
+    base_url: str,
+    token: str,
+    session=requests,
+) -> VerificationResult:
+    try:
+        health = session.request(
+            "GET",
+            f"{base_url.rstrip('/')}/v1/health",
+            timeout=10,
+        )
+    except requests.RequestException:
+        return VerificationResult("saved; server unreachable", EXIT_LOCAL)
+
+    if not health.ok:
+        return VerificationResult(
+            f"saved; health probe returned HTTP {health.status_code}",
+            exit_for_status(health.status_code),
+        )
+    if not token:
+        return VerificationResult("reachable; no token configured", EXIT_OK)
+
+    try:
+        status = session.request(
+            "GET",
+            f"{base_url.rstrip('/')}/v1/status",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return VerificationResult(
+            "reachable; authentication probe failed to connect",
+            EXIT_LOCAL,
+        )
+
+    if status.status_code in {401, 403}:
+        return VerificationResult("reachable; token was rejected", EXIT_AUTH)
+    if status.ok:
+        return VerificationResult("reachable; token authenticated", EXIT_OK)
+    return VerificationResult(
+        f"reachable; authentication probe returned HTTP {status.status_code}",
+        exit_for_status(status.status_code),
+    )

--- a/koan/app/cli/main.py
+++ b/koan/app/cli/main.py
@@ -33,7 +33,7 @@ def main(
         spec = load_spec(spec_path or DEFAULT_SPEC)
         operations = load_operations(spec)
         arguments = expand_alias(arguments, operations)
-        args = build_parser(operations).parse_args(arguments)
+        args = build_parser(operations, spec).parse_args(arguments)
         server_default = load_server_default(spec)
         path = config_path or CONFIG_PATH
 

--- a/koan/app/cli/main.py
+++ b/koan/app/cli/main.py
@@ -11,11 +11,13 @@ from app.cli.commands import (
     build_operation_request,
     build_parser,
     build_raw_request,
+    destructive_targets,
     expand_alias,
 )
 from app.cli.config import (
     CONFIG_PATH,
     load_settings,
+    read_profile,
     resolve_base_url,
     resolve_profile,
     resolve_timeout,
@@ -48,19 +50,28 @@ def main(
             # every other command, so an exported KOAN_PROFILE does not write
             # production credentials into [default].
             profile = resolve_profile(cli_profile=args.profile)
+            # Re-running configure edits a profile; it does not reset one. The
+            # stored values are the defaults, so pressing Enter twice on a
+            # remote profile keeps its URL and its token.
+            stored = read_profile(path, profile)
             default_url = resolve_base_url(
                 cli_base_url=args.base_url,
+                section=stored,
                 fallback=server_default,
             )
             entered_url = input(f"Base URL [{default_url}]: ").strip()
             base_url = (entered_url or default_url).rstrip("/")
-            token = getpass.getpass("Bearer token: ").strip()
+            stored_token = str(stored.get("token", "")).strip()
+            prompt = (
+                "Bearer token [keep existing]: " if stored_token else "Bearer token: "
+            )
+            token = getpass.getpass(prompt).strip() or stored_token
             write_profile(path, profile, base_url, token)
             verification = verify_configuration(
                 base_url,
                 token,
                 session,
-                timeout=resolve_timeout(cli_timeout=args.timeout),
+                timeout=resolve_timeout(cli_timeout=args.timeout, section=stored),
             )
             # stdout carries valid JSON only; a failed probe is a diagnostic.
             stream = sys.stdout if verification.exit_code == EXIT_OK else sys.stderr
@@ -81,6 +92,7 @@ def main(
                 settings.base_url,
                 data=args.data,
                 query=args.query,
+                destructive=destructive_targets(operations),
             )
         else:
             plan = build_operation_request(

--- a/koan/app/cli/main.py
+++ b/koan/app/cli/main.py
@@ -6,14 +6,19 @@ from pathlib import Path
 
 import requests
 
-from app.cli import EXIT_LOCAL, CliError
+from app.cli import EXIT_LOCAL, EXIT_OK, CliError
 from app.cli.commands import (
     build_operation_request,
     build_parser,
     build_raw_request,
     expand_alias,
 )
-from app.cli.config import CONFIG_PATH, load_settings, write_profile
+from app.cli.config import (
+    CONFIG_PATH,
+    load_settings,
+    resolve_timeout,
+    write_profile,
+)
 from app.cli.http import confirm_destructive, execute, verify_configuration
 from app.cli.spec import load_operations, load_server_default, load_spec
 
@@ -44,8 +49,15 @@ def main(
             base_url = (entered_url or default_url).rstrip("/")
             token = getpass.getpass("Bearer token: ").strip()
             write_profile(path, profile, base_url, token)
-            verification = verify_configuration(base_url, token, session)
-            print(verification.message)
+            verification = verify_configuration(
+                base_url,
+                token,
+                session,
+                timeout=resolve_timeout(cli_timeout=args.timeout),
+            )
+            # stdout carries valid JSON only; a failed probe is a diagnostic.
+            stream = sys.stdout if verification.exit_code == EXIT_OK else sys.stderr
+            print(verification.message, file=stream)
             return verification.exit_code
 
         settings = load_settings(
@@ -53,6 +65,7 @@ def main(
             server_default,
             cli_profile=args.profile,
             cli_base_url=args.base_url,
+            cli_timeout=args.timeout,
         )
         if getattr(args, "_builtin", None) == "raw":
             plan = build_raw_request(

--- a/koan/app/cli/main.py
+++ b/koan/app/cli/main.py
@@ -16,12 +16,13 @@ from app.cli.commands import (
 from app.cli.config import (
     CONFIG_PATH,
     load_settings,
+    resolve_base_url,
+    resolve_profile,
     resolve_timeout,
     write_profile,
 )
 from app.cli.http import confirm_destructive, execute, verify_configuration
 from app.cli.spec import load_operations, load_server_default, load_spec
-
 
 DEFAULT_SPEC = Path(__file__).resolve().parents[2] / "openapi.yaml"
 
@@ -43,8 +44,14 @@ def main(
         path = config_path or CONFIG_PATH
 
         if getattr(args, "_builtin", None) == "configure":
-            profile = (args.profile or "default").strip()
-            default_url = (args.base_url or server_default).rstrip("/")
+            # configure resolves the profile and URL on the same ladder as
+            # every other command, so an exported KOAN_PROFILE does not write
+            # production credentials into [default].
+            profile = resolve_profile(cli_profile=args.profile)
+            default_url = resolve_base_url(
+                cli_base_url=args.base_url,
+                fallback=server_default,
+            )
             entered_url = input(f"Base URL [{default_url}]: ").strip()
             base_url = (entered_url or default_url).rstrip("/")
             token = getpass.getpass("Bearer token: ").strip()

--- a/koan/app/cli/main.py
+++ b/koan/app/cli/main.py
@@ -1,0 +1,86 @@
+"""Top-level orchestration for generated and built-in REST CLI commands."""
+
+import getpass
+import sys
+from pathlib import Path
+
+import requests
+
+from app.cli import EXIT_LOCAL, CliError
+from app.cli.commands import (
+    build_operation_request,
+    build_parser,
+    build_raw_request,
+    expand_alias,
+)
+from app.cli.config import CONFIG_PATH, load_settings, write_profile
+from app.cli.http import confirm_destructive, execute, verify_configuration
+from app.cli.spec import load_operations, load_server_default, load_spec
+
+
+DEFAULT_SPEC = Path(__file__).resolve().parents[2] / "openapi.yaml"
+
+
+def main(
+    argv=None,
+    *,
+    spec_path: Path | None = None,
+    config_path: Path | None = None,
+    session=requests,
+) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    try:
+        spec = load_spec(spec_path or DEFAULT_SPEC)
+        operations = load_operations(spec)
+        arguments = expand_alias(arguments, operations)
+        args = build_parser(operations).parse_args(arguments)
+        server_default = load_server_default(spec)
+        path = config_path or CONFIG_PATH
+
+        if getattr(args, "_builtin", None) == "configure":
+            profile = (args.profile or "default").strip()
+            default_url = (args.base_url or server_default).rstrip("/")
+            entered_url = input(f"Base URL [{default_url}]: ").strip()
+            base_url = (entered_url or default_url).rstrip("/")
+            token = getpass.getpass("Bearer token: ").strip()
+            write_profile(path, profile, base_url, token)
+            verification = verify_configuration(base_url, token, session)
+            print(verification.message)
+            return verification.exit_code
+
+        settings = load_settings(
+            path,
+            server_default,
+            cli_profile=args.profile,
+            cli_base_url=args.base_url,
+        )
+        if getattr(args, "_builtin", None) == "raw":
+            plan = build_raw_request(
+                args.raw_method,
+                args.raw_path,
+                settings.base_url,
+                data=args.data,
+                query=args.query,
+            )
+        else:
+            plan = build_operation_request(
+                args._operation,
+                args,
+                settings.base_url,
+            )
+
+        confirm_destructive(plan, yes=args.yes)
+        return execute(
+            plan,
+            settings,
+            session,
+            compact=args.compact,
+            pretty=args.pretty,
+        )
+    except CliError as exc:
+        print(f"koan-cli: {exc}", file=sys.stderr)
+        return EXIT_LOCAL
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/koan/app/cli/spec.py
+++ b/koan/app/cli/spec.py
@@ -1,0 +1,191 @@
+"""Discover stable CLI commands from Kōan's committed OpenAPI document."""
+
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.cli import CliError
+
+
+HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+RESERVED_ROOTS = {"configure", "raw"}
+ITEM_VERBS = {
+    "get": "get",
+    "patch": "update",
+    "put": "update",
+    "delete": "delete",
+}
+
+
+class SpecError(CliError):
+    """An invalid or ambiguous OpenAPI document."""
+
+
+@dataclass(frozen=True)
+class Parameter:
+    name: str
+    location: str
+    required: bool
+    schema: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Operation:
+    method: str
+    path: str
+    operation_id: str
+    command: tuple[str, ...]
+    parameters: tuple[Parameter, ...]
+    body_schema: dict[str, Any] | None
+    body_required: bool
+    requires_auth: bool
+
+
+def load_spec(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError) as exc:
+        raise SpecError(f"cannot load OpenAPI document {path}: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("paths"), dict):
+        raise SpecError(f"invalid OpenAPI document: {path}")
+    return data
+
+
+def resolve_local_ref(spec: dict[str, Any], value: Any) -> Any:
+    if not isinstance(value, dict) or "$ref" not in value:
+        return value
+    ref = value["$ref"]
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        raise SpecError(f"unsupported OpenAPI reference: {ref}")
+    current: Any = spec
+    try:
+        for token in ref[2:].split("/"):
+            key = token.replace("~1", "/").replace("~0", "~")
+            current = current[key]
+    except (KeyError, TypeError) as exc:
+        raise SpecError(f"unresolved OpenAPI reference: {ref}") from exc
+    return resolve_local_ref(spec, current)
+
+
+def command_name(method: str, path: str, tag: str, tag_count: int) -> tuple[str, ...]:
+    segments = path.removeprefix("/v1/").strip("/").split("/")
+    first = segments[0].replace("_", "-")
+    if len(segments) == 1:
+        if tag_count == 1 and tag == first:
+            return (tag,)
+        if tag == first and method == "get":
+            return (tag, "list")
+        if tag == first and method == "post":
+            return (tag, "create")
+        return (tag, first)
+    if segments[1].startswith("{"):
+        if len(segments) > 2:
+            return (tag, segments[-1].replace("_", "-"))
+        try:
+            return (tag, ITEM_VERBS[method])
+        except KeyError as exc:
+            raise SpecError(f"unsupported item operation: {method.upper()} {path}") from exc
+    return (tag, segments[-1].replace("_", "-"))
+
+
+def load_operations(spec: dict[str, Any]) -> list[Operation]:
+    raw = []
+    tag_counts: dict[str, int] = {}
+    for path, path_item in spec["paths"].items():
+        if not isinstance(path_item, dict):
+            raise SpecError(f"invalid path item: {path}")
+        for method, operation in path_item.items():
+            if method not in HTTP_METHODS:
+                continue
+            if not isinstance(operation, dict):
+                raise SpecError(f"invalid operation: {method.upper()} {path}")
+            tags = operation.get("tags", [])
+            if not tags or not isinstance(tags[0], str):
+                raise SpecError(f"operation has no tag: {method.upper()} {path}")
+            tag = tags[0]
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+            raw.append((path, path_item, method, operation, tag))
+
+    operations = []
+    for path, path_item, method, operation, tag in raw:
+        params = []
+        for item in [*path_item.get("parameters", []), *operation.get("parameters", [])]:
+            item = resolve_local_ref(spec, item)
+            params.append(
+                Parameter(
+                    name=item["name"],
+                    location=item["in"],
+                    required=bool(item.get("required")),
+                    schema=resolve_local_ref(spec, item.get("schema", {})),
+                )
+            )
+        request_body = resolve_local_ref(spec, operation.get("requestBody", {}))
+        media = request_body.get("content", {}).get("application/json", {})
+        body_schema = resolve_local_ref(spec, media.get("schema"))
+        security = operation.get("security", spec.get("security", []))
+        try:
+            operation_id = operation["operationId"]
+        except KeyError as exc:
+            raise SpecError(f"operation has no operationId: {method.upper()} {path}") from exc
+        operations.append(
+            Operation(
+                method=method.upper(),
+                path=path,
+                operation_id=operation_id,
+                command=command_name(method, path, tag, tag_counts[tag]),
+                parameters=tuple(params),
+                body_schema=body_schema,
+                body_required=bool(request_body.get("required")),
+                requires_auth=bool(security),
+            )
+        )
+    assert_unique(operations)
+    return operations
+
+
+def assert_unique(operations: list[Operation]) -> None:
+    commands: dict[tuple[str, ...], Operation] = {}
+    aliases: dict[str, Operation] = {}
+
+    for operation in operations:
+        if operation.command in commands:
+            raise SpecError(f"duplicate command: {' '.join(operation.command)}")
+        commands[operation.command] = operation
+
+        if operation.operation_id in aliases:
+            raise SpecError(f"duplicate operationId alias: {operation.operation_id}")
+        aliases[operation.operation_id] = operation
+
+    for left, right in combinations(commands, 2):
+        shorter, longer = sorted((left, right), key=len)
+        if longer[: len(shorter)] == shorter:
+            raise SpecError(
+                f"command prefix collision: {' '.join(shorter)} / {' '.join(longer)}"
+            )
+
+    public_roots = {command[0] for command in commands}
+    reserved_collision = public_roots & RESERVED_ROOTS
+    if reserved_collision:
+        raise SpecError(f"reserved root command: {sorted(reserved_collision)[0]}")
+
+    for alias in aliases:
+        if alias in RESERVED_ROOTS:
+            raise SpecError(f"operationId alias collides with built-in: {alias}")
+        if alias in public_roots:
+            raise SpecError(f"operationId alias collides with root command: {alias}")
+
+
+def load_server_default(spec: dict[str, Any]) -> str:
+    servers = spec.get("servers")
+    if not isinstance(servers, list) or not servers:
+        raise SpecError("OpenAPI document has no servers entry")
+    first = servers[0]
+    if not isinstance(first, dict):
+        raise SpecError("OpenAPI servers[0] is invalid")
+    url = first.get("url", "")
+    if not isinstance(url, str) or not url.strip():
+        raise SpecError("OpenAPI servers[0].url is empty")
+    return url.strip().rstrip("/")

--- a/koan/app/cli/spec.py
+++ b/koan/app/cli/spec.py
@@ -11,6 +11,15 @@ from app.cli import CliError
 
 
 HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+# Operation summaries (from view docstrings) may span multiple lines; the CLI has
+# room for one. Keep only the first line so group/leaf help stays terse.
+FIRST_LINE_FALLBACK = "Unknown operation"
+
+
+def _first_line(summary: str) -> str:
+    if not summary.strip():
+        return FIRST_LINE_FALLBACK
+    return summary.strip().splitlines()[0].strip()
 RESERVED_ROOTS = {"configure", "raw"}
 ITEM_VERBS = {
     "get": "get",
@@ -30,6 +39,7 @@ class Parameter:
     location: str
     required: bool
     schema: dict[str, Any]
+    description: str = ""
 
 
 @dataclass(frozen=True)
@@ -42,6 +52,21 @@ class Operation:
     body_schema: dict[str, Any] | None
     body_required: bool
     requires_auth: bool
+    summary: str = ""
+    description: str = ""
+
+
+def load_tag_descriptions(spec: dict[str, Any]) -> dict[str, str]:
+    """Map each tag name to its one-line ``description`` ('' when absent)."""
+    descriptions: dict[str, str] = {}
+    for tag in spec.get("tags", []) or []:
+        if not isinstance(tag, dict):
+            continue
+        name = tag.get("name")
+        if not isinstance(name, str):
+            continue
+        descriptions[name] = (tag.get("description") or "").strip()
+    return descriptions
 
 
 def load_spec(path: Path) -> dict[str, Any]:
@@ -114,12 +139,17 @@ def load_operations(spec: dict[str, Any]) -> list[Operation]:
         params = []
         for item in [*path_item.get("parameters", []), *operation.get("parameters", [])]:
             item = resolve_local_ref(spec, item)
+            description = item.get("description") or ""
+            schema = resolve_local_ref(spec, item.get("schema", {}))
+            if not description:
+                description = schema.get("description") or ""
             params.append(
                 Parameter(
                     name=item["name"],
                     location=item["in"],
                     required=bool(item.get("required")),
-                    schema=resolve_local_ref(spec, item.get("schema", {})),
+                    schema=schema,
+                    description=str(description).strip(),
                 )
             )
         request_body = resolve_local_ref(spec, operation.get("requestBody", {}))
@@ -140,6 +170,8 @@ def load_operations(spec: dict[str, Any]) -> list[Operation]:
                 body_schema=body_schema,
                 body_required=bool(request_body.get("required")),
                 requires_auth=bool(security),
+                summary=_first_line(operation.get("summary") or ""),
+                description=(operation.get("description") or "").strip(),
             )
         )
     assert_unique(operations)

--- a/koan/app/cli/spec.py
+++ b/koan/app/cli/spec.py
@@ -96,6 +96,13 @@ def resolve_local_ref(spec: dict[str, Any], value: Any) -> Any:
 
 
 def command_name(method: str, path: str, tag: str, tag_count: int) -> tuple[str, ...]:
+    """Derive one operation's command tuple.
+
+    Several branches below are method-independent — they name the command after
+    the path alone. Two methods on the same path therefore produce the same
+    tuple; ``disambiguate_by_method()`` suffixes those before ``assert_unique()``
+    would reject the whole document.
+    """
     segments = path.removeprefix("/v1/").strip("/").split("/")
     first = segments[0].replace("_", "-")
     if len(segments) == 1:
@@ -116,6 +123,31 @@ def command_name(method: str, path: str, tag: str, tag_count: int) -> tuple[str,
     return (tag, segments[-1].replace("_", "-"))
 
 
+def disambiguate_by_method(
+    named: list[tuple[str, str, tuple[str, ...]]],
+) -> dict[tuple[str, str], tuple[str, ...]]:
+    """Suffix same-path commands that a method-independent rule collapsed.
+
+    ``named`` holds ``(path, method, command)`` triples. When one path yields the
+    same command for more than one method, every colliding entry gains a
+    ``-<method>`` suffix on its last segment, so the result stays deterministic
+    and independent of document order. Commands that are already unique within
+    their path are returned untouched.
+    """
+    grouped: dict[tuple[str, tuple[str, ...]], list[str]] = {}
+    for path, method, command in named:
+        grouped.setdefault((path, command), []).append(method)
+
+    resolved: dict[tuple[str, str], tuple[str, ...]] = {}
+    for (path, command), methods in grouped.items():
+        for method in methods:
+            if len(methods) == 1:
+                resolved[(path, method)] = command
+            else:
+                resolved[(path, method)] = (*command[:-1], f"{command[-1]}-{method}")
+    return resolved
+
+
 def load_operations(spec: dict[str, Any]) -> list[Operation]:
     raw = []
     tag_counts: dict[str, int] = {}
@@ -133,6 +165,13 @@ def load_operations(spec: dict[str, Any]) -> list[Operation]:
             tag = tags[0]
             tag_counts[tag] = tag_counts.get(tag, 0) + 1
             raw.append((path, path_item, method, operation, tag))
+
+    commands = disambiguate_by_method(
+        [
+            (path, method, command_name(method, path, tag, tag_counts[tag]))
+            for path, _, method, _, tag in raw
+        ]
+    )
 
     operations = []
     for path, path_item, method, operation, tag in raw:
@@ -165,7 +204,7 @@ def load_operations(spec: dict[str, Any]) -> list[Operation]:
                 method=method.upper(),
                 path=path,
                 operation_id=operation_id,
-                command=command_name(method, path, tag, tag_counts[tag]),
+                command=commands[(path, method)],
                 parameters=tuple(params),
                 body_schema=body_schema,
                 body_required=bool(request_body.get("required")),

--- a/koan/app/cli/spec.py
+++ b/koan/app/cli/spec.py
@@ -11,6 +11,8 @@ from app.cli import CliError
 
 
 HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+# Vendor extension emitted by app.api.openapi_metadata for a destructive view.
+DESTRUCTIVE_EXTENSION = "x-koan-destructive"
 # Operation summaries (from view docstrings) may span multiple lines; the CLI has
 # room for one. Keep only the first line so group/leaf help stays terse.
 FIRST_LINE_FALLBACK = "Unknown operation"
@@ -54,6 +56,7 @@ class Operation:
     requires_auth: bool
     summary: str = ""
     description: str = ""
+    destructive: bool = False
 
 
 def load_tag_descriptions(spec: dict[str, Any]) -> dict[str, str]:
@@ -211,6 +214,10 @@ def load_operations(spec: dict[str, Any]) -> list[Operation]:
                 requires_auth=bool(security),
                 summary=_first_line(operation.get("summary") or ""),
                 description=(operation.get("description") or "").strip(),
+                # DELETE is destructive by method; anything else says so itself,
+                # so a renamed route carries its guard with it.
+                destructive=method.upper() == "DELETE"
+                or bool(operation.get(DESTRUCTIVE_EXTENSION)),
             )
         )
     assert_unique(operations)

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -694,6 +694,7 @@ paths:
       summary: Request a full agent restart.
       tags:
       - admin
+      x-koan-destructive: true
   /v1/resume:
     post:
       operationId: admin_resume_post
@@ -748,6 +749,7 @@ paths:
       summary: Gracefully stop the agent.
       tags:
       - admin
+      x-koan-destructive: true
   /v1/status:
     get:
       operationId: status_status_get
@@ -802,6 +804,7 @@ paths:
       summary: Pull upstream changes and restart.
       tags:
       - admin
+      x-koan-destructive: true
   /v1/update_release:
     post:
       operationId: admin_update_release_post
@@ -829,6 +832,7 @@ paths:
       summary: Check out the latest tagged release and restart.
       tags:
       - admin
+      x-koan-destructive: true
   /v1/usage:
     get:
       operationId: observability_usage_get

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -74,6 +74,33 @@ paths:
   /v1/logs:
     get:
       operationId: observability_logs_get
+      parameters:
+      - description: Log source to read.
+        in: query
+        name: source
+        required: false
+        schema:
+          default: all
+          enum:
+          - run
+          - awake
+          - all
+          type: string
+      - description: Maximum lines returned per source.
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 200
+          maximum: 2000
+          minimum: 1
+          type: integer
+      - description: Case-insensitive substring filter.
+        in: query
+        name: q
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response
@@ -101,6 +128,22 @@ paths:
   /v1/metrics:
     get:
       operationId: observability_metrics_get
+      parameters:
+      - description: Lookback window; values are clamped to the documented range.
+        in: query
+        name: days
+        required: false
+        schema:
+          default: 30
+          maximum: 365
+          minimum: 0
+          type: integer
+      - description: Return metrics and trend for one project.
+        in: query
+        name: project
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response
@@ -128,6 +171,25 @@ paths:
   /v1/missions:
     get:
       operationId: missions_list_missions_route_get
+      parameters:
+      - description: Restrict results to one mission status.
+        in: query
+        name: status
+        required: false
+        schema:
+          enum:
+          - pending
+          - in_progress
+          - done
+          - failed
+          - removed
+          type: string
+      - description: Restrict results to one project.
+        in: query
+        name: project
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response
@@ -154,6 +216,37 @@ paths:
       - missions
     post:
       operationId: missions_create_mission_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - properties:
+                  command:
+                    pattern: \S
+                required:
+                - command
+              - properties:
+                  text:
+                    pattern: \S
+                required:
+                - text
+              properties:
+                command:
+                  description: Slash-command mission; takes precedence over text.
+                  type: string
+                project:
+                  description: Optional project name added as a project tag.
+                  type: string
+                text:
+                  description: Free-form mission text.
+                  type: string
+                urgent:
+                  default: false
+                  description: Insert the mission at the front of the pending queue.
+                  type: boolean
+              type: object
+        required: true
       responses:
         '202':
           description: Successful response
@@ -181,6 +274,23 @@ paths:
   /v1/missions/reorder:
     post:
       operationId: missions_reorder_mission_route_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                mission_id:
+                  pattern: \S
+                  type: string
+                target_position:
+                  description: One-indexed position in the pending queue.
+                  minimum: 1
+                  type: integer
+              required:
+              - mission_id
+              - target_position
+              type: object
+        required: true
       responses:
         '200':
           description: Successful response
@@ -278,6 +388,18 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                text:
+                  pattern: \S
+                  type: string
+              required:
+              - text
+              type: object
+        required: true
       responses:
         '200':
           description: Successful response
@@ -338,6 +460,16 @@ paths:
   /v1/pause:
     post:
       operationId: admin_pause_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                duration:
+                  description: Duration such as 2h, 30m, or 1h30m; omit for indefinite.
+                  type: string
+              type: object
+        required: false
       responses:
         '200':
           description: Successful response
@@ -391,6 +523,20 @@ paths:
       - projects
     post:
       operationId: projects_add_project_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                github_url:
+                  pattern: \S
+                  type: string
+                name:
+                  type: string
+              required:
+              - github_url
+              type: object
+        required: true
       responses:
         '201':
           description: Successful response
@@ -456,6 +602,47 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                patch:
+                  additionalProperties: false
+                  properties:
+                    autoreview:
+                      type: boolean
+                    cli_provider:
+                      type: string
+                    devcontainer:
+                      type: boolean
+                    exploration:
+                      type: boolean
+                    focus:
+                      type: boolean
+                    git_auto_merge.base_branch:
+                      type: string
+                    git_auto_merge.enabled:
+                      type: boolean
+                    git_auto_merge.strategy:
+                      enum:
+                      - squash
+                      - merge
+                      - rebase
+                      type: string
+                    github_url:
+                      type: string
+                    max_open_prs:
+                      type: integer
+                    max_pending_branches:
+                      type: integer
+                    rtk:
+                      type: boolean
+                  type: object
+              required:
+              - patch
+              type: object
+        required: true
       responses:
         '200':
           description: Successful response
@@ -645,6 +832,48 @@ paths:
   /v1/usage:
     get:
       operationId: observability_usage_get
+      parameters:
+      - description: Window length; values are clamped to the documented range.
+        in: query
+        name: days
+        required: false
+        schema:
+          default: 7
+          maximum: 100
+          minimum: 1
+          type: integer
+      - description: Shift the window back by this many granularity units.
+        in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: Series bucketing granularity.
+        in: query
+        name: granularity
+        required: false
+        schema:
+          default: day
+          enum:
+          - day
+          - week
+          - month
+          type: string
+      - description: Include a per-project series breakdown.
+        in: query
+        name: stacked
+        required: false
+        schema:
+          default: false
+          type: boolean
+      - description: Restrict totals and series to one project.
+        in: query
+        name: project
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -52,7 +52,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Get config
+      summary: Get the effective config, with secrets masked out.
       tags:
       - admin
   /v1/health:
@@ -68,7 +68,7 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: Error response
       security: []
-      summary: Health
+      summary: Liveness probe; public, no token required.
       tags:
       - health
   /v1/logs:
@@ -122,7 +122,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Logs
+      summary: Tail recent agent logs, optionally filtered by source.
       tags:
       - observability
   /v1/metrics:
@@ -165,7 +165,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Metrics
+      summary: Mission throughput and success metrics over a window.
       tags:
       - observability
   /v1/missions:
@@ -211,7 +211,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: List missions route
+      summary: List missions, newest first, optionally filtered.
       tags:
       - missions
     post:
@@ -268,7 +268,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Create mission
+      summary: Queue a new mission.
       tags:
       - missions
   /v1/missions/reorder:
@@ -312,7 +312,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Reorder mission route
+      summary: Move a pending mission to a new position.
       tags:
       - missions
   /v1/missions/{mission_id}:
@@ -345,7 +345,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Delete mission
+      summary: Remove a pending mission.
       tags:
       - missions
     get:
@@ -377,7 +377,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Get mission route
+      summary: Fetch one mission by id.
       tags:
       - missions
     patch:
@@ -421,7 +421,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Edit mission
+      summary: Change a pending mission.
       tags:
       - missions
   /v1/missions/{mission_id}/result:
@@ -454,7 +454,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Get mission result route
+      summary: Fetch a finished mission's result.
       tags:
       - missions
   /v1/pause:
@@ -491,7 +491,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Pause
+      summary: Pause the agent, optionally for a duration like "2h" or "30m".
       tags:
       - admin
   /v1/projects:
@@ -518,7 +518,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: List projects
+      summary: List watched projects.
       tags:
       - projects
     post:
@@ -558,7 +558,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Add project
+      summary: Add a project to watch.
       tags:
       - projects
   /v1/projects/{name}:
@@ -591,7 +591,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Delete project
+      summary: Remove a watched project.
       tags:
       - projects
     patch:
@@ -664,7 +664,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Patch project
+      summary: Update a watched project's configuration.
       tags:
       - projects
   /v1/restart:
@@ -691,7 +691,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Restart
+      summary: Request a full agent restart.
       tags:
       - admin
   /v1/resume:
@@ -718,7 +718,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Resume
+      summary: Resume the agent after a pause.
       tags:
       - admin
   /v1/shutdown:
@@ -745,7 +745,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Shutdown
+      summary: Gracefully stop the agent.
       tags:
       - admin
   /v1/status:
@@ -772,7 +772,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Status
+      summary: Get current agent state, execution and mission counters.
       tags:
       - status
   /v1/update:
@@ -799,7 +799,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Update
+      summary: Pull upstream changes and restart.
       tags:
       - admin
   /v1/update_release:
@@ -826,7 +826,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Update release
+      summary: Check out the latest tagged release and restart.
       tags:
       - admin
   /v1/usage:
@@ -895,7 +895,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: Usage
+      summary: Daily agent usage totals, optionally split by project.
       tags:
       - observability
 security:
@@ -904,9 +904,15 @@ servers:
 - description: Default loopback bind
   url: http://127.0.0.1:8420
 tags:
-- name: admin
-- name: health
-- name: missions
-- name: observability
-- name: projects
-- name: status
+- description: Config, pause/resume, restart, update and shutdown
+  name: admin
+- description: Liveness probe (no token required)
+  name: health
+- description: Queue, inspect, reorder and delete missions
+  name: missions
+- description: Logs, metrics and usage
+  name: observability
+- description: List, add, update and remove watched projects
+  name: projects
+- description: Current agent state, execution and mission counters
+  name: status

--- a/koan/tests/rest_cli/conftest.py
+++ b/koan/tests/rest_cli/conftest.py
@@ -1,0 +1,80 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.cli.spec import load_operations
+
+
+class FakeResponse:
+    def __init__(self, status, payload=None, *, text=""):
+        self.status_code = status
+        self._payload = payload
+        self.ok = 200 <= status < 300
+        self.text = text
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+@pytest.fixture
+def response_factory():
+    return FakeResponse
+
+
+@pytest.fixture
+def session_factory():
+    return FakeSession
+
+
+@pytest.fixture
+def api_spec_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "openapi.yaml"
+
+
+@pytest.fixture
+def enriched_operations(api_spec_path, tmp_path):
+    spec = yaml.safe_load(api_spec_path.read_text())
+    enriched = deepcopy(spec)
+    enriched["paths"]["/v1/logs"]["get"]["parameters"] = [
+        {
+            "name": "cursor",
+            "in": "query",
+            "required": True,
+            "schema": {"type": "string"},
+        }
+    ]
+    enriched["paths"]["/v1/missions"]["post"]["requestBody"] = {
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["command"],
+                    "properties": {
+                        "command": {"type": "string"},
+                        "urgent": {"type": "boolean"},
+                    },
+                }
+            }
+        },
+    }
+    path = tmp_path / "enriched-openapi.yaml"
+    path.write_text(yaml.safe_dump(enriched, sort_keys=True))
+    return load_operations(enriched)

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -1,0 +1,229 @@
+import argparse
+
+import pytest
+
+from app.cli import CliError
+from app.cli.commands import (
+    build_operation_request,
+    build_parser,
+    build_raw_request,
+    expand_alias,
+    is_destructive,
+)
+from app.cli.spec import load_operations, load_spec
+
+
+def test_data_is_available_on_get(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+    args = parser.parse_args(["health", "--data", '{"probe":true}'])
+    request = build_operation_request(args._operation, args, "http://localhost:8420")
+    assert request.has_body is True
+    assert request.body == {"probe": True}
+
+
+def test_enriched_required_query_and_body_flags(enriched_operations):
+    parser = build_parser(enriched_operations)
+
+    logs = parser.parse_args(["observability", "logs", "--cursor", "next"])
+    logs_request = build_operation_request(
+        logs._operation, logs, "http://localhost:8420"
+    )
+    assert logs_request.query == {"cursor": "next"}
+
+    create = parser.parse_args(
+        ["missions", "create", "--command", "/review", "--urgent", "true"]
+    )
+    create_request = build_operation_request(
+        create._operation, create, "http://localhost:8420"
+    )
+    assert create_request.body == {"command": "/review", "urgent": True}
+
+
+def test_required_values_can_come_from_generic_flags(enriched_operations):
+    parser = build_parser(enriched_operations)
+    logs = parser.parse_args(["observability", "logs", "-q", "cursor=generic"])
+    assert build_operation_request(
+        logs._operation, logs, "http://localhost"
+    ).query == {"cursor": "generic"}
+
+    create = parser.parse_args(
+        ["missions", "create", "--data", '{"command":"/review"}']
+    )
+    assert build_operation_request(
+        create._operation, create, "http://localhost"
+    ).body == {"command": "/review"}
+
+
+def test_hidden_alias_expands_to_public_command(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    argv = expand_alias(
+        ["missions_list_missions_route_get", "-q", "status=pending"],
+        operations,
+    )
+    assert argv == ["missions", "list", "-q", "status=pending"]
+
+
+def test_path_values_are_percent_encoded(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+    args = parser.parse_args(["missions", "get", "value/with spaces"])
+    request = build_operation_request(args._operation, args, "http://localhost/")
+    assert request.url == "http://localhost/v1/missions/value%2Fwith%20spaces"
+
+
+def test_raw_request_is_fully_constructed():
+    request = build_raw_request(
+        "POST",
+        "/v1/missions",
+        "https://koan.example.com",
+        data='{"command":"/review"}',
+        query=["urgent=true"],
+    )
+    assert request.method == "POST"
+    assert request.url == "https://koan.example.com/v1/missions"
+    assert request.body == {"command": "/review"}
+    assert request.query == {"urgent": "true"}
+    assert request.requires_auth is True
+
+
+def test_raw_health_auth_exception_is_exact():
+    public = build_raw_request(
+        "get", "/v1/health", "http://localhost", data=None, query=[]
+    )
+    queried = build_raw_request(
+        "GET", "/v1/health?verbose=1", "http://localhost", data=None, query=[]
+    )
+    post = build_raw_request(
+        "POST", "/v1/health", "http://localhost", data=None, query=[]
+    )
+    assert public.requires_auth is False
+    assert queried.requires_auth is False
+    assert post.requires_auth is True
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("DELETE", "/v1/missions/1"),
+        ("POST", "/v1/restart"),
+        ("POST", "/v1/shutdown"),
+        ("POST", "/v1/update"),
+        ("POST", "/v1/update_release?now=true"),
+    ],
+)
+def test_destructive_requests(method, path):
+    assert is_destructive(method, path)
+
+
+@pytest.mark.parametrize(
+    ("data", "query", "message"),
+    [
+        ("not-json", [], "invalid JSON"),
+        (None, ["missing"], "KEY=VALUE"),
+        (None, ["=value"], "key cannot be empty"),
+    ],
+)
+def test_invalid_generic_input_fails_locally(data, query, message):
+    with pytest.raises(CliError, match=message):
+        build_raw_request("GET", "/v1/status", "http://localhost", data=data, query=query)
+
+
+def test_typed_body_flags_cannot_merge_into_array(enriched_operations):
+    operation = next(op for op in enriched_operations if op.command == ("missions", "create"))
+    args = argparse.Namespace(
+        data="[]",
+        query=[],
+        _body_command="/review",
+        _body_urgent=None,
+    )
+    with pytest.raises(CliError, match="non-object JSON"):
+        build_operation_request(operation, args, "http://localhost")
+
+
+def test_missing_enriched_required_values_fail(enriched_operations):
+    parser = build_parser(enriched_operations)
+    logs = parser.parse_args(["observability", "logs"])
+    with pytest.raises(CliError, match="required query parameter: cursor"):
+        build_operation_request(logs._operation, logs, "http://localhost")
+
+    create = parser.parse_args(["missions", "create"])
+    with pytest.raises(CliError, match="requires a JSON request body"):
+        build_operation_request(create._operation, create, "http://localhost")
+
+
+def test_parser_usage_errors_exit_one(api_spec_path):
+    parser = build_parser(load_operations(load_spec(api_spec_path)))
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["unknown"])
+    assert exc.value.code == 1
+
+
+def test_every_spec_operation_is_parser_reachable(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+
+    for operation in operations:
+        argv = list(operation.command)
+        for parameter in operation.parameters:
+            if parameter.location == "path":
+                argv.append("sample-value")
+            elif parameter.location == "query" and parameter.required:
+                argv.extend(
+                    [f"--{parameter.name.replace('_', '-')}", "sample-value"]
+                )
+
+        namespace = parser.parse_args(argv)
+        assert namespace._operation == operation
+
+
+def test_every_required_parameter_is_expressible(enriched_operations):
+    parser = build_parser(enriched_operations)
+
+    for operation in enriched_operations:
+        path_names = {
+            parameter.name
+            for parameter in operation.parameters
+            if parameter.location == "path" and parameter.required
+        }
+        query_names = {
+            parameter.name
+            for parameter in operation.parameters
+            if parameter.location == "query" and parameter.required
+        }
+        body_names = set((operation.body_schema or {}).get("required", []))
+
+        argv = list(operation.command)
+        argv.extend("path-value" for _ in path_names)
+        for name in query_names:
+            argv.extend([f"--{name.replace('_', '-')}", "query-value"])
+        for name in body_names:
+            argv.extend([f"--{name.replace('_', '-')}", "body-value"])
+
+        namespace = parser.parse_args(argv)
+        request = build_operation_request(
+            operation, namespace, "http://127.0.0.1:8420"
+        )
+        assert all(f"{{{name}}}" not in request.url for name in path_names)
+        assert query_names <= set(request.query)
+        assert body_names <= set(request.body)
+
+
+def test_every_operation_accepts_generic_data_and_query(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+
+    for operation in operations:
+        argv = list(operation.command)
+        argv.extend(
+            "path-value"
+            for parameter in operation.parameters
+            if parameter.location == "path"
+        )
+        argv.extend(["--data", '{"generic":true}', "-q", "trace=test"])
+        namespace = parser.parse_args(argv)
+        request = build_operation_request(
+            operation, namespace, "http://127.0.0.1:8420"
+        )
+        assert request.body == {"generic": True}
+        assert request.query["trace"] == "test"

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 import pytest
 
@@ -11,6 +12,15 @@ from app.cli.commands import (
     is_destructive,
 )
 from app.cli.spec import load_operations, load_spec
+
+
+def _sample_value(schema):
+    return {
+        "boolean": True,
+        "integer": 1,
+        "number": 1.0,
+        "object": {},
+    }.get(schema.get("type"), "sample-value")
 
 
 def test_data_is_available_on_get(api_spec_path):
@@ -196,9 +206,15 @@ def test_every_required_parameter_is_expressible(enriched_operations):
         argv = list(operation.command)
         argv.extend("path-value" for _ in path_names)
         for name in query_names:
-            argv.extend([f"--{name.replace('_', '-')}", "query-value"])
+            parameter = next(
+                item for item in operation.parameters if item.name == name
+            )
+            argv.extend(
+                [f"--{name.replace('_', '-')}", str(_sample_value(parameter.schema))]
+            )
         for name in body_names:
-            argv.extend([f"--{name.replace('_', '-')}", "body-value"])
+            schema = operation.body_schema["properties"][name]
+            argv.extend([f"--{name.replace('_', '-')}", str(_sample_value(schema))])
 
         namespace = parser.parse_args(argv)
         request = build_operation_request(
@@ -220,10 +236,14 @@ def test_every_operation_accepts_generic_data_and_query(api_spec_path):
             for parameter in operation.parameters
             if parameter.location == "path"
         )
-        argv.extend(["--data", '{"generic":true}', "-q", "trace=test"])
+        body = {"generic": True}
+        schema = operation.body_schema or {}
+        for name in schema.get("required", []):
+            body[name] = _sample_value(schema["properties"][name])
+        argv.extend(["--data", json.dumps(body), "-q", "trace=test"])
         namespace = parser.parse_args(argv)
         request = build_operation_request(
             operation, namespace, "http://127.0.0.1:8420"
         )
-        assert request.body == {"generic": True}
+        assert request.body == body
         assert request.query["trace"] == "test"

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -3,7 +3,6 @@ import json
 import shlex
 
 import pytest
-
 from app.cli import CliError
 from app.cli.commands import (
     GROUP_EXAMPLES,
@@ -340,7 +339,7 @@ def test_every_operation_accepts_generic_data_and_query(api_spec_path):
 
 
 def test_object_body_flag_sends_a_json_object(api_spec_path):
-    """``--patch`` is declared ``type: object``; a JSON *string* can never satisfy it."""
+    """``--patch`` is ``type: object``; a JSON *string* can never satisfy it."""
     operations = load_operations(load_spec(api_spec_path))
     parser = build_parser(operations)
     args = parser.parse_args(
@@ -425,13 +424,17 @@ def test_every_help_example_actually_runs(api_spec_path):
         try:
             args = parser.parse_args(argv[1:])
         except SystemExit as exc:
-            raise AssertionError(f"--help example rejected by argparse: {line}") from exc
+            raise AssertionError(
+                f"--help example rejected by argparse: {line}"
+            ) from exc
         if getattr(args, "_builtin", None) is not None:
             continue
         try:
             build_operation_request(args._operation, args, "http://localhost:8420")
         except CliError as exc:
-            raise AssertionError(f"--help example builds no request: {line} ({exc})") from exc
+            raise AssertionError(
+                f"--help example builds no request: {line} ({exc})"
+            ) from exc
 
 
 def test_help_examples_cover_every_command_group(api_spec_path):

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -334,3 +334,69 @@ def test_every_operation_accepts_generic_data_and_query(api_spec_path):
         )
         assert request.body == body
         assert request.query["trace"] == "test"
+
+
+def test_object_body_flag_sends_a_json_object(api_spec_path):
+    """``--patch`` is declared ``type: object``; a JSON *string* can never satisfy it."""
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+    args = parser.parse_args(
+        ["projects", "update", "my-toolkit", "--patch", '{"focus": true}']
+    )
+    request = build_operation_request(args._operation, args, "http://localhost:8420")
+    assert request.body == {"patch": {"focus": True}}
+
+
+def test_object_body_flag_rejects_non_json_locally(api_spec_path, capsys):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["projects", "update", "my-toolkit", "--patch", "focus=true"])
+    assert "expected JSON" in capsys.readouterr().err
+
+
+def test_object_body_flag_rejects_a_json_scalar(api_spec_path, capsys):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["projects", "update", "my-toolkit", "--patch", '"focus"'])
+    assert "expected a JSON object" in capsys.readouterr().err
+
+
+def test_optional_body_does_not_inherit_schema_required(api_spec_path):
+    """``requestBody.required`` and ``schema.required`` are separate facts."""
+    spec = load_spec(api_spec_path)
+    body = spec["paths"]["/v1/pause"]["post"].setdefault("requestBody", {})
+    body["required"] = False
+    body["content"] = {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "required": ["reason"],
+                "properties": {"reason": {"type": "string"}},
+            }
+        }
+    }
+    operations = load_operations(spec)
+    parser = build_parser(operations)
+
+    args = parser.parse_args(["admin", "pause"])
+    request = build_operation_request(args._operation, args, "http://localhost:8420")
+    assert request.has_body is False
+
+    args = parser.parse_args(["admin", "pause", "--data", "{}"])
+    with pytest.raises(CliError, match="missing required body field: reason"):
+        build_operation_request(args._operation, args, "http://localhost:8420")
+
+
+def test_timeout_flag_precedes_an_operation_id_alias(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    assert expand_alias(["--timeout", "5", "health_get"], operations) == [
+        "--timeout",
+        "5",
+        "health",
+    ]
+    assert expand_alias(["--timeout=5", "health_get"], operations) == [
+        "--timeout=5",
+        "health",
+    ]

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -1,10 +1,13 @@
 import argparse
 import json
+import shlex
 
 import pytest
 
 from app.cli import CliError
 from app.cli.commands import (
+    GROUP_EXAMPLES,
+    _first_examples,
     build_operation_request,
     build_parser,
     build_raw_request,
@@ -400,3 +403,39 @@ def test_timeout_flag_precedes_an_operation_id_alias(api_spec_path):
         "--timeout=5",
         "health",
     ]
+
+
+def test_every_help_example_actually_runs(api_spec_path):
+    """Every example --help prints must parse and build a request.
+
+    --help is where a new user goes first; an example the tool itself printed
+    must not fail when pasted back. Nothing else pins these hand-written
+    strings to the generated interface.
+    """
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+
+    examples = list(_first_examples())
+    for group_examples in GROUP_EXAMPLES.values():
+        examples.extend(group_examples)
+
+    for line in examples:
+        argv = shlex.split(line)
+        assert argv[0] == "koan-cli", line
+        try:
+            args = parser.parse_args(argv[1:])
+        except SystemExit as exc:
+            raise AssertionError(f"--help example rejected by argparse: {line}") from exc
+        if getattr(args, "_builtin", None) is not None:
+            continue
+        try:
+            build_operation_request(args._operation, args, "http://localhost:8420")
+        except CliError as exc:
+            raise AssertionError(f"--help example builds no request: {line} ({exc})") from exc
+
+
+def test_help_examples_cover_every_command_group(api_spec_path):
+    """A new group must arrive with an example, or the epilog silently stays empty."""
+    operations = load_operations(load_spec(api_spec_path))
+    roots = {operation.command[0] for operation in operations}
+    assert roots <= set(GROUP_EXAMPLES), sorted(roots - set(GROUP_EXAMPLES))

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -10,6 +10,7 @@ from app.cli.commands import (
     build_operation_request,
     build_parser,
     build_raw_request,
+    destructive_targets,
     expand_alias,
     is_destructive,
 )
@@ -124,8 +125,65 @@ def test_raw_health_auth_exception_is_exact():
         ("POST", "/v1/update_release?now=true"),
     ],
 )
-def test_destructive_requests(method, path):
-    assert is_destructive(method, path)
+def test_destructive_requests(api_spec_path, method, path):
+    operations = load_operations(load_spec(api_spec_path))
+    assert is_destructive(method, path, destructive_targets(operations))
+
+
+def test_destructive_markers_resolve_to_live_operations(api_spec_path):
+    """Every confirmed target must still exist, so a rename cannot mute the guard."""
+    operations = load_operations(load_spec(api_spec_path))
+    live = {(operation.method, operation.path) for operation in operations}
+    targets = destructive_targets(operations)
+
+    assert targets <= live
+    assert {
+        ("POST", "/v1/restart"),
+        ("POST", "/v1/shutdown"),
+        ("POST", "/v1/update"),
+        ("POST", "/v1/update_release"),
+    } <= targets
+    assert all(
+        (operation.method, operation.path) in targets
+        for operation in operations
+        if operation.method == "DELETE"
+    )
+
+
+def test_generated_command_inherits_spec_destructiveness(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+
+    shutdown = parser.parse_args(["admin", "shutdown"])
+    status = parser.parse_args(["status"])
+
+    assert build_operation_request(
+        shutdown._operation, shutdown, "http://localhost"
+    ).destructive is True
+    assert build_operation_request(
+        status._operation, status, "http://localhost"
+    ).destructive is False
+
+
+def test_raw_request_uses_spec_markers(api_spec_path):
+    targets = destructive_targets(load_operations(load_spec(api_spec_path)))
+    plan = build_raw_request(
+        "POST",
+        "/v1/shutdown",
+        "http://localhost",
+        data=None,
+        query=[],
+        destructive=targets,
+    )
+    assert plan.destructive is True
+    assert build_raw_request(
+        "GET",
+        "/v1/status",
+        "http://localhost",
+        data=None,
+        query=[],
+        destructive=targets,
+    ).destructive is False
 
 
 @pytest.mark.parametrize(

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -169,6 +169,93 @@ def test_parser_usage_errors_exit_one(api_spec_path):
     assert exc.value.code == 1
 
 
+def test_every_operation_contributes_help(api_spec_path):
+    """Every operation must carry a non-empty summary so its --help is useful.
+
+    Guards the CLI's discoverability: a future endpoint that adds no docstring
+    would silently regress --help to a bare command name.
+    """
+    operations = load_operations(load_spec(api_spec_path))
+    assert operations  # guard against a vacuous pass on an empty spec
+    for operation in operations:
+        assert operation.summary, (
+            f"{operation.method} {operation.path} has no summary for --help; "
+            f"add a docstring to its view."
+        )
+
+
+def _walk_leaf_parsers(parser):
+    """Yield every leaf argparse parser (deeper than the root subparser set)."""
+    # Find the root subparsers action, then recurse through group subparsers.
+    visited = set()
+
+    def _walk(p):
+        if id(p) in visited:
+            return
+        visited.add(id(p))
+        for action in p._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                for sub in action.choices.values():
+                    if sub is None:
+                        continue
+                    if any(
+                        isinstance(a, argparse._SubParsersAction) for a in sub._actions
+                    ):
+                        yield from _walk(sub)  # group parser — descend again
+                    else:
+                        yield sub
+
+    yield from _walk(parser)
+
+
+def test_generated_meavars_never_leak_dest_prefixes(api_spec_path):
+    """No _BODY_/_QUERY_ dest prefix may appear in any generated --help."""
+    parser = build_parser(load_operations(load_spec(api_spec_path)))
+
+    def _assert_no_leak(help_text, context):
+        assert "_BODY_" not in help_text, f"_BODY_ leaked in {context}"
+        assert "_QUERY_" not in help_text, f"_QUERY_ leaked in {context}"
+
+    _assert_no_leak(parser.format_help(), "root --help")
+    for sub in _walk_leaf_parsers(parser):
+        _assert_no_leak(sub.format_help(), sub.prog)
+
+
+def test_generated_flags_with_spec_description_show_help(api_spec_path):
+    """Every spec-described query/body flag surfaces its help on that leaf.
+
+    Guards the help wiring: if a future regenerate stops passing help= from a
+    parameter or body-property description, this fails instead of silently
+    dropping the text from --help.
+    """
+    operations = load_operations(load_spec(api_spec_path))
+    parser = build_parser(operations)
+
+    leaves = {
+        sub.prog.removeprefix("koan-cli "): sub for sub in _walk_leaf_parsers(parser)
+    }
+    for operation in operations:
+        key = " ".join(operation.command)
+        leaf = leaves[key]
+        by_flag = {
+            flag: action
+            for action in leaf._actions
+            for flag in getattr(action, "option_strings", [])
+        }
+        for parameter in operation.parameters:
+            if parameter.location == "query" and parameter.description:
+                flag = f"--{parameter.name.replace('_', '-')}"
+                assert by_flag[flag].help == parameter.description, (
+                    f"{key} flag {flag} lost its spec help"
+                )
+        for name, schema in (operation.body_schema or {}).get("properties", {}).items():
+            if schema.get("description"):
+                flag = f"--{name.replace('_', '-')}"
+                assert by_flag[flag].help == schema["description"], (
+                    f"{key} flag {flag} lost its spec help"
+                )
+
+
 def test_every_spec_operation_is_parser_reachable(api_spec_path):
     operations = load_operations(load_spec(api_spec_path))
     parser = build_parser(operations)

--- a/koan/tests/rest_cli/test_config.py
+++ b/koan/tests/rest_cli/test_config.py
@@ -3,7 +3,12 @@ import stat
 import pytest
 
 from app.cli import CliError
-from app.cli.config import load_settings, write_profile
+from app.cli.config import (
+    DEFAULT_TIMEOUT,
+    load_settings,
+    resolve_timeout,
+    write_profile,
+)
 
 
 def test_empty_environment_values_are_unset(tmp_path):
@@ -93,3 +98,38 @@ def test_write_profile_is_mode_600_and_preserves_profiles(tmp_path):
 def test_empty_profile_name_cannot_be_written(tmp_path):
     with pytest.raises(CliError, match="profile name cannot be empty"):
         write_profile(tmp_path / "koan-cli.cfg", "  ", "http://localhost", "token")
+
+
+def test_timeout_defaults_then_yields_to_profile_env_and_flag(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text("[default]\nbase_url = https://file.example\ntimeout = 30\n")
+    path.chmod(0o600)
+
+    assert load_settings(path, "http://d", environ={}).timeout == 30.0
+    assert (
+        load_settings(path, "http://d", environ={"KOAN_TIMEOUT": "45"}).timeout == 45.0
+    )
+    assert (
+        load_settings(
+            path, "http://d", cli_timeout=5.0, environ={"KOAN_TIMEOUT": "45"}
+        ).timeout
+        == 5.0
+    )
+
+
+def test_timeout_defaults_when_nothing_configures_it(tmp_path):
+    settings = load_settings(tmp_path / "missing.cfg", "http://d", environ={})
+    assert settings.timeout == DEFAULT_TIMEOUT
+
+
+@pytest.mark.parametrize("value", ["abc", "0", "-3"])
+def test_invalid_timeout_fails_locally(tmp_path, value):
+    with pytest.raises(CliError, match="invalid KOAN_TIMEOUT"):
+        load_settings(
+            tmp_path / "missing.cfg", "http://d", environ={"KOAN_TIMEOUT": value}
+        )
+
+
+def test_configure_path_validates_a_nonpositive_timeout_flag():
+    with pytest.raises(CliError, match=r"invalid --timeout"):
+        resolve_timeout(cli_timeout=-5.0, environ={})

--- a/koan/tests/rest_cli/test_config.py
+++ b/koan/tests/rest_cli/test_config.py
@@ -74,6 +74,36 @@ def test_unknown_selected_profile_names_path(tmp_path):
         load_settings(path, "http://127.0.0.1:8420", cli_profile="prod")
 
 
+def test_explicit_profile_never_falls_back_silently(tmp_path):
+    """An explicitly named profile that is absent is an error, not the default."""
+    missing = tmp_path / "missing.cfg"
+    empty = tmp_path / "empty.cfg"
+    empty.write_text("")
+    empty.chmod(0o600)
+
+    with pytest.raises(CliError, match="unknown profile 'prod'"):
+        load_settings(missing, "http://127.0.0.1:8420", cli_profile="prod")
+    with pytest.raises(CliError, match="unknown profile 'prod'"):
+        load_settings(empty, "http://127.0.0.1:8420", cli_profile="prod")
+    with pytest.raises(CliError, match="unknown profile 'prod'"):
+        load_settings(
+            empty,
+            "http://127.0.0.1:8420",
+            environ={"KOAN_PROFILE": "prod"},
+        )
+
+
+def test_implicit_default_profile_may_be_absent(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text("[prod]\ntoken = prod-token\n")
+    path.chmod(0o600)
+
+    settings = load_settings(path, "http://127.0.0.1:8420", environ={})
+
+    assert settings.profile == "default"
+    assert settings.token == ""
+
+
 def test_insecure_config_names_exact_fix(tmp_path):
     path = tmp_path / "koan-cli.cfg"
     path.write_text("[default]\ntoken = exposed\n")

--- a/koan/tests/rest_cli/test_config.py
+++ b/koan/tests/rest_cli/test_config.py
@@ -1,0 +1,95 @@
+import stat
+
+import pytest
+
+from app.cli import CliError
+from app.cli.config import load_settings, write_profile
+
+
+def test_empty_environment_values_are_unset(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text(
+        "[default]\n"
+        "base_url = https://file.example\n"
+        "token = file-token\n"
+    )
+    path.chmod(0o600)
+
+    settings = load_settings(
+        path,
+        "http://127.0.0.1:8420",
+        environ={
+            "KOAN_PROFILE": "",
+            "KOAN_BASE_URL": "  ",
+            "KOAN_API_TOKEN": "",
+        },
+    )
+
+    assert settings.profile == "default"
+    assert settings.base_url == "https://file.example"
+    assert settings.token == "file-token"
+
+
+def test_cli_and_environment_precedence(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text(
+        "[prod]\n"
+        "base_url = https://file.example/\n"
+        "token = file-token\n"
+    )
+    path.chmod(0o400)
+
+    settings = load_settings(
+        path,
+        "http://127.0.0.1:8420",
+        cli_profile="prod",
+        cli_base_url="https://cli.example/",
+        environ={"KOAN_API_TOKEN": "env-token"},
+    )
+
+    assert settings.profile == "prod"
+    assert settings.base_url == "https://cli.example"
+    assert settings.token == "env-token"
+
+
+def test_missing_config_uses_spec_default(tmp_path):
+    settings = load_settings(
+        tmp_path / "missing.cfg",
+        "http://127.0.0.1:8420/",
+        environ={},
+    )
+    assert settings.base_url == "http://127.0.0.1:8420"
+    assert settings.token == ""
+
+
+def test_unknown_selected_profile_names_path(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text("[default]\ntoken = local\n")
+    path.chmod(0o600)
+    with pytest.raises(CliError, match=rf"unknown profile 'prod' in {path}"):
+        load_settings(path, "http://127.0.0.1:8420", cli_profile="prod")
+
+
+def test_insecure_config_names_exact_fix(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text("[default]\ntoken = exposed\n")
+    path.chmod(0o644)
+
+    with pytest.raises(CliError, match=rf"chmod 600 {path}"):
+        load_settings(path, "http://127.0.0.1:8420")
+
+
+def test_write_profile_is_mode_600_and_preserves_profiles(tmp_path):
+    path = tmp_path / "koan-cli.cfg"
+    write_profile(path, "prod", "https://prod.example", "prod-token")
+    write_profile(path, "default", "http://127.0.0.1:8420", "local-token")
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    text = path.read_text()
+    assert "[prod]" in text
+    assert "[default]" in text
+
+
+def test_empty_profile_name_cannot_be_written(tmp_path):
+    with pytest.raises(CliError, match="profile name cannot be empty"):
+        write_profile(tmp_path / "koan-cli.cfg", "  ", "http://localhost", "token")

--- a/koan/tests/rest_cli/test_config.py
+++ b/koan/tests/rest_cli/test_config.py
@@ -1,7 +1,6 @@
 import stat
 
 import pytest
-
 from app.cli import CliError
 from app.cli.config import (
     DEFAULT_TIMEOUT,

--- a/koan/tests/rest_cli/test_http.py
+++ b/koan/tests/rest_cli/test_http.py
@@ -1,0 +1,209 @@
+import io
+
+import pytest
+import requests
+
+from app.cli import EXIT_AUTH, EXIT_LOCAL, EXIT_NOT_FOUND, EXIT_OK, EXIT_SERVER, CliError
+from app.cli.commands import RequestPlan
+from app.cli.config import Settings
+from app.cli.http import confirm_destructive, execute, verify_configuration
+
+
+def request_plan(*, destructive=False):
+    return RequestPlan(
+        method="GET",
+        url="http://127.0.0.1:8420/v1/status",
+        query={},
+        body=None,
+        has_body=False,
+        requires_auth=True,
+        destructive=destructive,
+    )
+
+
+def test_http_exit_mapping_and_stderr_only(session_factory, response_factory):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = execute(
+        request_plan(),
+        Settings("default", "http://127.0.0.1:8420", "bad"),
+        session_factory([response_factory(403, {"error": {"code": "forbidden"}})]),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert code == EXIT_AUTH
+    assert stdout.getvalue() == ""
+    assert '"forbidden"' in stderr.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("status", "code"),
+    [(200, EXIT_OK), (400, EXIT_LOCAL), (401, EXIT_AUTH), (404, EXIT_NOT_FOUND), (503, EXIT_SERVER)],
+)
+def test_status_exit_codes(status, code, session_factory, response_factory):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    result = execute(
+        request_plan(),
+        Settings("default", "http://127.0.0.1:8420", "token"),
+        session_factory([response_factory(status, {"status": status})]),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert result == code
+    assert bool(stdout.getvalue()) is (code == EXIT_OK)
+    assert bool(stderr.getvalue()) is (code != EXIT_OK)
+
+
+def test_request_sends_auth_query_and_json(session_factory, response_factory):
+    plan = RequestPlan(
+        method="POST",
+        url="https://koan.example/v1/missions",
+        query={"trace": "test"},
+        body={"command": "/review"},
+        has_body=True,
+        requires_auth=True,
+        destructive=False,
+    )
+    session = session_factory([response_factory(202, {"id": "1"})])
+    code = execute(
+        plan,
+        Settings("prod", "https://koan.example", "secret"),
+        session,
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+    assert code == EXIT_OK
+    assert session.calls == [(
+        "POST",
+        "https://koan.example/v1/missions",
+        {
+            "params": {"trace": "test"},
+            "headers": {"Accept": "application/json", "Authorization": "Bearer secret"},
+            "timeout": 10,
+            "json": {"command": "/review"},
+        },
+    )]
+
+
+def test_missing_token_fails_without_request(session_factory):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    session = session_factory([])
+    code = execute(
+        request_plan(),
+        Settings("default", "http://127.0.0.1:8420", ""),
+        session,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert code == EXIT_LOCAL
+    assert session.calls == []
+    assert "authentication required" in stderr.getvalue()
+
+
+def test_connection_refused_has_setup_steps(session_factory):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = execute(
+        request_plan(),
+        Settings("default", "http://127.0.0.1:8420", "token"),
+        session_factory([requests.ConnectionError("refused")]),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert code == EXIT_LOCAL
+    assert "http://127.0.0.1:8420/v1/status" in stderr.getvalue()
+    assert "api.enabled" in stderr.getvalue()
+    assert "make api-token" in stderr.getvalue()
+    assert "make api" in stderr.getvalue()
+
+
+def test_other_request_failure_is_local(session_factory):
+    stderr = io.StringIO()
+    code = execute(
+        request_plan(),
+        Settings("default", "http://localhost", "token"),
+        session_factory([requests.Timeout("slow")]),
+        stdout=io.StringIO(),
+        stderr=stderr,
+    )
+    assert code == EXIT_LOCAL
+    assert "request failed" in stderr.getvalue()
+
+
+def test_dns_connection_error_does_not_claim_refusal(session_factory):
+    stderr = io.StringIO()
+    code = execute(
+        request_plan(),
+        Settings("default", "http://missing.example", "token"),
+        session_factory([requests.ConnectionError("name resolution failed")]),
+        stdout=io.StringIO(),
+        stderr=stderr,
+    )
+    assert code == EXIT_LOCAL
+    assert "request failed" in stderr.getvalue()
+    assert "api.enabled" not in stderr.getvalue()
+
+
+def test_non_json_response_remains_json(session_factory, response_factory):
+    stdout = io.StringIO()
+    execute(
+        request_plan(),
+        Settings("default", "http://localhost", "token"),
+        session_factory([response_factory(200, ValueError(), text="plain")]),
+        compact=True,
+        stdout=stdout,
+        stderr=io.StringIO(),
+    )
+    assert stdout.getvalue() == '{"body": "plain"}\n'
+
+
+def test_destructive_confirmation_requires_yes_without_tty():
+    with pytest.raises(CliError, match="requires --yes"):
+        confirm_destructive(
+            request_plan(destructive=True),
+            yes=False,
+            stdin=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+
+def test_destructive_confirmation_can_abort_or_continue():
+    class TtyInput(io.StringIO):
+        def isatty(self):
+            return True
+
+    with pytest.raises(CliError, match="aborted"):
+        confirm_destructive(
+            request_plan(destructive=True),
+            yes=False,
+            stdin=TtyInput("no\n"),
+            stderr=io.StringIO(),
+        )
+    confirm_destructive(
+        request_plan(destructive=True),
+        yes=False,
+        stdin=TtyInput("yes\n"),
+        stderr=io.StringIO(),
+    )
+
+
+def test_configure_probes_health_then_authenticated_status(session_factory, response_factory):
+    session = session_factory([
+        response_factory(200, {"status": "ok"}),
+        response_factory(200, {"agent": {"state": "idle"}}),
+    ])
+    result = verify_configuration("http://127.0.0.1:8420", "token", session)
+    assert result.message == "reachable; token authenticated"
+    assert result.exit_code == EXIT_OK
+    assert [call[1] for call in session.calls] == [
+        "http://127.0.0.1:8420/v1/health",
+        "http://127.0.0.1:8420/v1/status",
+    ]
+
+
+def test_configuration_probe_reports_rejected_token(session_factory, response_factory):
+    session = session_factory([
+        response_factory(200, {"status": "ok"}),
+        response_factory(401, {"error": {"code": "unauthorized"}}),
+    ])
+    result = verify_configuration("http://localhost", "bad", session)
+    assert result.message == "reachable; token was rejected"
+    assert result.exit_code == EXIT_AUTH

--- a/koan/tests/rest_cli/test_http.py
+++ b/koan/tests/rest_cli/test_http.py
@@ -5,7 +5,7 @@ import requests
 
 from app.cli import EXIT_AUTH, EXIT_LOCAL, EXIT_NOT_FOUND, EXIT_OK, EXIT_SERVER, CliError
 from app.cli.commands import RequestPlan
-from app.cli.config import Settings
+from app.cli.config import DEFAULT_TIMEOUT, Settings
 from app.cli.http import confirm_destructive, execute, verify_configuration
 
 
@@ -78,7 +78,7 @@ def test_request_sends_auth_query_and_json(session_factory, response_factory):
         {
             "params": {"trace": "test"},
             "headers": {"Accept": "application/json", "Authorization": "Bearer secret"},
-            "timeout": 10,
+            "timeout": DEFAULT_TIMEOUT,
             "json": {"command": "/review"},
         },
     )]
@@ -120,12 +120,40 @@ def test_other_request_failure_is_local(session_factory):
     code = execute(
         request_plan(),
         Settings("default", "http://localhost", "token"),
-        session_factory([requests.Timeout("slow")]),
+        session_factory([requests.TooManyRedirects("looping")]),
         stdout=io.StringIO(),
         stderr=stderr,
     )
     assert code == EXIT_LOCAL
     assert "request failed" in stderr.getvalue()
+
+
+def test_timeout_says_the_request_may_have_been_applied(session_factory):
+    stderr = io.StringIO()
+    code = execute(
+        request_plan(),
+        Settings("default", "http://localhost", "token", 45.0),
+        session_factory([requests.Timeout("slow")]),
+        stdout=io.StringIO(),
+        stderr=stderr,
+    )
+    assert code == EXIT_LOCAL
+    message = stderr.getvalue()
+    assert "no response within 45s" in message
+    assert "may still have been applied" in message
+    assert "request failed" not in message
+
+
+def test_settings_timeout_reaches_the_transport(session_factory, response_factory):
+    session = session_factory([response_factory(200, {})])
+    execute(
+        request_plan(),
+        Settings("default", "http://127.0.0.1:8420", "token", 7.5),
+        session,
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+    assert session.calls[0][2]["timeout"] == 7.5
 
 
 def test_dns_connection_error_does_not_claim_refusal(session_factory):
@@ -207,3 +235,11 @@ def test_configuration_probe_reports_rejected_token(session_factory, response_fa
     result = verify_configuration("http://localhost", "bad", session)
     assert result.message == "reachable; token was rejected"
     assert result.exit_code == EXIT_AUTH
+
+
+def test_unreachable_verification_names_the_cause(session_factory):
+    session = session_factory([requests.exceptions.MissingSchema("bad url")])
+    result = verify_configuration("htps://koan.example", "token", session)
+    assert result.exit_code == EXIT_LOCAL
+    assert "htps://koan.example" in result.message
+    assert "bad url" in result.message

--- a/koan/tests/rest_cli/test_http.py
+++ b/koan/tests/rest_cli/test_http.py
@@ -219,6 +219,13 @@ def test_destructive_confirmation_can_abort_or_continue():
     )
 
 
+def test_verification_without_a_token_is_not_success(session_factory, response_factory):
+    session = session_factory([response_factory(200, {"status": "ok"})])
+    result = verify_configuration("http://127.0.0.1:8420", "", session)
+    assert result.exit_code == EXIT_LOCAL
+    assert "no token configured" in result.message
+
+
 def test_configure_probes_health_then_authenticated_status(session_factory, response_factory):
     session = session_factory([
         response_factory(200, {"status": "ok"}),

--- a/koan/tests/rest_cli/test_http.py
+++ b/koan/tests/rest_cli/test_http.py
@@ -2,8 +2,14 @@ import io
 
 import pytest
 import requests
-
-from app.cli import EXIT_AUTH, EXIT_LOCAL, EXIT_NOT_FOUND, EXIT_OK, EXIT_SERVER, CliError
+from app.cli import (
+    EXIT_AUTH,
+    EXIT_LOCAL,
+    EXIT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_SERVER,
+    CliError,
+)
 from app.cli.commands import RequestPlan
 from app.cli.config import DEFAULT_TIMEOUT, Settings
 from app.cli.http import confirm_destructive, execute, verify_configuration

--- a/koan/tests/rest_cli/test_main.py
+++ b/koan/tests/rest_cli/test_main.py
@@ -1,5 +1,6 @@
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import requests
@@ -77,12 +78,16 @@ def test_destructive_non_tty_stops_before_request(
 
 def test_executable_help():
     executable = Path(__file__).resolve().parents[3] / "bin" / "koan-cli"
+    # Run under the interpreter executing the tests, not whichever python3 the
+    # shebang finds on PATH -- the documented `.venv/bin/pytest ...` invocation
+    # does not put the venv on PATH, so `env python3` would miss the deps. This
+    # still exercises the sys.path bootstrap inside bin/koan-cli.
     result = subprocess.run(
-        [executable, "--help"],
+        [sys.executable, str(executable), "--help"],
         check=False,
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     assert "configure" in result.stdout
     assert "raw" in result.stdout

--- a/koan/tests/rest_cli/test_main.py
+++ b/koan/tests/rest_cli/test_main.py
@@ -134,6 +134,47 @@ def test_configure_prompt_defaults_to_the_environment_base_url(
     assert "https://env.example" in path.read_text()
 
 
+def test_configure_keeps_stored_url_and_token_on_empty_entry(
+    api_spec_path, tmp_path, monkeypatch, session_factory
+):
+    """Re-running configure edits a profile; empty answers must not wipe it."""
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text("[prod]\nbase_url = https://prod.example\ntoken = prod-token\n")
+    path.chmod(0o600)
+    prompts = []
+    monkeypatch.setattr("builtins.input", lambda prompt: prompts.append(prompt) or "")
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "")
+
+    main(
+        ["--profile", "prod", "configure"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session_factory([requests.ConnectionError("down")]),
+    )
+
+    written = path.read_text()
+    assert "https://prod.example" in prompts[0]
+    assert "base_url = https://prod.example" in written
+    assert "token = prod-token" in written
+
+
+def test_configure_without_any_token_reports_failure(
+    api_spec_path, tmp_path, monkeypatch, session_factory, response_factory
+):
+    path = tmp_path / "koan-cli.cfg"
+    monkeypatch.setattr("builtins.input", lambda prompt: "")
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "")
+
+    code = main(
+        ["configure"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session_factory([response_factory(200, {"status": "ok"})]),
+    )
+
+    assert code == EXIT_LOCAL
+
+
 def test_configure_flag_beats_the_environment(
     api_spec_path, tmp_path, monkeypatch, session_factory
 ):

--- a/koan/tests/rest_cli/test_main.py
+++ b/koan/tests/rest_cli/test_main.py
@@ -1,0 +1,88 @@
+import stat
+import subprocess
+from pathlib import Path
+
+import requests
+
+from app.cli import EXIT_LOCAL, EXIT_OK
+from app.cli.main import main
+
+
+def test_health_uses_spec_default_without_config(
+    api_spec_path, tmp_path, session_factory, response_factory
+):
+    session = session_factory([response_factory(200, {"status": "ok"})])
+    code = main(
+        ["health", "--compact"],
+        spec_path=api_spec_path,
+        config_path=tmp_path / "missing.cfg",
+        session=session,
+    )
+    assert code == EXIT_OK
+    assert session.calls[0][1] == "http://127.0.0.1:8420/v1/health"
+    assert "Authorization" not in session.calls[0][2]["headers"]
+
+
+def test_raw_dispatch_honors_profile(
+    api_spec_path, tmp_path, session_factory, response_factory
+):
+    path = tmp_path / "koan-cli.cfg"
+    path.write_text("[prod]\nbase_url = https://prod.example\ntoken = prod-token\n")
+    path.chmod(0o600)
+    session = session_factory([response_factory(200, {"ok": True})])
+
+    code = main(
+        ["--profile", "prod", "raw", "GET", "/v1/status", "--compact"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session,
+    )
+    assert code == EXIT_OK
+    assert session.calls[0][1] == "https://prod.example/v1/status"
+    assert session.calls[0][2]["headers"]["Authorization"] == "Bearer prod-token"
+
+
+def test_configure_saves_even_when_server_is_down(
+    api_spec_path, tmp_path, monkeypatch, session_factory
+):
+    path = tmp_path / "koan-cli.cfg"
+    monkeypatch.setattr("builtins.input", lambda prompt: "https://down.example")
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "token")
+    session = session_factory([requests.ConnectionError("down")])
+
+    assert main(
+        ["configure"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session,
+    ) == EXIT_LOCAL
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert "https://down.example" in path.read_text()
+
+
+def test_destructive_non_tty_stops_before_request(
+    api_spec_path, tmp_path, session_factory, monkeypatch
+):
+    session = session_factory([])
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    code = main(
+        ["admin", "shutdown"],
+        spec_path=api_spec_path,
+        config_path=tmp_path / "missing.cfg",
+        session=session,
+    )
+    assert code == EXIT_LOCAL
+    assert session.calls == []
+
+
+def test_executable_help():
+    executable = Path(__file__).resolve().parents[3] / "bin" / "koan-cli"
+    result = subprocess.run(
+        [executable, "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "configure" in result.stdout
+    assert "raw" in result.stdout

--- a/koan/tests/rest_cli/test_main.py
+++ b/koan/tests/rest_cli/test_main.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 import requests
-
 from app.cli import EXIT_LOCAL, EXIT_OK
 from app.cli.main import main
 
@@ -91,3 +90,67 @@ def test_executable_help():
     assert result.returncode == 0, result.stderr
     assert "configure" in result.stdout
     assert "raw" in result.stdout
+
+
+def test_configure_writes_the_profile_named_by_the_environment(
+    api_spec_path, tmp_path, monkeypatch, session_factory
+):
+    """configure must not drop prod credentials into [default] under KOAN_PROFILE."""
+    path = tmp_path / "koan-cli.cfg"
+    monkeypatch.setenv("KOAN_PROFILE", "prod")
+    monkeypatch.setattr("builtins.input", lambda prompt: "")
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "prod-token")
+
+    main(
+        ["configure"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session_factory([requests.ConnectionError("down")]),
+    )
+
+    written = path.read_text()
+    assert "[prod]" in written
+    assert "[default]" not in written
+    assert "prod-token" in written
+
+
+def test_configure_prompt_defaults_to_the_environment_base_url(
+    api_spec_path, tmp_path, monkeypatch, session_factory
+):
+    path = tmp_path / "koan-cli.cfg"
+    monkeypatch.setenv("KOAN_BASE_URL", "https://env.example")
+    prompts = []
+    monkeypatch.setattr("builtins.input", lambda prompt: prompts.append(prompt) or "")
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "token")
+
+    main(
+        ["configure"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session_factory([requests.ConnectionError("down")]),
+    )
+
+    assert "https://env.example" in prompts[0]
+    assert "https://env.example" in path.read_text()
+
+
+def test_configure_flag_beats_the_environment(
+    api_spec_path, tmp_path, monkeypatch, session_factory
+):
+    path = tmp_path / "koan-cli.cfg"
+    monkeypatch.setenv("KOAN_PROFILE", "prod")
+    monkeypatch.setenv("KOAN_BASE_URL", "https://env.example")
+    monkeypatch.setattr("builtins.input", lambda prompt: "")
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "token")
+
+    main(
+        ["--profile", "staging", "--base-url", "https://flag.example", "configure"],
+        spec_path=api_spec_path,
+        config_path=path,
+        session=session_factory([requests.ConnectionError("down")]),
+    )
+
+    written = path.read_text()
+    assert "[staging]" in written
+    assert "https://flag.example" in written
+    assert "env.example" not in written

--- a/koan/tests/rest_cli/test_spec.py
+++ b/koan/tests/rest_cli/test_spec.py
@@ -2,7 +2,6 @@ from dataclasses import replace
 
 import pytest
 import yaml
-
 from app.cli.spec import (
     SpecError,
     assert_unique,
@@ -11,7 +10,6 @@ from app.cli.spec import (
     load_spec,
     resolve_local_ref,
 )
-
 
 EXPECTED = {
     ("GET", "/v1/health"): ("health",),

--- a/koan/tests/rest_cli/test_spec.py
+++ b/koan/tests/rest_cli/test_spec.py
@@ -1,6 +1,7 @@
 from dataclasses import replace
 
 import pytest
+import yaml
 
 from app.cli.spec import (
     SpecError,
@@ -97,3 +98,32 @@ def test_invalid_server_default_is_rejected(servers):
     spec = {} if servers is None else {"servers": servers}
     with pytest.raises(SpecError, match="servers"):
         load_server_default(spec)
+
+
+def test_same_path_methods_get_distinct_commands(api_spec_path):
+    """A GET+POST pair on one path must not collapse onto a single command.
+
+    The path-derived naming branches ignore the method, so without
+    disambiguation ``assert_unique`` would reject the document and every
+    invocation -- ``--help`` included -- would die at parse time.
+    """
+    spec = yaml.safe_load(api_spec_path.read_text())
+    item = spec["paths"]["/v1/pause"]
+    item["get"] = {
+        "operationId": "admin_probe_pause",
+        "tags": ["admin"],
+        "summary": "Report pause state.",
+        "responses": {"200": {"description": "ok"}},
+    }
+
+    commands = {op.path + op.method: op.command for op in load_operations(spec)}
+    assert commands["/v1/pauseGET"] == ("admin", "pause-get")
+    assert commands["/v1/pausePOST"] == ("admin", "pause-post")
+
+
+def test_disambiguation_leaves_unique_commands_untouched(api_spec_path):
+    spec = yaml.safe_load(api_spec_path.read_text())
+    commands = {op.operation_id: op.command for op in load_operations(spec)}
+    assert commands["missions_list_missions_route_get"] == ("missions", "list")
+    assert commands["missions_create_mission_post"] == ("missions", "create")
+    assert all("-get" not in leaf for command in commands.values() for leaf in command)

--- a/koan/tests/rest_cli/test_spec.py
+++ b/koan/tests/rest_cli/test_spec.py
@@ -1,0 +1,99 @@
+from dataclasses import replace
+
+import pytest
+
+from app.cli.spec import (
+    SpecError,
+    assert_unique,
+    load_operations,
+    load_server_default,
+    load_spec,
+    resolve_local_ref,
+)
+
+
+EXPECTED = {
+    ("GET", "/v1/health"): ("health",),
+    ("GET", "/v1/status"): ("status",),
+    ("GET", "/v1/missions"): ("missions", "list"),
+    ("POST", "/v1/missions"): ("missions", "create"),
+    ("POST", "/v1/missions/reorder"): ("missions", "reorder"),
+    ("GET", "/v1/missions/{mission_id}"): ("missions", "get"),
+    ("PATCH", "/v1/missions/{mission_id}"): ("missions", "update"),
+    ("DELETE", "/v1/missions/{mission_id}"): ("missions", "delete"),
+    ("GET", "/v1/missions/{mission_id}/result"): ("missions", "result"),
+    ("GET", "/v1/projects"): ("projects", "list"),
+    ("POST", "/v1/projects"): ("projects", "create"),
+    ("PATCH", "/v1/projects/{name}"): ("projects", "update"),
+    ("DELETE", "/v1/projects/{name}"): ("projects", "delete"),
+    ("GET", "/v1/config"): ("admin", "config"),
+    ("POST", "/v1/pause"): ("admin", "pause"),
+    ("POST", "/v1/resume"): ("admin", "resume"),
+    ("POST", "/v1/restart"): ("admin", "restart"),
+    ("POST", "/v1/shutdown"): ("admin", "shutdown"),
+    ("POST", "/v1/update"): ("admin", "update"),
+    ("POST", "/v1/update_release"): ("admin", "update-release"),
+    ("GET", "/v1/usage"): ("observability", "usage"),
+    ("GET", "/v1/metrics"): ("observability", "metrics"),
+    ("GET", "/v1/logs"): ("observability", "logs"),
+}
+
+
+def test_current_spec_resolves_exact_command_table(api_spec_path):
+    spec = load_spec(api_spec_path)
+    operations = load_operations(spec)
+    assert len(operations) == 23
+    assert {(op.method, op.path): op.command for op in operations} == EXPECTED
+    assert load_server_default(spec) == "http://127.0.0.1:8420"
+
+
+def test_alias_cannot_collide_with_public_root(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    colliding = replace(operations[0], operation_id="missions")
+    with pytest.raises(SpecError, match="root command"):
+        assert_unique([colliding, *operations[1:]])
+
+
+@pytest.mark.parametrize("reserved", ["configure", "raw"])
+def test_alias_cannot_collide_with_builtin(api_spec_path, reserved):
+    operations = load_operations(load_spec(api_spec_path))
+    colliding = replace(operations[0], operation_id=reserved)
+    with pytest.raises(SpecError, match="built-in"):
+        assert_unique([colliding, *operations[1:]])
+
+
+def test_public_root_cannot_use_builtin(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    colliding = replace(operations[0], command=("raw", "call"))
+    with pytest.raises(SpecError, match="reserved root"):
+        assert_unique([colliding, *operations[1:]])
+
+
+def test_duplicate_and_prefix_commands_are_rejected(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    with pytest.raises(SpecError, match="duplicate command"):
+        assert_unique([operations[0], replace(operations[1], command=operations[0].command)])
+    with pytest.raises(SpecError, match="prefix collision"):
+        assert_unique([
+            replace(operations[0], command=("sample",)),
+            replace(operations[1], command=("sample", "child")),
+        ])
+
+
+def test_duplicate_alias_is_rejected(api_spec_path):
+    operations = load_operations(load_spec(api_spec_path))
+    duplicate = replace(operations[1], operation_id=operations[0].operation_id)
+    with pytest.raises(SpecError, match="duplicate operationId"):
+        assert_unique([operations[0], duplicate])
+
+
+def test_external_reference_is_rejected():
+    with pytest.raises(SpecError, match="unsupported OpenAPI reference"):
+        resolve_local_ref({}, {"$ref": "https://example.test/schema.yaml"})
+
+
+@pytest.mark.parametrize("servers", [None, [], [{}], [{"url": "  "}]])
+def test_invalid_server_default_is_rejected(servers):
+    spec = {} if servers is None else {"servers": servers}
+    with pytest.raises(SpecError, match="servers"):
+        load_server_default(spec)

--- a/koan/tests/test_api_observability.py
+++ b/koan/tests/test_api_observability.py
@@ -19,6 +19,12 @@ def _auth():
     return {"Authorization": "Bearer secret123"}
 
 
+def _query_default(spec, path, name):
+    parameters = spec["paths"][path]["get"]["parameters"]
+    parameter = next(item for item in parameters if item["name"] == name)
+    return parameter["schema"]["default"]
+
+
 def test_usage_requires_token(client):
     assert client.get("/v1/usage").status_code == 401
 
@@ -88,3 +94,42 @@ def test_metrics_bad_days_returns_422(client):
 def test_logs_bad_limit_returns_422(client):
     r = client.get("/v1/logs?limit=xyz", headers=_auth())
     assert r.status_code == 422
+
+
+def test_numeric_query_defaults_match_openapi(client, monkeypatch):
+    from app import log_reader, mission_metrics, usage_service
+    from app.api import openapi_gen
+
+    captured = {}
+
+    def fake_usage(instance_dir, **kwargs):
+        captured["usage_days"] = kwargs["days"]
+        captured["usage_offset"] = kwargs["offset"]
+        return {}
+
+    def fake_metrics(instance_dir, days):
+        captured["metrics_days"] = days
+        return {"by_project": {}}
+
+    def fake_logs(koan_root, *, source, limit, q):
+        captured["logs_limit"] = limit
+        return {"lines": [], "total": 0}
+
+    monkeypatch.setattr(usage_service, "build_usage_payload", fake_usage)
+    monkeypatch.setattr(mission_metrics, "compute_global_metrics", fake_metrics)
+    monkeypatch.setattr(log_reader, "read_logs", fake_logs)
+    monkeypatch.setattr(
+        "app.security_review.count_security_blocks",
+        lambda instance, days: 0,
+    )
+
+    headers = _auth()
+    assert client.get("/v1/usage", headers=headers).status_code == 200
+    assert client.get("/v1/metrics", headers=headers).status_code == 200
+    assert client.get("/v1/logs", headers=headers).status_code == 200
+
+    spec = openapi_gen.build_spec(client.application)
+    assert captured["usage_days"] == _query_default(spec, "/v1/usage", "days")
+    assert captured["usage_offset"] == _query_default(spec, "/v1/usage", "offset")
+    assert captured["metrics_days"] == _query_default(spec, "/v1/metrics", "days")
+    assert captured["logs_limit"] == _query_default(spec, "/v1/logs", "limit")

--- a/koan/tests/test_openapi_gen.py
+++ b/koan/tests/test_openapi_gen.py
@@ -440,6 +440,24 @@ def test_tags_cover_blueprints(app):
             assert name.isidentifier()
 
 
+def test_destructive_routes_declare_the_marker(app):
+    """Destructiveness travels with the view, so clients need no path allow-list."""
+    spec = openapi_gen.build_spec(app)
+    marked = {
+        (method.upper(), path)
+        for path, item in spec["paths"].items()
+        for method, operation in item.items()
+        if operation.get("x-koan-destructive")
+    }
+    assert marked == {
+        ("POST", "/v1/restart"),
+        ("POST", "/v1/shutdown"),
+        ("POST", "/v1/update"),
+        ("POST", "/v1/update_release"),
+    }
+    assert "x-koan-destructive" not in spec["paths"]["/v1/status"]["get"]
+
+
 def test_request_required_without_a_schema_is_rejected():
     """The flag is only stored alongside a schema; alone it would be a silent no-op."""
     with pytest.raises(ValueError, match="request_required"):

--- a/koan/tests/test_openapi_gen.py
+++ b/koan/tests/test_openapi_gen.py
@@ -5,8 +5,8 @@ request metadata, that generation is deterministic, and that the drift check
 works — testing observable outputs, never source text.
 """
 
-import re
 import inspect
+import re
 from contextlib import ExitStack
 from unittest.mock import patch
 
@@ -440,3 +440,9 @@ def test_tags_cover_blueprints(app):
     for path in spec["paths"]:
         for name in re.findall(r"{([^{}]+)}", path):
             assert name.isidentifier()
+
+
+def test_request_required_without_a_schema_is_rejected():
+    """The flag is only stored alongside a schema; alone it would be a silent no-op."""
+    with pytest.raises(ValueError, match="request_required"):
+        openapi_operation(request_required=False)

--- a/koan/tests/test_openapi_gen.py
+++ b/koan/tests/test_openapi_gen.py
@@ -1,17 +1,22 @@
 """Behavior tests for the OpenAPI generator (app.api.openapi_gen).
 
-These assert that the generated document matches the live Flask route table
-(paths, methods, auth), that generation is deterministic, and that the drift
-check works — testing observable outputs, never source text.
+These assert that the generated document matches live Flask routes and attached
+request metadata, that generation is deterministic, and that the drift check
+works — testing observable outputs, never source text.
 """
 
 import re
+import inspect
+from contextlib import ExitStack
+from unittest.mock import patch
 
 import pytest
 import yaml
+from flask import request
 
 from app.api import create_app
 from app.api import openapi_gen
+from app.api.openapi_metadata import openapi_operation, query_parameter
 
 
 @pytest.fixture
@@ -38,6 +43,242 @@ def _spec_operations(spec):
         for path, item in spec["paths"].items()
         for method in item
     }
+
+
+class _TrackedDict(dict):
+    def __init__(self, values):
+        super().__init__(values)
+        self.accessed = set()
+
+    def get(self, key, default=None):
+        self.accessed.add(key)
+        return super().get(key, default)
+
+    def __getitem__(self, key):
+        self.accessed.add(key)
+        return super().__getitem__(key)
+
+
+def _body_fields_used(app, endpoint, payload, view_args=(), patches=()):
+    with app.test_request_context("/", method="POST"):
+        tracked = _TrackedDict(payload)
+        flask_request = request._get_current_object()
+        flask_request.get_json = lambda silent=True: tracked
+
+        with ExitStack() as stack:
+            for target, value in patches:
+                stack.enter_context(patch(target, return_value=value))
+            inspect.unwrap(app.view_functions[endpoint])(*view_args)
+
+        return tracked.accessed
+
+
+def _query_fields_used(app, endpoint, values, patches=()):
+    with app.test_request_context("/", method="GET"):
+        tracked = _TrackedDict(values)
+        flask_request = request._get_current_object()
+        flask_request.__dict__["args"] = tracked
+
+        with ExitStack() as stack:
+            for target, value in patches:
+                stack.enter_context(patch(target, return_value=value))
+            inspect.unwrap(app.view_functions[endpoint])()
+
+        return tracked.accessed
+
+
+def test_request_body_schemas_match_handler_accesses(app):
+    pending = {"status": "pending", "project": None, "text": "- Existing"}
+
+    cases = {
+        ("post", "/v1/missions"): (
+            "missions.create_mission",
+            {"command": "/status", "text": "", "project": "", "urgent": False},
+            (),
+            (
+                ("app.utils.insert_pending_mission", None),
+                ("app.api.routes_missions.record_mission", "mission-id"),
+            ),
+        ),
+        ("post", "/v1/missions/reorder"): (
+            "missions.reorder_mission_route",
+            {"mission_id": "", "target_position": None},
+            (),
+            (),
+        ),
+        ("patch", "/v1/missions/{mission_id}"): (
+            "missions.edit_mission",
+            {"text": ""},
+            ("mission-id",),
+            (
+                ("app.api.routes_missions.get_mission", pending),
+                ("app.api.routes_missions.reconcile", pending),
+            ),
+        ),
+        ("post", "/v1/projects"): (
+            "projects.add_project",
+            {"github_url": "https://github.com/org/repo", "name": "my-toolkit"},
+            (),
+            (("app.api.routes_projects._run_skill", (True, "added")),),
+        ),
+        ("patch", "/v1/projects/{name}"): (
+            "projects.patch_project",
+            {"patch": {}},
+            ("my-toolkit",),
+            (("app.projects_config.apply_project_patch", {}),),
+        ),
+        ("post", "/v1/pause"): (
+            "admin.pause",
+            {"duration": ""},
+            (),
+            (("app.pause_manager.create_pause", None),),
+        ),
+    }
+
+    spec = openapi_gen.build_spec(app)
+    documented = {
+        (method, path)
+        for path, path_item in spec["paths"].items()
+        for method, operation in path_item.items()
+        if "requestBody" in operation
+    }
+    assert documented == set(cases)
+
+    for (method, path), (endpoint, payload, args, patches) in cases.items():
+        schema = spec["paths"][path][method]["requestBody"]["content"][
+            "application/json"
+        ]["schema"]
+        accessed = _body_fields_used(app, endpoint, payload, args, patches)
+        assert set(schema["properties"]) == accessed
+
+
+def test_request_body_requiredness_matches_handlers(app):
+    spec = openapi_gen.build_spec(app)
+
+    create = spec["paths"]["/v1/missions"]["post"]["requestBody"]
+    assert create["required"] is True
+    assert {
+        tuple(branch["required"])
+        for branch in create["content"]["application/json"]["schema"]["anyOf"]
+    } == {("command",), ("text",)}
+
+    required = {
+        ("post", "/v1/missions/reorder"): {"mission_id", "target_position"},
+        ("patch", "/v1/missions/{mission_id}"): {"text"},
+        ("post", "/v1/projects"): {"github_url"},
+        ("patch", "/v1/projects/{name}"): {"patch"},
+    }
+    for (method, path), fields in required.items():
+        body = spec["paths"][path][method]["requestBody"]
+        schema = body["content"]["application/json"]["schema"]
+        assert body["required"] is True
+        assert set(schema["required"]) == fields
+
+    assert spec["paths"]["/v1/pause"]["post"]["requestBody"]["required"] is False
+
+
+def test_query_parameter_schemas_match_handler_accesses(app):
+    cases = {
+        ("get", "/v1/missions"): (
+            "missions.list_missions_route",
+            {"status": None, "project": None},
+            (("app.api.routes_missions.list_missions", []),),
+        ),
+        ("get", "/v1/usage"): (
+            "observability.usage",
+            {
+                "days": "7",
+                "offset": "0",
+                "stacked": "false",
+                "project": "",
+                "granularity": "day",
+            },
+            (("app.usage_service.build_usage_payload", {}),),
+        ),
+        ("get", "/v1/metrics"): (
+            "observability.metrics",
+            {"days": "30", "project": ""},
+            (
+                ("app.mission_metrics.compute_global_metrics", {"by_project": {}}),
+                ("app.security_review.count_security_blocks", 0),
+            ),
+        ),
+        ("get", "/v1/logs"): (
+            "observability.logs",
+            {"source": "all", "limit": "200", "q": ""},
+            (("app.log_reader.read_logs", {"lines": [], "total": 0}),),
+        ),
+    }
+
+    spec = openapi_gen.build_spec(app)
+    documented = {
+        (method, path)
+        for path, path_item in spec["paths"].items()
+        for method, operation in path_item.items()
+        if any(
+            parameter["in"] == "query"
+            for parameter in operation.get("parameters", [])
+        )
+    }
+    assert documented == set(cases)
+
+    for (method, path), (endpoint, values, patches) in cases.items():
+        declared = {
+            parameter["name"]
+            for parameter in spec["paths"][path][method]["parameters"]
+            if parameter["in"] == "query"
+        }
+        assert declared == _query_fields_used(app, endpoint, values, patches)
+
+
+def test_view_metadata_emits_request_body_and_query_parameters():
+    from flask import Flask
+
+    test_app = Flask(__name__)
+
+    @test_app.post("/widgets/<widget_id>")
+    @openapi_operation(
+        request_schema={
+            "type": "object",
+            "required": ["name"],
+            "properties": {"name": {"type": "string"}},
+        },
+        request_required=False,
+        query_parameters=(
+            query_parameter(
+                "dry_run",
+                {"type": "boolean", "default": False},
+                "Validate without applying the change.",
+            ),
+        ),
+    )
+    def create_widget(widget_id):
+        return {"id": widget_id}
+
+    spec = openapi_gen.build_spec(test_app)
+    operation = spec["paths"]["/widgets/{widget_id}"]["post"]
+
+    assert operation["requestBody"] == {
+        "required": False,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        },
+    }
+    assert {
+        (parameter["in"], parameter["name"])
+        for parameter in operation["parameters"]
+    } == {("path", "widget_id"), ("query", "dry_run")}
+
+    operation["parameters"][1]["schema"]["default"] = True
+    regenerated = openapi_gen.build_spec(test_app)
+    query = regenerated["paths"]["/widgets/{widget_id}"]["post"]["parameters"][1]
+    assert query["schema"]["default"] is False
 
 
 def test_spec_matches_live_route_table(app):

--- a/koan/tests/test_openapi_gen.py
+++ b/koan/tests/test_openapi_gen.py
@@ -12,11 +12,9 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from flask import request
-
-from app.api import create_app
-from app.api import openapi_gen
+from app.api import create_app, openapi_gen
 from app.api.openapi_metadata import openapi_operation, query_parameter
+from flask import request
 
 
 @pytest.fixture

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -4,12 +4,13 @@ title: "Component Spec — Web Dashboard & REST API"
 description: "Documents the Flask dashboard and token-gated REST API, their shared `dashboard_service`/`usage_service`/`log_reader` logic, the code-derived OpenAPI spec + drift guard, and the invariants keeping the two surfaces from drifting."
 tags: [web]
 created: 2026-06-27
-updated: 2026-07-17
+updated: 2026-09-08
 ---
 
 # Component Spec — Web Dashboard & REST API
 
-**Packages:** `koan/app/dashboard/`, `koan/app/dashboard_service/`, `koan/app/api/`
+**Packages:** `koan/app/dashboard/`, `koan/app/dashboard_service/`, `koan/app/api/`,
+`koan/app/cli/`
 + shared `usage_service.py`, `log_reader.py`
 
 ## Purpose
@@ -38,6 +39,13 @@ dashboard_service/  (pure logic, no Flask client needed to test)
 api/  (Flask blueprints via create_app())
   auth (require_token) · mission_index (sidecar) · routes_missions/projects/status/
   admin/observability · server.py (waitress entrypoint) · openapi_gen.py (spec generator)
+
+cli/  (runtime OpenAPI REST client)
+  ├─ spec.py      operation discovery, stable command names, collision checks
+  ├─ config.py    mode-0600 named profiles and environment overrides
+  ├─ commands.py  argparse generation and generic request construction
+  ├─ http.py      confirmation, transport, JSON output, exit-code mapping
+  └─ main.py      generated commands plus configure/raw built-ins
 ```
 
 ## Key types & functions
@@ -180,6 +188,15 @@ control flow, lifecycle, or quota decisions.
   check (`.github/workflows/openapi.yml`) enforces this only when API-defining files change.
   Generation is deterministic (unchanged code → byte-identical output) and needs no server,
   token, or `api.enabled`.
+- **The REST CLI consumes the committed OpenAPI document at runtime.** It does
+  not commit generated client code. Every documented operation must map to one
+  collision-free public command and its hidden `operationId` alias.
+- **Sparse specifications remain usable.** Every operation accepts generic
+  JSON through `--data` and repeatable query pairs through `--query`; schema-
+  derived flags are additive when request/query schemas exist.
+- **CLI credentials fail closed.** Tokens come from a mode-0600 or mode-0400
+  profile or `KOAN_API_TOKEN`, never from argv. Destructive requests require
+  confirmation on a TTY and `--yes` in non-interactive execution.
 
 ## Integration points
 

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -4,7 +4,7 @@ title: "Component Spec — Web Dashboard & REST API"
 description: "Documents the Flask dashboard and token-gated REST API, their shared `dashboard_service`/`usage_service`/`log_reader` logic, the code-derived OpenAPI spec + drift guard, and the invariants keeping the two surfaces from drifting."
 tags: [web]
 created: 2026-06-27
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # Component Spec — Web Dashboard & REST API
@@ -62,7 +62,8 @@ cli/  (runtime OpenAPI REST client)
 | `usage_service.build_usage_payload()` | Shared usage payload (week/month buckets) for dashboard **and** `GET /v1/usage`. |
 | `log_reader.tail_log()/read_logs()` | Shared log tailing for dashboard **and** `GET /v1/logs`. |
 | `api/server.py` | Validates token at startup (fail-closed), warns on non-loopback bind, serves via waitress. |
-| `api/openapi_gen.py` | Generates the committed OpenAPI 3.1 doc `koan/openapi.yaml` from the live `create_app()` route table. `build_spec(app)` (pure: equal route table → equal dict) → `dump_yaml()` (deterministic, sorted) → `generate()`/`check()`. Per-route bearer-auth is read from the `require_token` marker `_koan_requires_token` (single source of truth), never an allow-list. `make openapi` regenerates; `make openapi-check` (and CI `openapi.yml`, path-filtered) fails on drift. |
+| `api/openapi_metadata.py` | Defines route-adjacent request-schema and query-parameter declarations. `openapi_operation()` stores metadata on the registered view, mirroring the auth marker pattern without performing runtime validation. |
+| `api/openapi_gen.py` | Generates the committed OpenAPI 3.1 document from the live route table plus metadata attached to each view. Paths, methods, path parameters, auth, JSON request bodies, and query parameters are code-derived; response schemas remain a separate enrichment. |
 
 ## Mission record: typed structured `result`
 
@@ -188,6 +189,11 @@ control flow, lifecycle, or quota decisions.
   check (`.github/workflows/openapi.yml`) enforces this only when API-defining files change.
   Generation is deterministic (unchanged code → byte-identical output) and needs no server,
   token, or `api.enabled`.
+- **OpenAPI request metadata stays beside the handler.** Every view that reads a JSON body
+  or query parameter declares that input through `openapi_operation()`. The generator reads
+  those markers and never maintains a second method/path schema map. Handler-access tests
+  guard the declared field names, and numeric defaults used by both metadata and parsing come
+  from the same constants.
 - **The REST CLI consumes the committed OpenAPI document at runtime.** It does
   not commit generated client code. Every documented operation must map to one
   collision-free public command and its hidden `operationId` alias.

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -203,6 +203,23 @@ control flow, lifecycle, or quota decisions.
 - **CLI credentials fail closed.** Tokens come from a mode-0600 or mode-0400
   profile or `KOAN_API_TOKEN`, never from argv. Destructive requests require
   confirmation on a TTY and `--yes` in non-interactive execution.
+- **Command names are unique by construction, not by luck.** Several naming
+  branches derive a command from the path alone, so two methods on one path
+  would collapse onto one name and a `SpecError` would abort *every* invocation,
+  `--help` included. Same-path collisions are resolved deterministically with a
+  `-<method>` suffix before the uniqueness check runs; the check still guards
+  cross-path collisions, reserved roots, and alias clashes.
+- **An absent response is never reported as an absent request.** The response
+  timeout is operator-controlled (`--timeout`, `KOAN_TIMEOUT`, profile
+  `timeout`) and defaults above the budget of the handlers that do their work
+  synchronously inside the request. A timeout is reported distinctly from a
+  transport failure and states that the operation may already have been applied,
+  because several exposed operations are not idempotent.
+- **Structured schemas keep their shape at the CLI boundary.** A body property
+  typed `object` or `array` produces a JSON-parsing flag that rejects malformed
+  or wrongly-shaped input locally; it is never coerced to a string the server
+  cannot accept. `requestBody.required` (must a body be sent) and
+  `schema.required` (which properties, if one is) stay separate facts.
 
 ## Integration points
 

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -4,7 +4,7 @@ title: "Component Spec — Web Dashboard & REST API"
 description: "Documents the Flask dashboard and token-gated REST API, their shared `dashboard_service`/`usage_service`/`log_reader` logic, the code-derived OpenAPI spec + drift guard, and the invariants keeping the two surfaces from drifting."
 tags: [web]
 created: 2026-06-27
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Component Spec — Web Dashboard & REST API
@@ -202,7 +202,16 @@ control flow, lifecycle, or quota decisions.
   derived flags are additive when request/query schemas exist.
 - **CLI credentials fail closed.** Tokens come from a mode-0600 or mode-0400
   profile or `KOAN_API_TOKEN`, never from argv. Destructive requests require
-  confirmation on a TTY and `--yes` in non-interactive execution.
+  confirmation on a TTY and `--yes` in non-interactive execution. An explicitly
+  named profile that does not exist is an error — never a silent fallback to
+  `default`, which would target a different agent and report success. `configure`
+  edits the selected profile: empty answers keep the stored base URL and token,
+  and a profile left with no token verifies as a failure.
+- **Destructiveness is a route-adjacent marker, like auth.** A view declares
+  `openapi_operation(destructive=True)`; the generator emits
+  `x-koan-destructive`, and clients read it instead of maintaining a method/path
+  allow-list, so renaming a route can never mute its confirmation prompt. DELETE
+  is destructive by method.
 - **Command names are unique by construction, not by luck.** Several naming
   branches derive a command from the path alone, so two methods on one path
   would collapse onto one name and a `SpecError` would abort *every* invocation,

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -4,7 +4,7 @@ The catalog of all pages in this wiki. Each entry: a link to the page and a one-
 
 This wiki spans two content roots — `docs/` (operational "how to use", see [`docs/README.md`](docs/README.md)) and the durable half of `specs/` (design "why/contract", see [`specs/README.md`](../specs/README.md)) — reached from here via the `wiki/docs`, `wiki/specs-components`, `wiki/specs-skills` symlinks. Speckit's ephemeral per-feature folders (`specs/<NNN-slug>/`) are listed under "Specs — Active Features" below with a computed status, not frontmattered. See `SCHEMA.md` for the full rationale.
 
-~84 pages total — well under the ~150-page / 300-line shard threshold, so this stays flat.
+~85 pages total — well under the ~150-page / 300-line shard threshold, so this stays flat.
 
 ---
 
@@ -92,6 +92,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 
 ### Users
 - [`users/koan-md.md`](docs/users/koan-md.md) — Documents the optional project-root `KOAN.md` file and the `.koan/` directory (a second `.koan/KOAN.md`, per-skill `.koan/skills/<skill>/*.md` hooks, and a structured `.koan/config.yaml` with `review.always_check`): koan-only steering for the autonomous agent, 16k caps, runner `project_path` wiring, and this repo's dogfood quality-gate layout.
+- [`users/koan-cli.md`](docs/users/koan-cli.md) — Explains the runtime OpenAPI REST client, secure named profiles, generated commands, generic JSON/query input, output and exit-code contracts, and destructive-request confirmation.
 - [`users/model-configuration.md`](docs/users/model-configuration.md) — Explains how to configure which model handles each Koan role (mission, chat, lightweight, fallback, etc.) per provider via `config.yaml`, including resolution order and CLI-provider-per-role routing.
 - [`users/onboarding.md`](docs/users/onboarding.md) — Documents the interactive 12-step onboarding wizard that sets up a new Koan instance, its resumability, personality presets, and non-interactive/CI mode.
 - [`users/quickstart.md`](docs/users/quickstart.md) — A 5-minute guide to the commands for driving Koan from GitHub PRs/issues, Jira, and messaging apps (Telegram/Slack), with minimal and context-augmented examples for each.


### PR DESCRIPTION
## Summary

Add a checkout-local REST CLI generated from the committed OpenAPI
specification. Secure profiles, raw requests, destructive-action
confirmation, stable JSON output, and complete current/future-schema
coverage make every API operation scriptable without generated client
artifacts.

## Changes

- Generate collision-checked commands and hidden `operationId` aliases for
  all 23 current operations.
- Add secure named profiles, generic and schema-derived inputs, HTTP
  transport, exit mapping, and configuration probes.
- Add 61 focused tests plus coverage invariants for every OpenAPI operation.
- Document CLI usage and the runtime-spec contract across user, API,
  component, and wiki docs.

New package `koan/app/cli/` plus the `bin/koan-cli` launcher. It depends
only on stdlib, `requests`, and `pyyaml` — all already in
`koan/requirements.txt`. No new dependencies.

- [x] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs
  review before approval. Rationale: adds a runtime OpenAPI client surface
  with coverage and credential-handling invariants.

## Test plan

- `KOAN_ROOT=$(mktemp -d) pytest koan/tests/rest_cli -q` — 61 passed.
- `ruff check .` — passed.
- `python -m app.api.openapi_gen --check --output openapi.yaml` — no drift.
- `python scripts/wiki_check.py --full --strict` — passed.
- `python scripts/instance_guard.py` — passed.
- `python scripts/spec_change_guard.py` — passed.
- New module coverage: 89% (baseline 88%).