### PR TITLE
fix(rebase): stop reviewer refs auto-linking to unrelated issues

### DIFF
--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -4,7 +4,7 @@ title: "GitHub And Trackers"
 description: "Covers GitHub/Jira notification flow, PR workflows (footer, receiving-code-review protocol), review issue-tracker enrichment, and the instance/ tracker files used to dedupe work."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-08-14
+updated: 2026-09-10
 ---
 
 # GitHub And Trackers
@@ -54,6 +54,24 @@ request is incorrect — while complying when the human insists. Trivial/mechani
 feedback takes a fast-path. The review-learning extraction additionally records
 pushback outcomes (validated vs. overridden) so the agent learns which pushbacks to
 trust.
+
+### Reviewer references never auto-link
+
+A review comment numbers its findings (`1.`, `2.`, … and `warning #3` in the
+checklist), and the rebase feedback agent echoes those numbers back in its
+summary — "reviewer #5", "#7 (transport fallback)". GitHub auto-links any bare
+`#N` in comment prose to the issue or PR with that number, so those references
+used to render as links to unrelated repository issues.
+
+`app.github.escape_issue_refs` neutralizes them: every bare `#N` (including the
+`owner/repo#N` cross-repo form) becomes a fullwidth `＃N` (U+FF03), which
+reads the same but is not a GitHub reference. Fenced code blocks, inline code
+spans, and URLs are left verbatim, so a `…/pull/12#issuecomment-9` fragment or a
+`#1f2937` hex colour survives untouched. The rebase PR comment
+(`rebase_pr._build_rebase_comment`) runs its whole rendered body through it —
+nothing that comment emits is ever a deliberate issue link. Comments that *do*
+link real issues on purpose (the already-solved close notice's "linked to PR
+#N") are not passed through it.
 
 ### Force-push content-preservation guard
 

--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -45,6 +45,61 @@ def sanitize_github_comment(text: Optional[str]) -> Optional[str]:
     return _BOT_MENTION_RE.sub(r'`@\1`', text)
 
 
+# ---------------------------------------------------------------------------
+# Issue/PR cross-reference escaping
+# ---------------------------------------------------------------------------
+#
+# GitHub auto-links any bare ``#123`` (and ``owner/repo#123``) in comment prose
+# to an issue or PR in the target repository. Bot comments that number their own
+# items — a review's "warning #5", a rebase summary echoing "reviewer #7" — then
+# render as links to unrelated issues, which is actively misleading. Escaping the
+# hash keeps the reference readable while breaking the auto-link.
+
+# Regions whose contents must never be rewritten: fenced code blocks, inline code
+# spans, and URLs (a ``…/pull/12#issuecomment-9`` fragment or a ``#rrggbb``-style
+# anchor must survive verbatim).
+_PROTECTED_SPAN_RE = re.compile(
+    r"```.*?```"            # fenced code block (``` … ```)
+    r"|~~~.*?~~~"           # fenced code block (~~~ … ~~~)
+    r"|`[^`\n]*`"           # inline code span
+    r"|<https?://[^>\s]+>"  # autolink
+    r"|https?://\S+",       # bare or markdown-target URL
+    re.DOTALL,
+)
+
+# A bare cross-reference: ``#`` followed only by digits. ``\b`` keeps hex colors
+# (``#1f2937``) and heading markers (``## Stats``) out, and the ``&`` lookbehind
+# leaves HTML entities such as ``&#39;`` alone.
+_ISSUE_REF_RE = re.compile(r"(?<!&)#(\d+)\b")
+
+# Fullwidth number sign (U+FF03) — visually a hash, but not a GitHub reference.
+FULLWIDTH_HASH = "＃"
+
+
+def escape_issue_refs(text: Optional[str]) -> Optional[str]:
+    """Neutralize bare ``#123`` refs so GitHub does not auto-link them.
+
+    Replaces the ASCII ``#`` of every bare numeric cross-reference with the
+    fullwidth number sign ``＃`` (U+FF03), outside of code spans, fenced code
+    blocks and URLs. Use on generated bot prose that numbers its own items;
+    do NOT use on text where ``#123`` is a deliberate link to a real issue.
+    """
+    if not text:
+        return text
+
+    def _escape(chunk: str) -> str:
+        return _ISSUE_REF_RE.sub(FULLWIDTH_HASH + r"\1", chunk)
+
+    out: List[str] = []
+    pos = 0
+    for match in _PROTECTED_SPAN_RE.finditer(text):
+        out.append(_escape(text[pos:match.start()]))
+        out.append(match.group(0))
+        pos = match.end()
+    out.append(_escape(text[pos:]))
+    return "".join(out)
+
+
 class SSOAuthRequired(RuntimeError):
     """Raised when a GitHub API call fails due to missing SSO authorization.
 

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -57,7 +57,7 @@ from app.config import (
     get_skill_timeout,
 )
 from app.git_utils import ordered_remotes as _ordered_remotes
-from app.github import run_gh, sanitize_github_comment
+from app.github import escape_issue_refs, run_gh, sanitize_github_comment
 from app.prompts import load_prompt, load_prompt_or_skill, load_skill_prompt  # noqa: F401 — safety import
 from app.retry import retry_with_backoff
 from app.utils import (
@@ -2803,7 +2803,11 @@ def _build_rebase_comment(
 
     parts.append("---\n_Automated by Kōan_")
 
-    return "\n".join(parts)
+    # The feedback agent numbers reviewer points ("reviewer #5", "#7") after the
+    # review comment's own finding IDs. GitHub would auto-link those to unrelated
+    # issues/PRs in this repo, so neutralize every bare #N in the rendered body.
+    # Nothing this comment emits is ever a deliberate issue link.
+    return escape_issue_refs("\n".join(parts))
 
 
 def _extract_change_items(

--- a/koan/tests/test_github.py
+++ b/koan/tests/test_github.py
@@ -15,6 +15,7 @@ from app.github import (
     _upstream_remote_repo,
     origin_repo, _parse_remote_url,
     sanitize_github_comment,
+    escape_issue_refs,
     find_bot_comment,
 )
 import app.github as github_module
@@ -1775,3 +1776,63 @@ class TestIssueLabelToggle:
         assert seen[0][:5] == ("label", "create", "koan:working",
                                "--repo", "o/r")
         assert "--force" in seen[0]
+
+
+# ---------------------------------------------------------------------------
+# escape_issue_refs
+# ---------------------------------------------------------------------------
+
+class TestEscapeIssueRefs:
+    """Bare ``#N`` refs must stop auto-linking to unrelated issues/PRs."""
+
+    def test_escapes_bare_ref(self):
+        assert escape_issue_refs("reviewer #5 asked for this") == (
+            "reviewer \uFF035 asked for this"
+        )
+
+    def test_escapes_every_ref_in_a_line(self):
+        result = escape_issue_refs("Points #5, #6 and #7 remain.")
+        assert result == "Points \uFF035, \uFF036 and \uFF037 remain."
+        assert "#" not in result
+
+    def test_escapes_ref_in_parentheses(self):
+        assert escape_issue_refs("(reviewer #12)") == "(reviewer \uFF0312)"
+
+    def test_escapes_cross_repo_ref(self):
+        assert escape_issue_refs("owner/repo#5") == "owner/repo\uFF035"
+
+    def test_leaves_inline_code_span_alone(self):
+        assert escape_issue_refs("see `#7` here") == "see `#7` here"
+
+    def test_leaves_fenced_code_block_alone(self):
+        text = "before #1\n```\nfix #2\n```\nafter #3"
+        assert escape_issue_refs(text) == "before \uFF031\n```\nfix #2\n```\nafter \uFF033"
+
+    def test_leaves_tilde_fence_alone(self):
+        assert escape_issue_refs("~~~\nfix #2\n~~~") == "~~~\nfix #2\n~~~"
+
+    def test_leaves_url_fragment_alone(self):
+        url = "https://github.com/o/r/pull/12#issuecomment-999"
+        assert escape_issue_refs(f"see {url} now") == f"see {url} now"
+
+    def test_leaves_autolink_alone(self):
+        text = "<https://example.com/p#1> ok"
+        assert escape_issue_refs(text) == text
+
+    def test_leaves_markdown_headings_alone(self):
+        assert escape_issue_refs("## Stats\n### CI status") == "## Stats\n### CI status"
+
+    def test_leaves_hex_color_alone(self):
+        assert escape_issue_refs("color #1f2937 stays") == "color #1f2937 stays"
+
+    def test_leaves_html_entity_alone(self):
+        assert escape_issue_refs("it&#39;s fine") == "it&#39;s fine"
+
+    def test_no_refs_is_unchanged(self):
+        assert escape_issue_refs("nothing to escape") == "nothing to escape"
+
+    def test_empty_string(self):
+        assert escape_issue_refs("") == ""
+
+    def test_none(self):
+        assert escape_issue_refs(None) is None

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -695,6 +695,38 @@ class TestBuildRebaseComment:
         # Callout comes before the collapsed Actions section.
         assert result.index("[!WARNING]") < result.index("<details>")
 
+    def test_reviewer_refs_do_not_autolink(self):
+        # The feedback agent numbers reviewer points after the review comment's
+        # own finding IDs. A bare "#5" would auto-link to issue/PR 5 in this
+        # repo, which is a different, unrelated thing.
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main", "Applied review feedback"],
+            {"title": "Fix bug", "review_comments": "please fix the typo"},
+            change_summary=(
+                "APPLIED:\n"
+                "- `koan/app/mcp/http.py` \u2014 audit write failure now logs (reviewer #5).\n"
+                "SKIPPED:\n"
+                "- #7 (transport fallback): intentional fail-closed design."
+            ),
+        )
+        assert "reviewer \uFF035" in result
+        assert "\uFF037 (transport fallback)" in result
+        assert "#5" not in result
+        assert "#7" not in result
+
+    def test_escaping_keeps_headings_and_code_intact(self):
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main", "Applied review feedback"],
+            {"title": "Fix bug"},
+            diffstat="22 files changed, 811 insertions(+), 66 deletions(-)",
+            change_summary="Reverted the `#3` marker verbatim.",
+        )
+        assert "### Stats" in result
+        assert "## Rebase with requested adjustments" in result
+        assert "`#3`" in result
+
     def test_feedback_failed_warning_has_default_reason(self):
         result = _build_rebase_comment(
             "42", "koan/fix", "main",

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -92,6 +92,13 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
   before continuing. Its per-round agent budget is `rebase_conflict_timeout`
   (600 seconds by default); exhaustion aborts the rebase and preserves the
   existing recreate fallback.
+- **The rebase PR comment never auto-links a reviewer reference.** The feedback
+  agent numbers reviewer points after the review comment's own finding IDs
+  ("reviewer #5", "#7"). The rendered body is passed through
+  `app.github.escape_issue_refs`, which rewrites every bare `#N` (and the
+  `owner/repo#N` form) to a fullwidth `＃N` outside code spans, fenced blocks and
+  URLs — so a reviewer point never renders as a link to an unrelated repository
+  issue or PR. Nothing this comment emits is ever a deliberate issue link.
 - **Force pushes are guarded, not gated.** The content-preservation guard runs
   after the pipeline's last push (private-gate re-pushes included — the gate
   feeds its own pre-push observations and pushed SHA back into the guard's


### PR DESCRIPTION
## Summary

The rebase feedback agent numbers reviewer points after the review comment's own
finding IDs, so its summary says things like `reviewer ＃5` or
`＃7 (transport fallback hides misconfig)` — with a plain ASCII hash. GitHub
auto-links any bare `＃N` in comment prose, so each of those rendered as a link to
a **completely unrelated** issue or PR in the repository. (This description uses
the escaped glyph for the same reason.)

**Fix** — new `app.github.escape_issue_refs`:

- rewrites a bare hash-number reference (and the `owner/repo` cross-repo form) to
  a fullwidth number sign `＃` (U+FF03) — the same glyph to a reader, but not a
  GitHub reference;
- skips fenced code blocks, inline code spans and URLs, so an `issuecomment` URL
  fragment, a six-digit hex colour and a Markdown heading marker all survive
  verbatim;
- is the same escape the review comment's checklist already applies to its own
  finding labels — now factored into one shared, tested helper.

`rebase_pr._build_rebase_comment` runs its whole rendered body through it:
nothing that comment emits is ever a deliberate issue link. Comments that *do*
link real issues on purpose — the already-solved close notice's "linked to PR"
line — are deliberately left alone, as is `sanitize_github_comment`, which every
other comment path shares.

## Testing

- `ruff check .` — clean
- 17 new unit tests: 15 on `escape_issue_refs` (bare / multiple / parenthesised /
  cross-repo refs; code spans, ``` and `~~~` fences, URLs, autolinks, headings,
  hex colours, HTML entities, empty and `None`), 2 on the rendered rebase comment
- `pytest koan/tests/test_github.py koan/tests/test_rebase_pr.py
  koan/tests/test_review_runner.py koan/tests/test_recreate_pr.py
  koan/tests/test_squash_pr.py koan/tests/test_pr_review.py
  koan/tests/test_pr_quality.py koan/tests/test_github_reply.py` — all green
- Full suite green on the same change
- `scripts/spec_change_guard.py` — passed, additive spec change only
- `scripts/instance_guard.py` — passed
- `scripts/wiki_check.py --full --strict` — no OKF conformance gaps

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!-- Unchecked: the specs/skills/rebase.md change is purely additive (one new
     invariant bullet); the spec-change guard confirms "additive spec changes
     only, no declaration needed". -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)