### PR TITLE
feat(api): emit request inputs in OpenAPI

### DIFF
--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -4,7 +4,7 @@ title: "REST API"
 description: "Documents Kōan's optional, token-authenticated HTTP control layer (missions, projects, pause/resume, config, admin, usage/metrics/logs endpoints), its generated OpenAPI spec + drift guard, and its security model."
 tags: [operations]
 created: 2026-05-31
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # REST API
@@ -136,10 +136,14 @@ but **only when an API-defining file changes** (`koan/app/api/**`, `koan/openapi
 CI time on it. If the check
 fails, the log tells you to run `make openapi` and commit the result.
 
-> **Scope (iteration 1):** the document precisely covers **paths, methods, path parameters,
-> and bearer-auth security** for every route. Per-operation request/response **body** schemas
-> are a planned enrichment and are not yet included. Two known non-`200` successes are
-> reflected: `POST /v1/missions` → `202`, `POST /v1/projects` → `201`.
+> **Request coverage:** the generated document covers paths, methods, path
+> parameters, bearer-auth security, JSON request bodies, and query parameters
+> for every current route. Body schemas and query declarations live beside
+> their Flask views through `openapi_operation()`, while
+> `app.api.openapi_gen` reads those declarations from the registered route.
+> Response body schemas remain a planned enrichment and are not included in
+> this iteration. Two known non-`200` successes remain explicit:
+> `POST /v1/missions` → `202` and `POST /v1/projects` → `201`.
 
 ---
 

--- a/koan/app/api/openapi_gen.py
+++ b/koan/app/api/openapi_gen.py
@@ -1,9 +1,8 @@
 """Generate the OpenAPI document for the Kōan REST API from the live Flask app.
 
-The document is **derived** from the app's route table — it can only describe
-routes that are actually registered, so it cannot drift from the code. Auth
-requirements come from the ``require_token`` decorator marker
-(``_koan_requires_token``), not a hand-maintained allow-list.
+The document is **derived** from the app's route table and request metadata
+attached to registered views. Auth requirements come from the ``require_token``
+decorator marker (``_koan_requires_token``), not a hand-maintained allow-list.
 
 Usage::
 
@@ -17,10 +16,17 @@ See specs/005-openapi-enforcement/ and docs/operations/rest-api.md.
 import argparse
 import re
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 import yaml
 from flask import Flask
+
+from app.api.openapi_metadata import (
+    QUERY_PARAMETERS_ATTR,
+    REQUEST_REQUIRED_ATTR,
+    REQUEST_SCHEMA_ATTR,
+)
 
 # The API contract version (matches the /v1 URL prefix). Pinned deliberately so
 # that bumping app.__version__ on a release does NOT cause spurious spec drift.
@@ -91,7 +97,7 @@ def _tag(endpoint: str) -> str:
 def build_spec(app: Flask) -> dict:
     """Build the OpenAPI 3.1 document (as a plain dict) from ``app``'s route table.
 
-    Pure with respect to the route table: equal route tables yield equal dicts.
+    Pure with respect to registered routes and their attached metadata.
     """
     paths: dict = {}
     tags: set = set()
@@ -108,7 +114,9 @@ def build_spec(app: Flask) -> dict:
         secured = bool(getattr(view, "_koan_requires_token", False))
         tag = _tag(rule.endpoint)
         tags.add(tag)
-        params = _path_params(openapi_path)
+        path_params = _path_params(openapi_path)
+        query_params = getattr(view, QUERY_PARAMETERS_ATTR, ())
+        request_schema = getattr(view, REQUEST_SCHEMA_ATTR, None)
 
         for method in methods:
             m = method.lower()
@@ -127,8 +135,18 @@ def build_spec(app: Flask) -> dict:
                 "tags": [tag],
                 "responses": responses,
             }
-            if params:
-                operation["parameters"] = params
+            parameters = [*deepcopy(path_params), *deepcopy(query_params)]
+            if parameters:
+                operation["parameters"] = parameters
+            if request_schema is not None:
+                operation["requestBody"] = {
+                    "required": bool(getattr(view, REQUEST_REQUIRED_ATTR, True)),
+                    "content": {
+                        "application/json": {
+                            "schema": deepcopy(request_schema),
+                        },
+                    },
+                }
             if not secured:
                 # Override the global bearerAuth requirement — this route is public.
                 operation["security"] = []

--- a/koan/app/api/openapi_metadata.py
+++ b/koan/app/api/openapi_metadata.py
@@ -1,0 +1,38 @@
+"""Route-adjacent metadata consumed by the OpenAPI generator."""
+
+from collections.abc import Callable
+from typing import Any
+
+REQUEST_SCHEMA_ATTR = "_koan_openapi_request_schema"
+REQUEST_REQUIRED_ATTR = "_koan_openapi_request_required"
+QUERY_PARAMETERS_ATTR = "_koan_openapi_query_parameters"
+
+
+def query_parameter(name: str, schema: dict[str, Any], description: str) -> dict:
+    """Build one optional OpenAPI query-parameter declaration."""
+    return {
+        "name": name,
+        "in": "query",
+        "required": False,
+        "description": description,
+        "schema": schema,
+    }
+
+
+def openapi_operation(
+    *,
+    request_schema: dict[str, Any] | None = None,
+    request_required: bool = True,
+    query_parameters: tuple[dict, ...] = (),
+) -> Callable:
+    """Attach request-side OpenAPI metadata to a Flask view."""
+
+    def decorate(view):
+        if request_schema is not None:
+            setattr(view, REQUEST_SCHEMA_ATTR, request_schema)
+            setattr(view, REQUEST_REQUIRED_ATTR, request_required)
+        if query_parameters:
+            setattr(view, QUERY_PARAMETERS_ATTR, query_parameters)
+        return view
+
+    return decorate

--- a/koan/app/api/routes_admin.py
+++ b/koan/app/api/routes_admin.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation
 
 bp = Blueprint("admin", __name__)
 
@@ -23,6 +24,16 @@ _SECRET_SUBSTRINGS = (
     "signing_key",
     "encryption_key",
 )
+
+_PAUSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "duration": {
+            "type": "string",
+            "description": "Duration such as 2h, 30m, or 1h30m; omit for indefinite.",
+        },
+    },
+}
 
 
 def _koan_root() -> Path:
@@ -52,6 +63,7 @@ def _mask_secrets(obj, depth: int = 0):
 
 
 @bp.route("/v1/pause", methods=["POST"])
+@openapi_operation(request_schema=_PAUSE_SCHEMA, request_required=False)
 @require_token
 def pause():
     data = request.get_json(silent=True) or {}

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation, query_parameter
 from app.api.mission_index import (
     _normalize_for_match,
     cancel_mission,
@@ -21,6 +22,76 @@ bp = Blueprint("missions", __name__)
 
 # Validate command-style missions
 _COMMAND_RE = re.compile(r"^/[a-zA-Z0-9_]+")
+
+_CREATE_MISSION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "Slash-command mission; takes precedence over text.",
+        },
+        "text": {
+            "type": "string",
+            "description": "Free-form mission text.",
+        },
+        "project": {
+            "type": "string",
+            "description": "Optional project name added as a project tag.",
+        },
+        "urgent": {
+            "type": "boolean",
+            "default": False,
+            "description": "Insert the mission at the front of the pending queue.",
+        },
+    },
+    "anyOf": [
+        {
+            "required": ["command"],
+            "properties": {"command": {"pattern": r"\S"}},
+        },
+        {
+            "required": ["text"],
+            "properties": {"text": {"pattern": r"\S"}},
+        },
+    ],
+}
+
+_REORDER_MISSION_SCHEMA = {
+    "type": "object",
+    "required": ["mission_id", "target_position"],
+    "properties": {
+        "mission_id": {"type": "string", "pattern": r"\S"},
+        "target_position": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "One-indexed position in the pending queue.",
+        },
+    },
+}
+
+_EDIT_MISSION_SCHEMA = {
+    "type": "object",
+    "required": ["text"],
+    "properties": {
+        "text": {"type": "string", "pattern": r"\S"},
+    },
+}
+
+_LIST_MISSIONS_QUERY_PARAMETERS = (
+    query_parameter(
+        "status",
+        {
+            "type": "string",
+            "enum": ["pending", "in_progress", "done", "failed", "removed"],
+        },
+        "Restrict results to one mission status.",
+    ),
+    query_parameter(
+        "project",
+        {"type": "string"},
+        "Restrict results to one project.",
+    ),
+)
 
 
 def _instance_dir() -> Path:
@@ -88,6 +159,7 @@ def _find_pending_position(content: str, stored_text: str):
 
 
 @bp.route("/v1/missions", methods=["GET"])
+@openapi_operation(query_parameters=_LIST_MISSIONS_QUERY_PARAMETERS)
 @require_token
 def list_missions_route():
     status_filter = request.args.get("status")
@@ -103,6 +175,7 @@ def list_missions_route():
 
 
 @bp.route("/v1/missions", methods=["POST"])
+@openapi_operation(request_schema=_CREATE_MISSION_SCHEMA)
 @require_token
 def create_mission():
     data = request.get_json(silent=True) or {}
@@ -121,6 +194,7 @@ def create_mission():
 
 
 @bp.route("/v1/missions/reorder", methods=["POST"])
+@openapi_operation(request_schema=_REORDER_MISSION_SCHEMA)
 @require_token
 def reorder_mission_route():
     data = request.get_json(silent=True)
@@ -264,6 +338,7 @@ def delete_mission(mission_id: str):
 
 
 @bp.route("/v1/missions/<mission_id>", methods=["PATCH"])
+@openapi_operation(request_schema=_EDIT_MISSION_SCHEMA)
 @require_token
 def edit_mission(mission_id: str):
     rec = get_mission(_instance_dir(), mission_id)

--- a/koan/app/api/routes_observability.py
+++ b/koan/app/api/routes_observability.py
@@ -5,8 +5,104 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation, query_parameter
+from app.log_reader import LOG_DEFAULT_LIMIT, LOG_MAX_LIMIT
 
 bp = Blueprint("observability", __name__)
+
+_USAGE_DEFAULT_DAYS = 7
+_USAGE_DEFAULT_OFFSET = 0
+_USAGE_MIN_DAYS = 1
+_USAGE_MAX_DAYS = 100
+_METRICS_DEFAULT_DAYS = 30
+_METRICS_MIN_DAYS = 0
+_METRICS_MAX_DAYS = 365
+
+_USAGE_QUERY_PARAMETERS = (
+    query_parameter(
+        "days",
+        {
+            "type": "integer",
+            "default": _USAGE_DEFAULT_DAYS,
+            "minimum": _USAGE_MIN_DAYS,
+            "maximum": _USAGE_MAX_DAYS,
+        },
+        "Window length; values are clamped to the documented range.",
+    ),
+    query_parameter(
+        "offset",
+        {
+            "type": "integer",
+            "default": _USAGE_DEFAULT_OFFSET,
+            "minimum": 0,
+        },
+        "Shift the window back by this many granularity units.",
+    ),
+    query_parameter(
+        "granularity",
+        {
+            "type": "string",
+            "enum": ["day", "week", "month"],
+            "default": "day",
+        },
+        "Series bucketing granularity.",
+    ),
+    query_parameter(
+        "stacked",
+        {"type": "boolean", "default": False},
+        "Include a per-project series breakdown.",
+    ),
+    query_parameter(
+        "project",
+        {"type": "string"},
+        "Restrict totals and series to one project.",
+    ),
+)
+
+_METRICS_QUERY_PARAMETERS = (
+    query_parameter(
+        "days",
+        {
+            "type": "integer",
+            "default": _METRICS_DEFAULT_DAYS,
+            "minimum": _METRICS_MIN_DAYS,
+            "maximum": _METRICS_MAX_DAYS,
+        },
+        "Lookback window; values are clamped to the documented range.",
+    ),
+    query_parameter(
+        "project",
+        {"type": "string"},
+        "Return metrics and trend for one project.",
+    ),
+)
+
+_LOGS_QUERY_PARAMETERS = (
+    query_parameter(
+        "source",
+        {
+            "type": "string",
+            "enum": ["run", "awake", "all"],
+            "default": "all",
+        },
+        "Log source to read.",
+    ),
+    query_parameter(
+        "limit",
+        {
+            "type": "integer",
+            "default": LOG_DEFAULT_LIMIT,
+            "minimum": 1,
+            "maximum": LOG_MAX_LIMIT,
+        },
+        "Maximum lines returned per source.",
+    ),
+    query_parameter(
+        "q",
+        {"type": "string"},
+        "Case-insensitive substring filter.",
+    ),
+)
 
 
 def _instance_dir() -> Path:
@@ -31,13 +127,14 @@ def _int_param(name: str, default: str) -> int:
 
 
 @bp.route("/v1/usage")
+@openapi_operation(query_parameters=_USAGE_QUERY_PARAMETERS)
 @require_token
 def usage():
     from app.usage_service import build_usage_payload
 
     try:
-        days = _int_param("days", "7")
-        offset = _int_param("offset", "0")
+        days = _int_param("days", str(_USAGE_DEFAULT_DAYS))
+        offset = _int_param("offset", str(_USAGE_DEFAULT_OFFSET))
     except _BadParam as e:
         return jsonify({"error": {"code": "invalid_request", "message": str(e)}}), 422
     stacked = request.args.get("stacked", "false").lower() in ("true", "1", "yes")
@@ -52,6 +149,7 @@ def usage():
 
 
 @bp.route("/v1/metrics")
+@openapi_operation(query_parameters=_METRICS_QUERY_PARAMETERS)
 @require_token
 def metrics():
     from app.mission_metrics import (
@@ -61,7 +159,13 @@ def metrics():
     )
 
     try:
-        days = max(0, min(_int_param("days", "30"), 365))
+        days = max(
+            _METRICS_MIN_DAYS,
+            min(
+                _int_param("days", str(_METRICS_DEFAULT_DAYS)),
+                _METRICS_MAX_DAYS,
+            ),
+        )
     except _BadParam as e:
         return jsonify({"error": {"code": "invalid_request", "message": str(e)}}), 422
     project = request.args.get("project", "")
@@ -82,9 +186,10 @@ def metrics():
 
 
 @bp.route("/v1/logs")
+@openapi_operation(query_parameters=_LOGS_QUERY_PARAMETERS)
 @require_token
 def logs():
-    from app.log_reader import LOG_DEFAULT_LIMIT, read_logs
+    from app.log_reader import read_logs
 
     source = request.args.get("source", "all")
     try:

--- a/koan/app/api/routes_projects.py
+++ b/koan/app/api/routes_projects.py
@@ -6,10 +6,48 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
+from app.api.openapi_metadata import openapi_operation
 
 log = logging.getLogger("koan.api")
 
 bp = Blueprint("projects", __name__)
+
+_ADD_PROJECT_SCHEMA = {
+    "type": "object",
+    "required": ["github_url"],
+    "properties": {
+        "github_url": {"type": "string", "pattern": r"\S"},
+        "name": {"type": "string"},
+    },
+}
+
+_PATCH_PROJECT_SCHEMA = {
+    "type": "object",
+    "required": ["patch"],
+    "properties": {
+        "patch": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "cli_provider": {"type": "string"},
+                "autoreview": {"type": "boolean"},
+                "focus": {"type": "boolean"},
+                "exploration": {"type": "boolean"},
+                "rtk": {"type": "boolean"},
+                "devcontainer": {"type": "boolean"},
+                "max_open_prs": {"type": "integer"},
+                "max_pending_branches": {"type": "integer"},
+                "github_url": {"type": "string"},
+                "git_auto_merge.enabled": {"type": "boolean"},
+                "git_auto_merge.base_branch": {"type": "string"},
+                "git_auto_merge.strategy": {
+                    "type": "string",
+                    "enum": ["squash", "merge", "rebase"],
+                },
+            },
+        },
+    },
+}
 
 
 def _koan_root() -> Path:
@@ -76,6 +114,7 @@ def list_projects():
 
 
 @bp.route("/v1/projects", methods=["POST"])
+@openapi_operation(request_schema=_ADD_PROJECT_SCHEMA)
 @require_token
 def add_project():
     data = request.get_json(silent=True) or {}
@@ -104,6 +143,7 @@ def delete_project(name: str):
 
 
 @bp.route("/v1/projects/<name>", methods=["PATCH"])
+@openapi_operation(request_schema=_PATCH_PROJECT_SCHEMA)
 @require_token
 def patch_project(name: str):
     from app.projects_config import apply_project_patch

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -74,6 +74,33 @@ paths:
   /v1/logs:
     get:
       operationId: observability_logs_get
+      parameters:
+      - description: Log source to read.
+        in: query
+        name: source
+        required: false
+        schema:
+          default: all
+          enum:
+          - run
+          - awake
+          - all
+          type: string
+      - description: Maximum lines returned per source.
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 200
+          maximum: 2000
+          minimum: 1
+          type: integer
+      - description: Case-insensitive substring filter.
+        in: query
+        name: q
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response
@@ -101,6 +128,22 @@ paths:
   /v1/metrics:
     get:
       operationId: observability_metrics_get
+      parameters:
+      - description: Lookback window; values are clamped to the documented range.
+        in: query
+        name: days
+        required: false
+        schema:
+          default: 30
+          maximum: 365
+          minimum: 0
+          type: integer
+      - description: Return metrics and trend for one project.
+        in: query
+        name: project
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response
@@ -128,6 +171,25 @@ paths:
   /v1/missions:
     get:
       operationId: missions_list_missions_route_get
+      parameters:
+      - description: Restrict results to one mission status.
+        in: query
+        name: status
+        required: false
+        schema:
+          enum:
+          - pending
+          - in_progress
+          - done
+          - failed
+          - removed
+          type: string
+      - description: Restrict results to one project.
+        in: query
+        name: project
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response
@@ -154,6 +216,37 @@ paths:
       - missions
     post:
       operationId: missions_create_mission_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - properties:
+                  command:
+                    pattern: \S
+                required:
+                - command
+              - properties:
+                  text:
+                    pattern: \S
+                required:
+                - text
+              properties:
+                command:
+                  description: Slash-command mission; takes precedence over text.
+                  type: string
+                project:
+                  description: Optional project name added as a project tag.
+                  type: string
+                text:
+                  description: Free-form mission text.
+                  type: string
+                urgent:
+                  default: false
+                  description: Insert the mission at the front of the pending queue.
+                  type: boolean
+              type: object
+        required: true
       responses:
         '202':
           description: Successful response
@@ -181,6 +274,23 @@ paths:
   /v1/missions/reorder:
     post:
       operationId: missions_reorder_mission_route_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                mission_id:
+                  pattern: \S
+                  type: string
+                target_position:
+                  description: One-indexed position in the pending queue.
+                  minimum: 1
+                  type: integer
+              required:
+              - mission_id
+              - target_position
+              type: object
+        required: true
       responses:
         '200':
           description: Successful response
@@ -278,6 +388,18 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                text:
+                  pattern: \S
+                  type: string
+              required:
+              - text
+              type: object
+        required: true
       responses:
         '200':
           description: Successful response
@@ -338,6 +460,16 @@ paths:
   /v1/pause:
     post:
       operationId: admin_pause_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                duration:
+                  description: Duration such as 2h, 30m, or 1h30m; omit for indefinite.
+                  type: string
+              type: object
+        required: false
       responses:
         '200':
           description: Successful response
@@ -391,6 +523,20 @@ paths:
       - projects
     post:
       operationId: projects_add_project_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                github_url:
+                  pattern: \S
+                  type: string
+                name:
+                  type: string
+              required:
+              - github_url
+              type: object
+        required: true
       responses:
         '201':
           description: Successful response
@@ -456,6 +602,47 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                patch:
+                  additionalProperties: false
+                  properties:
+                    autoreview:
+                      type: boolean
+                    cli_provider:
+                      type: string
+                    devcontainer:
+                      type: boolean
+                    exploration:
+                      type: boolean
+                    focus:
+                      type: boolean
+                    git_auto_merge.base_branch:
+                      type: string
+                    git_auto_merge.enabled:
+                      type: boolean
+                    git_auto_merge.strategy:
+                      enum:
+                      - squash
+                      - merge
+                      - rebase
+                      type: string
+                    github_url:
+                      type: string
+                    max_open_prs:
+                      type: integer
+                    max_pending_branches:
+                      type: integer
+                    rtk:
+                      type: boolean
+                  type: object
+              required:
+              - patch
+              type: object
+        required: true
       responses:
         '200':
           description: Successful response
@@ -645,6 +832,48 @@ paths:
   /v1/usage:
     get:
       operationId: observability_usage_get
+      parameters:
+      - description: Window length; values are clamped to the documented range.
+        in: query
+        name: days
+        required: false
+        schema:
+          default: 7
+          maximum: 100
+          minimum: 1
+          type: integer
+      - description: Shift the window back by this many granularity units.
+        in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: Series bucketing granularity.
+        in: query
+        name: granularity
+        required: false
+        schema:
+          default: day
+          enum:
+          - day
+          - week
+          - month
+          type: string
+      - description: Include a per-project series breakdown.
+        in: query
+        name: stacked
+        required: false
+        schema:
+          default: false
+          type: boolean
+      - description: Restrict totals and series to one project.
+        in: query
+        name: project
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Successful response

--- a/koan/tests/rest_cli/test_commands.py
+++ b/koan/tests/rest_cli/test_commands.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 import pytest
 
@@ -11,6 +12,15 @@ from app.cli.commands import (
     is_destructive,
 )
 from app.cli.spec import load_operations, load_spec
+
+
+def _sample_value(schema):
+    return {
+        "boolean": True,
+        "integer": 1,
+        "number": 1.0,
+        "object": {},
+    }.get(schema.get("type"), "sample-value")
 
 
 def test_data_is_available_on_get(api_spec_path):
@@ -196,9 +206,15 @@ def test_every_required_parameter_is_expressible(enriched_operations):
         argv = list(operation.command)
         argv.extend("path-value" for _ in path_names)
         for name in query_names:
-            argv.extend([f"--{name.replace('_', '-')}", "query-value"])
+            parameter = next(
+                item for item in operation.parameters if item.name == name
+            )
+            argv.extend(
+                [f"--{name.replace('_', '-')}", str(_sample_value(parameter.schema))]
+            )
         for name in body_names:
-            argv.extend([f"--{name.replace('_', '-')}", "body-value"])
+            schema = operation.body_schema["properties"][name]
+            argv.extend([f"--{name.replace('_', '-')}", str(_sample_value(schema))])
 
         namespace = parser.parse_args(argv)
         request = build_operation_request(
@@ -220,10 +236,14 @@ def test_every_operation_accepts_generic_data_and_query(api_spec_path):
             for parameter in operation.parameters
             if parameter.location == "path"
         )
-        argv.extend(["--data", '{"generic":true}', "-q", "trace=test"])
+        body = {"generic": True}
+        schema = operation.body_schema or {}
+        for name in schema.get("required", []):
+            body[name] = _sample_value(schema["properties"][name])
+        argv.extend(["--data", json.dumps(body), "-q", "trace=test"])
         namespace = parser.parse_args(argv)
         request = build_operation_request(
             operation, namespace, "http://127.0.0.1:8420"
         )
-        assert request.body == {"generic": True}
+        assert request.body == body
         assert request.query["trace"] == "test"

--- a/koan/tests/test_api_observability.py
+++ b/koan/tests/test_api_observability.py
@@ -19,6 +19,12 @@ def _auth():
     return {"Authorization": "Bearer secret123"}
 
 
+def _query_default(spec, path, name):
+    parameters = spec["paths"][path]["get"]["parameters"]
+    parameter = next(item for item in parameters if item["name"] == name)
+    return parameter["schema"]["default"]
+
+
 def test_usage_requires_token(client):
     assert client.get("/v1/usage").status_code == 401
 
@@ -88,3 +94,42 @@ def test_metrics_bad_days_returns_422(client):
 def test_logs_bad_limit_returns_422(client):
     r = client.get("/v1/logs?limit=xyz", headers=_auth())
     assert r.status_code == 422
+
+
+def test_numeric_query_defaults_match_openapi(client, monkeypatch):
+    from app import log_reader, mission_metrics, usage_service
+    from app.api import openapi_gen
+
+    captured = {}
+
+    def fake_usage(instance_dir, **kwargs):
+        captured["usage_days"] = kwargs["days"]
+        captured["usage_offset"] = kwargs["offset"]
+        return {}
+
+    def fake_metrics(instance_dir, days):
+        captured["metrics_days"] = days
+        return {"by_project": {}}
+
+    def fake_logs(koan_root, *, source, limit, q):
+        captured["logs_limit"] = limit
+        return {"lines": [], "total": 0}
+
+    monkeypatch.setattr(usage_service, "build_usage_payload", fake_usage)
+    monkeypatch.setattr(mission_metrics, "compute_global_metrics", fake_metrics)
+    monkeypatch.setattr(log_reader, "read_logs", fake_logs)
+    monkeypatch.setattr(
+        "app.security_review.count_security_blocks",
+        lambda instance, days: 0,
+    )
+
+    headers = _auth()
+    assert client.get("/v1/usage", headers=headers).status_code == 200
+    assert client.get("/v1/metrics", headers=headers).status_code == 200
+    assert client.get("/v1/logs", headers=headers).status_code == 200
+
+    spec = openapi_gen.build_spec(client.application)
+    assert captured["usage_days"] == _query_default(spec, "/v1/usage", "days")
+    assert captured["usage_offset"] == _query_default(spec, "/v1/usage", "offset")
+    assert captured["metrics_days"] == _query_default(spec, "/v1/metrics", "days")
+    assert captured["logs_limit"] == _query_default(spec, "/v1/logs", "limit")

--- a/koan/tests/test_openapi_gen.py
+++ b/koan/tests/test_openapi_gen.py
@@ -1,17 +1,22 @@
 """Behavior tests for the OpenAPI generator (app.api.openapi_gen).
 
-These assert that the generated document matches the live Flask route table
-(paths, methods, auth), that generation is deterministic, and that the drift
-check works — testing observable outputs, never source text.
+These assert that the generated document matches live Flask routes and attached
+request metadata, that generation is deterministic, and that the drift check
+works — testing observable outputs, never source text.
 """
 
 import re
+import inspect
+from contextlib import ExitStack
+from unittest.mock import patch
 
 import pytest
 import yaml
+from flask import request
 
 from app.api import create_app
 from app.api import openapi_gen
+from app.api.openapi_metadata import openapi_operation, query_parameter
 
 
 @pytest.fixture
@@ -38,6 +43,242 @@ def _spec_operations(spec):
         for path, item in spec["paths"].items()
         for method in item
     }
+
+
+class _TrackedDict(dict):
+    def __init__(self, values):
+        super().__init__(values)
+        self.accessed = set()
+
+    def get(self, key, default=None):
+        self.accessed.add(key)
+        return super().get(key, default)
+
+    def __getitem__(self, key):
+        self.accessed.add(key)
+        return super().__getitem__(key)
+
+
+def _body_fields_used(app, endpoint, payload, view_args=(), patches=()):
+    with app.test_request_context("/", method="POST"):
+        tracked = _TrackedDict(payload)
+        flask_request = request._get_current_object()
+        flask_request.get_json = lambda silent=True: tracked
+
+        with ExitStack() as stack:
+            for target, value in patches:
+                stack.enter_context(patch(target, return_value=value))
+            inspect.unwrap(app.view_functions[endpoint])(*view_args)
+
+        return tracked.accessed
+
+
+def _query_fields_used(app, endpoint, values, patches=()):
+    with app.test_request_context("/", method="GET"):
+        tracked = _TrackedDict(values)
+        flask_request = request._get_current_object()
+        flask_request.__dict__["args"] = tracked
+
+        with ExitStack() as stack:
+            for target, value in patches:
+                stack.enter_context(patch(target, return_value=value))
+            inspect.unwrap(app.view_functions[endpoint])()
+
+        return tracked.accessed
+
+
+def test_request_body_schemas_match_handler_accesses(app):
+    pending = {"status": "pending", "project": None, "text": "- Existing"}
+
+    cases = {
+        ("post", "/v1/missions"): (
+            "missions.create_mission",
+            {"command": "/status", "text": "", "project": "", "urgent": False},
+            (),
+            (
+                ("app.utils.insert_pending_mission", None),
+                ("app.api.routes_missions.record_mission", "mission-id"),
+            ),
+        ),
+        ("post", "/v1/missions/reorder"): (
+            "missions.reorder_mission_route",
+            {"mission_id": "", "target_position": None},
+            (),
+            (),
+        ),
+        ("patch", "/v1/missions/{mission_id}"): (
+            "missions.edit_mission",
+            {"text": ""},
+            ("mission-id",),
+            (
+                ("app.api.routes_missions.get_mission", pending),
+                ("app.api.routes_missions.reconcile", pending),
+            ),
+        ),
+        ("post", "/v1/projects"): (
+            "projects.add_project",
+            {"github_url": "https://github.com/org/repo", "name": "my-toolkit"},
+            (),
+            (("app.api.routes_projects._run_skill", (True, "added")),),
+        ),
+        ("patch", "/v1/projects/{name}"): (
+            "projects.patch_project",
+            {"patch": {}},
+            ("my-toolkit",),
+            (("app.projects_config.apply_project_patch", {}),),
+        ),
+        ("post", "/v1/pause"): (
+            "admin.pause",
+            {"duration": ""},
+            (),
+            (("app.pause_manager.create_pause", None),),
+        ),
+    }
+
+    spec = openapi_gen.build_spec(app)
+    documented = {
+        (method, path)
+        for path, path_item in spec["paths"].items()
+        for method, operation in path_item.items()
+        if "requestBody" in operation
+    }
+    assert documented == set(cases)
+
+    for (method, path), (endpoint, payload, args, patches) in cases.items():
+        schema = spec["paths"][path][method]["requestBody"]["content"][
+            "application/json"
+        ]["schema"]
+        accessed = _body_fields_used(app, endpoint, payload, args, patches)
+        assert set(schema["properties"]) == accessed
+
+
+def test_request_body_requiredness_matches_handlers(app):
+    spec = openapi_gen.build_spec(app)
+
+    create = spec["paths"]["/v1/missions"]["post"]["requestBody"]
+    assert create["required"] is True
+    assert {
+        tuple(branch["required"])
+        for branch in create["content"]["application/json"]["schema"]["anyOf"]
+    } == {("command",), ("text",)}
+
+    required = {
+        ("post", "/v1/missions/reorder"): {"mission_id", "target_position"},
+        ("patch", "/v1/missions/{mission_id}"): {"text"},
+        ("post", "/v1/projects"): {"github_url"},
+        ("patch", "/v1/projects/{name}"): {"patch"},
+    }
+    for (method, path), fields in required.items():
+        body = spec["paths"][path][method]["requestBody"]
+        schema = body["content"]["application/json"]["schema"]
+        assert body["required"] is True
+        assert set(schema["required"]) == fields
+
+    assert spec["paths"]["/v1/pause"]["post"]["requestBody"]["required"] is False
+
+
+def test_query_parameter_schemas_match_handler_accesses(app):
+    cases = {
+        ("get", "/v1/missions"): (
+            "missions.list_missions_route",
+            {"status": None, "project": None},
+            (("app.api.routes_missions.list_missions", []),),
+        ),
+        ("get", "/v1/usage"): (
+            "observability.usage",
+            {
+                "days": "7",
+                "offset": "0",
+                "stacked": "false",
+                "project": "",
+                "granularity": "day",
+            },
+            (("app.usage_service.build_usage_payload", {}),),
+        ),
+        ("get", "/v1/metrics"): (
+            "observability.metrics",
+            {"days": "30", "project": ""},
+            (
+                ("app.mission_metrics.compute_global_metrics", {"by_project": {}}),
+                ("app.security_review.count_security_blocks", 0),
+            ),
+        ),
+        ("get", "/v1/logs"): (
+            "observability.logs",
+            {"source": "all", "limit": "200", "q": ""},
+            (("app.log_reader.read_logs", {"lines": [], "total": 0}),),
+        ),
+    }
+
+    spec = openapi_gen.build_spec(app)
+    documented = {
+        (method, path)
+        for path, path_item in spec["paths"].items()
+        for method, operation in path_item.items()
+        if any(
+            parameter["in"] == "query"
+            for parameter in operation.get("parameters", [])
+        )
+    }
+    assert documented == set(cases)
+
+    for (method, path), (endpoint, values, patches) in cases.items():
+        declared = {
+            parameter["name"]
+            for parameter in spec["paths"][path][method]["parameters"]
+            if parameter["in"] == "query"
+        }
+        assert declared == _query_fields_used(app, endpoint, values, patches)
+
+
+def test_view_metadata_emits_request_body_and_query_parameters():
+    from flask import Flask
+
+    test_app = Flask(__name__)
+
+    @test_app.post("/widgets/<widget_id>")
+    @openapi_operation(
+        request_schema={
+            "type": "object",
+            "required": ["name"],
+            "properties": {"name": {"type": "string"}},
+        },
+        request_required=False,
+        query_parameters=(
+            query_parameter(
+                "dry_run",
+                {"type": "boolean", "default": False},
+                "Validate without applying the change.",
+            ),
+        ),
+    )
+    def create_widget(widget_id):
+        return {"id": widget_id}
+
+    spec = openapi_gen.build_spec(test_app)
+    operation = spec["paths"]["/widgets/{widget_id}"]["post"]
+
+    assert operation["requestBody"] == {
+        "required": False,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        },
+    }
+    assert {
+        (parameter["in"], parameter["name"])
+        for parameter in operation["parameters"]
+    } == {("path", "widget_id"), ("query", "dry_run")}
+
+    operation["parameters"][1]["schema"]["default"] = True
+    regenerated = openapi_gen.build_spec(test_app)
+    query = regenerated["paths"]["/widgets/{widget_id}"]["post"]["parameters"][1]
+    assert query["schema"]["default"] is False
 
 
 def test_spec_matches_live_route_table(app):

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -4,7 +4,7 @@ title: "Component Spec — Web Dashboard & REST API"
 description: "Documents the Flask dashboard and token-gated REST API, their shared `dashboard_service`/`usage_service`/`log_reader` logic, the code-derived OpenAPI spec + drift guard, and the invariants keeping the two surfaces from drifting."
 tags: [web]
 created: 2026-06-27
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # Component Spec — Web Dashboard & REST API
@@ -62,7 +62,8 @@ cli/  (runtime OpenAPI REST client)
 | `usage_service.build_usage_payload()` | Shared usage payload (week/month buckets) for dashboard **and** `GET /v1/usage`. |
 | `log_reader.tail_log()/read_logs()` | Shared log tailing for dashboard **and** `GET /v1/logs`. |
 | `api/server.py` | Validates token at startup (fail-closed), warns on non-loopback bind, serves via waitress. |
-| `api/openapi_gen.py` | Generates the committed OpenAPI 3.1 doc `koan/openapi.yaml` from the live `create_app()` route table. `build_spec(app)` (pure: equal route table → equal dict) → `dump_yaml()` (deterministic, sorted) → `generate()`/`check()`. Per-route bearer-auth is read from the `require_token` marker `_koan_requires_token` (single source of truth), never an allow-list. `make openapi` regenerates; `make openapi-check` (and CI `openapi.yml`, path-filtered) fails on drift. |
+| `api/openapi_metadata.py` | Defines route-adjacent request-schema and query-parameter declarations. `openapi_operation()` stores metadata on the registered view, mirroring the auth marker pattern without performing runtime validation. |
+| `api/openapi_gen.py` | Generates the committed OpenAPI 3.1 document from the live route table plus metadata attached to each view. Paths, methods, path parameters, auth, JSON request bodies, and query parameters are code-derived; response schemas remain a separate enrichment. |
 
 ## Mission record: typed structured `result`
 
@@ -188,6 +189,11 @@ control flow, lifecycle, or quota decisions.
   check (`.github/workflows/openapi.yml`) enforces this only when API-defining files change.
   Generation is deterministic (unchanged code → byte-identical output) and needs no server,
   token, or `api.enabled`.
+- **OpenAPI request metadata stays beside the handler.** Every view that reads a JSON body
+  or query parameter declares that input through `openapi_operation()`. The generator reads
+  those markers and never maintains a second method/path schema map. Handler-access tests
+  guard the declared field names, and numeric defaults used by both metadata and parsing come
+  from the same constants.
 - **The REST CLI consumes the committed OpenAPI document at runtime.** It does
   not commit generated client code. Every documented operation must map to one
   collision-free public command and its hidden `operationId` alias.


### PR DESCRIPTION
Need to merge #2509 first

## Summary

The committed OpenAPI document described what every REST operation *returns*, but
nothing about what it *accepts*. Request bodies were opaque and query parameters were
undocumented, so a spec-driven client had no way to know which inputs an operation
takes or which of them are required.

This PR generates JSON request-body schemas and typed query parameters from metadata
attached directly to the Flask views, keeping the description next to the handler that
implements it rather than in a hand-maintained side file. Shared constants keep the
numeric OpenAPI defaults aligned with the runtime parsing, so the document cannot
advertise a default the handler does not actually apply.

## Changes

- Add `koan/app/api/openapi_metadata.py` with the `openapi_operation()` and
  `query_parameter()` helpers, which copy their generator input defensively so a
  route declaration cannot be mutated after registration.
- Describe six JSON-body operations and twelve query parameters across four GET
  operations in `routes_admin`, `routes_missions`, `routes_observability`, and
  `routes_projects`.
- Teach `openapi_gen` to emit `requestBody` and `parameters` from that metadata.
- Add handler-access drift tests (the declared metadata must match the attributes the
  handler really reads), runtime-default tests, and typed REST CLI fixture coverage.
- Regenerate `koan/openapi.yaml` and refresh `docs/operations/rest-api.md`.

## Stacking

This PR is stacked on #2509 (`feat(cli): add spec-driven REST client`) and targets that
branch, not `main`. The reason is not cosmetic: declaring required request-body
properties changes what the REST CLI's coverage tests must send, so
`koan/tests/rest_cli/test_commands.py` is updated in the same commit. Splitting the two
would leave whichever PR merged second with a red suite. Please merge #2509 first; this
branch then rebases onto `main` cleanly.

## Testing

All gates run locally against the stacked base:

- `ruff check .` — clean.
- `make openapi-check` (`app.api.openapi_gen --check`) — no drift.
- `pytest koan/tests -k "api or openapi or dashboard or rest or cli"` — 2078 passed, 1 skipped, 0 failed.
- `scripts/instance_guard.py` — passed.
- `scripts/wiki_check.py --full --strict` — no OKF conformance gaps.
- `scripts/spec_change_guard.py` — passed with the declaration below.

## Declarations

- [x] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: `specs/components/web.md` now makes route-adjacent
  request metadata part of the OpenAPI generation contract, so a route's declared
  inputs become a reviewed surface rather than an implementation detail.