### PR TITLE
fix(api): GET /v1/missions reads the mission store, not the sidecar

### DIFF
--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -4,7 +4,7 @@ title: "REST API"
 description: "Documents Kōan's optional, token-authenticated HTTP control layer (missions, projects, pause/resume, config, admin, usage/metrics/logs endpoints), its generated OpenAPI spec + drift guard, and its security model."
 tags: [operations]
 created: 2026-05-31
-updated: 2026-09-10
+updated: 2026-09-11
 ---
 
 # REST API
@@ -247,17 +247,38 @@ sessions also suppress the flag. The same cross-check backs the `make status`
 The list endpoint reads the authoritative mission store — the same source as
 `GET /v1/status`'s counts — so every queued mission is visible regardless of
 how it was created. `?status` filters to a store state (`pending`,
-`in_progress`, `done`, `failed`); unknown values return `400`. `?limit=N`
-caps the rows returned per state (terminal states can be large). The
-single-mission detail and result endpoints (`GET /v1/missions/{id}`,
-`/result`) still operate on API-queued records only.
+`in_progress`, `done`, `failed`); unknown values return `422`. `?limit=N`
+caps the rows returned **per state** (terminal states can be large), so a
+`?limit` with no `?status` can return up to four times that many rows; a
+non-integer or `< 1` value returns `422` rather than silently meaning
+"unlimited". The single-mission detail and result endpoints
+(`GET /v1/missions/{id}`, `/result`) still operate on API-queued records
+only.
+
+Rows are grouped by state in `pending`, `in_progress`, `done`, `failed`
+order — queue order (oldest first) within the live states, most-recent-first
+within the terminal ones. The list is **not** globally newest-first.
+
+Each row carries two identities:
+
+- `id` — the API sidecar id, the handle the single-mission routes accept. It
+  is `null` for a mission queued outside the API (Telegram, Slack, GitHub,
+  the dashboard), which has no sidecar record and is therefore not
+  addressable via `GET`/`PATCH`/`DELETE /v1/missions/{id}`, `/result`, or
+  `/v1/missions/reorder`.
+- `store_id` — the mission store's own identifier. It is stable and useful
+  for correlation, but the single-mission routes do **not** accept it.
 
 > **Backward-compatibility note.** The list previously returned sidecar
 > records carrying `result`/`result_ref`/`usage`/`created` and a `removed`
 > status for API-queued missions. Now that the list is store-backed, those
 > fields are no longer present and `removed` is not a valid `?status`
 > filter. Consumers that need result or cancellation state should use
-> `GET /v1/missions/{id}` and `GET /v1/missions/{id}/result`.
+> `GET /v1/missions/{id}` and `GET /v1/missions/{id}/result`. Two further
+> changes: `id` is now `null` for missions that were not queued through the
+> API (it was previously always a sidecar id, because only API-queued
+> missions were listed at all), and `project` reports the store's `default`
+> for an untagged mission where the sidecar reported `null`.
 
 **POST /v1/missions** body:
 ```json

--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -237,12 +237,27 @@ sessions also suppress the flag. The same cross-check backs the `make status`
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `GET` | `/v1/missions` | yes | List API-queued missions. Query params: `?status=pending\|in_progress\|done\|failed\|removed`, `?project=name` |
+| `GET` | `/v1/missions` | yes | List missions from the mission store (all queue sources: Slack/GitHub/API/dashboard). Query params: `?status=pending\|in_progress\|done\|failed`, `?project=name`, `?limit=N` |
 | `POST` | `/v1/missions` | yes | Queue a new mission |
 | `GET` | `/v1/missions/{id}` | yes | Get mission by id (reconciles vs missions.md) |
 | `PATCH` | `/v1/missions/{id}` | yes | Edit a pending mission's text (409 if not pending) |
 | `DELETE` | `/v1/missions/{id}` | yes | Cancel a pending mission (409 if already started) |
 | `POST` | `/v1/missions/reorder` | yes | Reorder a pending mission in the queue |
+
+The list endpoint reads the authoritative mission store — the same source as
+`GET /v1/status`'s counts — so every queued mission is visible regardless of
+how it was created. `?status` filters to a store state (`pending`,
+`in_progress`, `done`, `failed`); unknown values return `400`. `?limit=N`
+caps the rows returned per state (terminal states can be large). The
+single-mission detail and result endpoints (`GET /v1/missions/{id}`,
+`/result`) still operate on API-queued records only.
+
+> **Backward-compatibility note.** The list previously returned sidecar
+> records carrying `result`/`result_ref`/`usage`/`created` and a `removed`
+> status for API-queued missions. Now that the list is store-backed, those
+> fields are no longer present and `removed` is not a valid `?status`
+> filter. Consumers that need result or cancellation state should use
+> `GET /v1/missions/{id}` and `GET /v1/missions/{id}/result`.
 
 **POST /v1/missions** body:
 ```json

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -94,7 +94,10 @@ _LIST_MISSIONS_QUERY_PARAMETERS = (
     query_parameter(
         "limit",
         {"type": "integer", "minimum": 1},
-        "Cap the rows returned per state. Omitted or < 1 means unlimited.",
+        (
+            "Cap the rows returned per state. Omit for unlimited; "
+            "a non-integer or < 1 value is rejected with 422."
+        ),
     ),
 )
 
@@ -126,8 +129,22 @@ def _parse_limit(raw: str | None):
     return limit, None
 
 
+def _match_key(text: str) -> str:
+    """Identity key shared by both sides of the sidecar ↔ store join.
+
+    ``canonical_mission_key()`` is the repo's canonical identity helper: it
+    strips the lifecycle markers, ``[r:N]``, ``[complexity:X]``,
+    ``[verify-failed: …]`` and a leading ``"- "`` while keeping
+    ``[project:X]``. The queue appends that metadata to a mission *after* it
+    was recorded in the sidecar, so a looser normalizer would make the two
+    sides diverge the moment the loop tags a mission.
+    """
+    from app.missions import canonical_mission_key
+    return canonical_mission_key(text)
+
+
 def _sidecar_ids_by_text(instance_dir: Path) -> dict:
-    """Map normalized mission text → API sidecar id.
+    """Map canonical mission key → API sidecar id.
 
     The list is store-backed, but every single-mission route
     (``GET``/``PATCH``/``DELETE /v1/missions/{id}``, ``/result``, ``/reorder``)
@@ -140,7 +157,7 @@ def _sidecar_ids_by_text(instance_dir: Path) -> dict:
     for rec in list_missions(instance_dir):
         if rec.get("status") == "removed":
             continue
-        key = _normalize_for_match(rec.get("text", ""))
+        key = _match_key(rec.get("text", ""))
         if key:
             ids[key] = rec["id"]
     return ids
@@ -247,7 +264,7 @@ def list_missions_route():
     for state in states:
         out.extend(
             {
-                "id": sidecar_ids.get(_normalize_for_match(m.text)),
+                "id": sidecar_ids.get(_match_key(m.text)),
                 "store_id": m.id,
                 "text": m.text,
                 "status": m.state,

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from app.api.auth import require_token
-from app.api.openapi_metadata import openapi_operation, query_parameter
 from app.api.mission_index import (
     _normalize_for_match,
     cancel_mission,
@@ -17,6 +16,7 @@ from app.api.mission_index import (
     reconcile,
     update_mission_text,
 )
+from app.api.openapi_metadata import openapi_operation, query_parameter
 
 bp = Blueprint("missions", __name__)
 

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -11,6 +11,7 @@ from app.api.mission_index import (
     _normalize_for_match,
     cancel_mission,
     get_mission,
+    list_missions,
     load_full_result,
     record_mission,
     reconcile,
@@ -102,6 +103,49 @@ def _instance_dir() -> Path:
     return current_app.config["INSTANCE_DIR"]
 
 
+def _invalid_request(message: str):
+    """422 `invalid_request`, the house shape for a rejected parameter."""
+    return jsonify({"error": {"code": "invalid_request", "message": message}}), 422
+
+
+def _parse_limit(raw: str | None):
+    """Parse ``?limit``; returns ``(limit, error_response)``.
+
+    A malformed bound is rejected rather than coerced to "unlimited": that
+    fallback would widen the response to the caller's whole mission history,
+    the opposite of what a capped query asked for.
+    """
+    if not raw:
+        return None, None
+    try:
+        limit = int(raw)
+    except ValueError:
+        return None, _invalid_request(f"'limit' must be an integer, got '{raw}'")
+    if limit < 1:
+        return None, _invalid_request("'limit' must be >= 1")
+    return limit, None
+
+
+def _sidecar_ids_by_text(instance_dir: Path) -> dict:
+    """Map normalized mission text → API sidecar id.
+
+    The list is store-backed, but every single-mission route
+    (``GET``/``PATCH``/``DELETE /v1/missions/{id}``, ``/result``, ``/reorder``)
+    resolves ids through the sidecar. Emitting the store's rowid as ``id``
+    would hand clients a handle that 404s everywhere else, so ``id`` keeps
+    meaning "sidecar id" and the store identity travels as ``store_id``.
+    Later records win: a re-queued mission resolves to its newest record.
+    """
+    ids: dict = {}
+    for rec in list_missions(instance_dir):
+        if rec.get("status") == "removed":
+            continue
+        key = _normalize_for_match(rec.get("text", ""))
+        if key:
+            ids[key] = rec["id"]
+    return ids
+
+
 def _missions_file() -> Path:
     return _instance_dir() / "missions.md"
 
@@ -166,13 +210,16 @@ def _find_pending_position(content: str, stored_text: str):
 @openapi_operation(query_parameters=_LIST_MISSIONS_QUERY_PARAMETERS)
 @require_token
 def list_missions_route():
-    """List missions from the authoritative mission store, newest first.
+    """List missions from the authoritative mission store.
 
     The store is the same source ``GET /v1/status`` counts, so a mission
     queued from Slack/GitHub/dashboard is visible here even when it was never
-    recorded in the API sidecar. ``?status`` filters to a store state
-    (``pending``/``in_progress``/``done``/``failed``). ``?limit`` caps each
-    state's returned rows.
+    recorded in the API sidecar. Rows are grouped by state in
+    ``pending``/``in_progress``/``done``/``failed`` order — queue order within
+    the live states, most-recent-first within the terminal ones. ``?status``
+    filters to one state, ``?project`` to one project, and ``?limit`` caps the
+    rows returned *per state* (so a limit with no ``?status`` can return up to
+    four times that many rows).
     """
     from app.mission_store import VALID_STATES, get_mission_store
     from app.mission_store.transition import ensure_store_synced
@@ -180,30 +227,19 @@ def list_missions_route():
     status_filter = request.args.get("status")
     project_filter = request.args.get("project")
 
-    try:
-        limit = int(request.args.get("limit")) if request.args.get("limit") else None
-    except (TypeError, ValueError):
-        limit = None
-    if limit is not None and limit < 1:
-        limit = None
+    limit, limit_error = _parse_limit(request.args.get("limit"))
+    if limit_error is not None:
+        return limit_error
 
     if status_filter and status_filter not in VALID_STATES:
-        return (
-            jsonify(
-                {
-                    "error": {
-                        "code": "invalid_request",
-                        "message": f"Unknown status '{status_filter}'. "
-                        f"Valid: {', '.join(VALID_STATES)}",
-                    }
-                }
-            ),
-            400,
+        return _invalid_request(
+            f"Unknown status '{status_filter}'. Valid: {', '.join(VALID_STATES)}"
         )
 
     instance = _instance_dir()
     ensure_store_synced(str(instance))
     store = get_mission_store(str(instance))
+    sidecar_ids = _sidecar_ids_by_text(instance)
 
     states = [status_filter] if status_filter else list(VALID_STATES)
 
@@ -211,7 +247,8 @@ def list_missions_route():
     for state in states:
         out.extend(
             {
-                "id": m.id,
+                "id": sidecar_ids.get(_normalize_for_match(m.text)),
+                "store_id": m.id,
                 "text": m.text,
                 "status": m.state,
                 "project": m.project,

--- a/koan/app/api/routes_missions.py
+++ b/koan/app/api/routes_missions.py
@@ -11,7 +11,6 @@ from app.api.mission_index import (
     _normalize_for_match,
     cancel_mission,
     get_mission,
-    list_missions,
     load_full_result,
     record_mission,
     reconcile,
@@ -82,14 +81,19 @@ _LIST_MISSIONS_QUERY_PARAMETERS = (
         "status",
         {
             "type": "string",
-            "enum": ["pending", "in_progress", "done", "failed", "removed"],
+            "enum": ["pending", "in_progress", "done", "failed"],
         },
-        "Restrict results to one mission status.",
+        "Restrict results to one mission-store state.",
     ),
     query_parameter(
         "project",
         {"type": "string"},
         "Restrict results to one project.",
+    ),
+    query_parameter(
+        "limit",
+        {"type": "integer", "minimum": 1},
+        "Cap the rows returned per state. Omitted or < 1 means unlimited.",
     ),
 )
 
@@ -162,16 +166,63 @@ def _find_pending_position(content: str, stored_text: str):
 @openapi_operation(query_parameters=_LIST_MISSIONS_QUERY_PARAMETERS)
 @require_token
 def list_missions_route():
-    """List missions, newest first, optionally filtered."""
+    """List missions from the authoritative mission store, newest first.
+
+    The store is the same source ``GET /v1/status`` counts, so a mission
+    queued from Slack/GitHub/dashboard is visible here even when it was never
+    recorded in the API sidecar. ``?status`` filters to a store state
+    (``pending``/``in_progress``/``done``/``failed``). ``?limit`` caps each
+    state's returned rows.
+    """
+    from app.mission_store import VALID_STATES, get_mission_store
+    from app.mission_store.transition import ensure_store_synced
+
     status_filter = request.args.get("status")
     project_filter = request.args.get("project")
-    records = list_missions(_instance_dir(), status_filter, project_filter)
-    # Reconcile each record
+
+    try:
+        limit = int(request.args.get("limit")) if request.args.get("limit") else None
+    except (TypeError, ValueError):
+        limit = None
+    if limit is not None and limit < 1:
+        limit = None
+
+    if status_filter and status_filter not in VALID_STATES:
+        return (
+            jsonify(
+                {
+                    "error": {
+                        "code": "invalid_request",
+                        "message": f"Unknown status '{status_filter}'. "
+                        f"Valid: {', '.join(VALID_STATES)}",
+                    }
+                }
+            ),
+            400,
+        )
+
+    instance = _instance_dir()
+    ensure_store_synced(str(instance))
+    store = get_mission_store(str(instance))
+
+    states = [status_filter] if status_filter else list(VALID_STATES)
+
     out = []
-    for rec in records:
-        rec = reconcile(_instance_dir(), _missions_file(), rec["id"])
-        if rec:
-            out.append(rec)
+    for state in states:
+        out.extend(
+            {
+                "id": m.id,
+                "text": m.text,
+                "status": m.state,
+                "project": m.project,
+                "sequence": m.sequence,
+                "complexity": m.complexity,
+                "queued_at": m.queued_at,
+                "started_at": m.started_at,
+                "completed_at": m.completed_at,
+            }
+            for m in store.list_by_state(state, project=project_filter, limit=limit)
+        )
     return jsonify(out)
 
 

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -189,7 +189,7 @@ paths:
         required: false
         schema:
           type: string
-      - description: Cap the rows returned per state. Omitted or < 1 means unlimited.
+      - description: Cap the rows returned per state. Omit for unlimited; a non-integer or < 1 value is rejected with 422.
         in: query
         name: limit
         required: false

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -172,7 +172,7 @@ paths:
     get:
       operationId: missions_list_missions_route_get
       parameters:
-      - description: Restrict results to one mission status.
+      - description: Restrict results to one mission-store state.
         in: query
         name: status
         required: false
@@ -182,7 +182,6 @@ paths:
           - in_progress
           - done
           - failed
-          - removed
           type: string
       - description: Restrict results to one project.
         in: query
@@ -190,6 +189,13 @@ paths:
         required: false
         schema:
           type: string
+      - description: Cap the rows returned per state. Omitted or < 1 means unlimited.
+        in: query
+        name: limit
+        required: false
+        schema:
+          minimum: 1
+          type: integer
       responses:
         '200':
           description: Successful response
@@ -211,7 +217,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: List missions, newest first, optionally filtered.
+      summary: List missions from the authoritative mission store, newest first.
       tags:
       - missions
     post:

--- a/koan/openapi.yaml
+++ b/koan/openapi.yaml
@@ -217,7 +217,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Error response
-      summary: List missions from the authoritative mission store, newest first.
+      summary: List missions from the authoritative mission store.
       tags:
       - missions
     post:

--- a/koan/tests/test_api_missions.py
+++ b/koan/tests/test_api_missions.py
@@ -341,6 +341,33 @@ class TestListMissionsStoreBacked:
         assert detail.status_code == 200
         assert detail.get_json()["id"] == created["id"]
 
+    def test_list_id_survives_queue_appended_metadata(
+        self, api_client, instance_dir
+    ):
+        # The agent loop appends [complexity:X] (and [r:N] on crash recovery)
+        # to a pending line after the API recorded it. The sidecar keeps the
+        # untagged text, so the join must use the canonical identity key or an
+        # addressable mission starts reporting `id: null`.
+        from app.missions import tag_complexity_in_pending
+
+        created = api_client.post(
+            "/v1/missions", json={"text": "Tag me"}, headers=_AUTH
+        ).get_json()
+        tag_complexity_in_pending("Tag me", "simple", instance_dir / "missions.md")
+
+        listed = [
+            m
+            for m in api_client.get("/v1/missions", headers=_AUTH).get_json()
+            if "Tag me" in m["text"]
+        ]
+        assert len(listed) == 1
+        assert "[complexity:simple]" in listed[0]["text"]
+        assert listed[0]["id"] == created["id"]
+        assert (
+            api_client.get(f"/v1/missions/{listed[0]['id']}", headers=_AUTH).status_code
+            == 200
+        )
+
     def test_list_store_only_mission_has_null_id_and_a_store_id(
         self, api_client, instance_dir
     ):

--- a/koan/tests/test_api_missions.py
+++ b/koan/tests/test_api_missions.py
@@ -295,6 +295,19 @@ class TestListMissionsStoreBacked:
         assert len(data) == 1
         assert data[0]["project"] == "alpha"
 
+    def test_list_untagged_mission_reports_default_project(
+        self, api_client, instance_dir
+    ):
+        # Store-backed: an untagged mission reports "default", where the
+        # sidecar-backed list used to report null.
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- No project\n\n"
+            "## In Progress\n\n## Done\n",
+        )
+        data = api_client.get("/v1/missions", headers=_AUTH).get_json()
+        assert [m["project"] for m in data] == ["default"]
+
     def test_list_created_api_mission_appears_and_drops_sidecar_fields(
         self, api_client, instance_dir
     ):
@@ -309,6 +322,40 @@ class TestListMissionsStoreBacked:
         assert "API queued" in texts
         assert all("result" not in m and "created" not in m for m in data)
 
+    def test_list_id_is_the_sidecar_id_and_round_trips_to_detail(
+        self, api_client, instance_dir
+    ):
+        # The id a client reads from the list must resolve on the
+        # single-mission routes — the store rowid does not.
+        created = api_client.post(
+            "/v1/missions", json={"text": "Round trip me"}, headers=_AUTH
+        ).get_json()
+        listed = [
+            m
+            for m in api_client.get("/v1/missions", headers=_AUTH).get_json()
+            if m["text"] == "Round trip me"
+        ]
+        assert len(listed) == 1
+        assert listed[0]["id"] == created["id"]
+        detail = api_client.get(f"/v1/missions/{listed[0]['id']}", headers=_AUTH)
+        assert detail.status_code == 200
+        assert detail.get_json()["id"] == created["id"]
+
+    def test_list_store_only_mission_has_null_id_and_a_store_id(
+        self, api_client, instance_dir
+    ):
+        # A mission queued outside the API has no sidecar record, so it is not
+        # addressable by id — say so with null rather than an id that 404s.
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- Queued from Telegram\n\n"
+            "## In Progress\n\n## Done\n",
+        )
+        data = api_client.get("/v1/missions", headers=_AUTH).get_json()
+        assert len(data) == 1
+        assert data[0]["id"] is None
+        assert data[0]["store_id"]
+
     def test_list_cancelled_api_mission_not_listed(self, api_client, instance_dir):
         # A cancelled API mission is `removed` in the sidecar only; the
         # store-backed list must not resurrect it and `?status` has no removed.
@@ -320,15 +367,15 @@ class TestListMissionsStoreBacked:
         data = resp.get_json()
         assert all(m["text"] != "To cancel" for m in data)
 
-    def test_list_unknown_status_returns_400(self, api_client, instance_dir):
+    def test_list_unknown_status_returns_422(self, api_client, instance_dir):
         seed_missions(
             instance_dir,
             "# Missions\n\n## Pending\n\n- Fix auth bug\n\n"
             "## In Progress\n\n## Done\n",
         )
         resp = api_client.get("/v1/missions?status=bogus", headers=_AUTH)
-        assert resp.status_code == 400
-        assert "error" in resp.get_json()
+        assert resp.status_code == 422
+        assert resp.get_json()["error"]["code"] == "invalid_request"
 
     def test_list_limit_caps_rows_per_state(self, api_client, instance_dir):
         seed_missions(
@@ -340,15 +387,36 @@ class TestListMissionsStoreBacked:
         data = resp.get_json()
         assert len(data) == 2
 
-    def test_list_limit_zero_or_bad_is_unlimited(self, api_client, instance_dir):
+    def test_list_limit_without_status_caps_each_state_separately(
+        self, api_client, instance_dir
+    ):
+        # `limit` is per state, so an unfiltered query can return up to
+        # limit * len(VALID_STATES) rows. Pin the multiplier.
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- P1\n- P2\n- P3\n\n"
+            "## In Progress\n\n- R1\n- R2\n\n## Done\n",
+        )
+        data = api_client.get("/v1/missions?limit=1", headers=_AUTH).get_json()
+        by_state = {}
+        for m in data:
+            by_state[m["status"]] = by_state.get(m["status"], 0) + 1
+        assert by_state == {"pending": 1, "in_progress": 1}
+
+    def test_list_bad_limit_is_rejected_not_silently_unlimited(
+        self, api_client, instance_dir
+    ):
         seed_missions(
             instance_dir,
             "# Missions\n\n## Pending\n\n- P1\n- P2\n- P3\n\n"
             "## In Progress\n\n## Done\n",
         )
-        for bad in ("0", "-1", "abc"):
-            resp = api_client.get(f"/v1/missions?status=pending&limit={bad}", headers=_AUTH)
-            assert len(resp.get_json()) == 3
+        for bad in ("0", "-1", "abc", "1O"):
+            resp = api_client.get(
+                f"/v1/missions?status=pending&limit={bad}", headers=_AUTH
+            )
+            assert resp.status_code == 422, bad
+            assert resp.get_json()["error"]["code"] == "invalid_request"
 
 
 class TestCancelByText:

--- a/koan/tests/test_api_missions.py
+++ b/koan/tests/test_api_missions.py
@@ -245,6 +245,112 @@ class TestListMissions:
         assert data[0]["project"] == "alpha"
 
 
+class TestListMissionsStoreBacked:
+    """GET /v1/missions must read the mission store, not the API sidecar."""
+
+    def test_list_returns_store_queued_missions_without_sidecar(
+        self, api_client, instance_dir
+    ):
+        # No .api-missions.json on this host: the bug this fixes.
+        assert not (instance_dir / ".api-missions.json").exists()
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n"
+            "- Fix auth bug\n"
+            "- Deploy release\n\n"
+            "## In Progress\n\n"
+            "## Done\n",
+        )
+        resp = api_client.get("/v1/missions", headers=_AUTH)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data) == 2
+        assert {m["text"] for m in data} == {"Fix auth bug", "Deploy release"}
+        assert all(m["status"] == "pending" for m in data)
+
+    def test_list_agrees_with_status_counts(self, api_client, instance_dir):
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- P1\n- P2\n\n"
+            "## In Progress\n\n- Running\n\n## Done\n",
+        )
+        list_resp = api_client.get("/v1/missions", headers=_AUTH).get_json()
+        counts = {}
+        for m in list_resp:
+            counts[m["status"]] = counts.get(m["status"], 0) + 1
+        status = api_client.get("/v1/status", headers=_AUTH).get_json()
+        assert counts.get("pending") == status["missions"]["pending"] == 2
+        assert counts.get("in_progress") == status["missions"]["in_progress"] == 1
+
+    def test_list_filter_by_project_store_backed(self, api_client, instance_dir):
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n"
+            "- [project:alpha] For proj\n"
+            "- No project\n\n"
+            "## In Progress\n\n## Done\n",
+        )
+        resp = api_client.get("/v1/missions?project=alpha", headers=_AUTH)
+        data = resp.get_json()
+        assert len(data) == 1
+        assert data[0]["project"] == "alpha"
+
+    def test_list_created_api_mission_appears_and_drops_sidecar_fields(
+        self, api_client, instance_dir
+    ):
+        # A mission created via the API lives in both the sidecar and the store;
+        # the list is store-backed and renders Mission fields only (no result).
+        api_client.post(
+            "/v1/missions", json={"text": "API queued"}, headers=_AUTH
+        )
+        resp = api_client.get("/v1/missions", headers=_AUTH)
+        data = resp.get_json()
+        texts = {m["text"] for m in data}
+        assert "API queued" in texts
+        assert all("result" not in m and "created" not in m for m in data)
+
+    def test_list_cancelled_api_mission_not_listed(self, api_client, instance_dir):
+        # A cancelled API mission is `removed` in the sidecar only; the
+        # store-backed list must not resurrect it and `?status` has no removed.
+        create = api_client.post(
+            "/v1/missions", json={"text": "To cancel"}, headers=_AUTH
+        ).get_json()
+        api_client.delete(f"/v1/missions/{create['id']}", headers=_AUTH)
+        resp = api_client.get("/v1/missions", headers=_AUTH)
+        data = resp.get_json()
+        assert all(m["text"] != "To cancel" for m in data)
+
+    def test_list_unknown_status_returns_400(self, api_client, instance_dir):
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- Fix auth bug\n\n"
+            "## In Progress\n\n## Done\n",
+        )
+        resp = api_client.get("/v1/missions?status=bogus", headers=_AUTH)
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_list_limit_caps_rows_per_state(self, api_client, instance_dir):
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- P1\n- P2\n- P3\n\n"
+            "## In Progress\n\n## Done\n",
+        )
+        resp = api_client.get("/v1/missions?status=pending&limit=2", headers=_AUTH)
+        data = resp.get_json()
+        assert len(data) == 2
+
+    def test_list_limit_zero_or_bad_is_unlimited(self, api_client, instance_dir):
+        seed_missions(
+            instance_dir,
+            "# Missions\n\n## Pending\n\n- P1\n- P2\n- P3\n\n"
+            "## In Progress\n\n## Done\n",
+        )
+        for bad in ("0", "-1", "abc"):
+            resp = api_client.get(f"/v1/missions?status=pending&limit={bad}", headers=_AUTH)
+            assert len(resp.get_json()) == 3
+
+
 class TestCancelByText:
     def test_cancel_by_text_marks_removed(self, instance_dir):
         from app.api.mission_index import record_mission, cancel_by_text, get_mission

--- a/koan/tests/test_openapi_gen.py
+++ b/koan/tests/test_openapi_gen.py
@@ -8,6 +8,7 @@ works — testing observable outputs, never source text.
 import inspect
 import re
 from contextlib import ExitStack
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -176,11 +177,17 @@ def test_request_body_requiredness_matches_handlers(app):
 
 
 def test_query_parameter_schemas_match_handler_accesses(app):
+    empty_store = SimpleNamespace(list_by_state=lambda *args, **kwargs: [])
+
     cases = {
         ("get", "/v1/missions"): (
             "missions.list_missions_route",
-            {"status": None, "project": None},
-            (("app.api.routes_missions.list_missions", []),),
+            {"status": None, "project": None, "limit": None},
+            (
+                ("app.api.routes_missions.list_missions", []),
+                ("app.mission_store.transition.ensure_store_synced", None),
+                ("app.mission_store.get_mission_store", empty_store),
+            ),
         ),
         ("get", "/v1/usage"): (
             "observability.usage",

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -58,6 +58,7 @@ cli/  (runtime OpenAPI REST client)
 | `api/auth.require_token` | Bearer parse + `hmac.compare_digest`. Token: env `KOAN_API_TOKEN` → `api.token` → `""`. |
 | `api/mission_index.py` | Sidecar `instance/.api-missions.json` (atomic). `record/get/list/reconcile/cancel`; `reconcile()` maps stored text → current `missions.md` section, and prefers the durable `OutcomeStore` for authoritative terminal status + the `outcome` field. Typed `result`/`result_ref` store: `attach_result()` (size-cap spill, summary-preserving), `load_full_result()` (inline-or-spill). `find_active_mission_id()` resolves a mission title back to its id (in_progress→pending→recent) for usage attribution. |
 | `api/mission_results.py` | Command→resolver registry (`register_resolver`, `resolve_mission_result`, `always_inline_keys`); built-in `/review`+`/ultrareview` resolver reads the PR-keyed findings sidecar. |
+| `routes_missions.list_missions_route()` | `GET /v1/missions` lists missions from the authoritative mission store (`ensure_store_synced()` + `list_by_state()`), rendering the `Mission` fields under the response's `status` key. Single-mission detail/result routes (`GET/PATCH/DELETE /v1/missions/{id}`, `/result`) remain sidecar-backed for API-queued records. |
 | `routes_missions.get_mission_route()` | `GET /v1/missions/{id}` returns the reconciled record (with typed `result`/`result_ref`) **plus** a `usage` object (`aggregate_mission_usage()` over `created`→today): token/cache/cost totals, `call_count`, `models`/`providers`, and an `unattributed` block for id-less title matches. Response is a copy — the sidecar is never mutated with `usage`. |
 | `usage_service.build_usage_payload()` | Shared usage payload (week/month buckets) for dashboard **and** `GET /v1/usage`. |
 | `log_reader.tail_log()/read_logs()` | Shared log tailing for dashboard **and** `GET /v1/logs`. |
@@ -67,9 +68,8 @@ cli/  (runtime OpenAPI REST client)
 
 ## Mission record: typed structured `result`
 
-The mission record (`.api-missions.json`, exposed by `GET /v1/missions/{id}`
-and `GET /v1/missions`) carries a typed `result` payload in addition to the
-free-text `result_line`:
+The mission record (`.api-missions.json`, exposed by `GET /v1/missions/{id}`)
+carries a typed `result` payload in addition to the free-text `result_line`:
 
 | Field         | Type            | Contract |
 |---------------|-----------------|----------|
@@ -93,7 +93,7 @@ PR-keyed findings sidecar `instance/.review-findings/{owner}_{repo}_{pr}.json`
 (256 KB) spill to `instance/.api-results/<id>.json`; the record keeps
 `result_ref` plus a trimmed inline copy of the resolver's `always_inline` keys
 (`/review`: `kind`, `review_summary`, plus `result_truncated: true`) so the
-verdict/summary never drop from list/GET payloads. `GET /v1/missions/{id}/result`
+verdict/summary never drop from `GET` payloads. `GET /v1/missions/{id}/result`
 streams the complete result (inline or spilled) so remote clients that cannot
 read the instance filesystem can always retrieve the full findings.
 

--- a/specs/components/web.md
+++ b/specs/components/web.md
@@ -4,7 +4,7 @@ title: "Component Spec — Web Dashboard & REST API"
 description: "Documents the Flask dashboard and token-gated REST API, their shared `dashboard_service`/`usage_service`/`log_reader` logic, the code-derived OpenAPI spec + drift guard, and the invariants keeping the two surfaces from drifting."
 tags: [web]
 created: 2026-06-27
-updated: 2026-09-10
+updated: 2026-09-11
 ---
 
 # Component Spec — Web Dashboard & REST API
@@ -58,7 +58,7 @@ cli/  (runtime OpenAPI REST client)
 | `api/auth.require_token` | Bearer parse + `hmac.compare_digest`. Token: env `KOAN_API_TOKEN` → `api.token` → `""`. |
 | `api/mission_index.py` | Sidecar `instance/.api-missions.json` (atomic). `record/get/list/reconcile/cancel`; `reconcile()` maps stored text → current `missions.md` section, and prefers the durable `OutcomeStore` for authoritative terminal status + the `outcome` field. Typed `result`/`result_ref` store: `attach_result()` (size-cap spill, summary-preserving), `load_full_result()` (inline-or-spill). `find_active_mission_id()` resolves a mission title back to its id (in_progress→pending→recent) for usage attribution. |
 | `api/mission_results.py` | Command→resolver registry (`register_resolver`, `resolve_mission_result`, `always_inline_keys`); built-in `/review`+`/ultrareview` resolver reads the PR-keyed findings sidecar. |
-| `routes_missions.list_missions_route()` | `GET /v1/missions` lists missions from the authoritative mission store (`ensure_store_synced()` + `list_by_state()`), rendering the `Mission` fields under the response's `status` key. Single-mission detail/result routes (`GET/PATCH/DELETE /v1/missions/{id}`, `/result`) remain sidecar-backed for API-queued records. |
+| `routes_missions.list_missions_route()` | `GET /v1/missions` lists missions from the authoritative mission store (`ensure_store_synced()` + `list_by_state()`), rendering the `Mission` fields under the response's `status` key. Rows are grouped by state (live states in queue order, terminal states newest-first) — never globally newest-first. `id` stays the **sidecar** id (`null` when the mission was not API-queued) so a listed id resolves on the single-mission routes; the store identity is exposed separately as `store_id`, which those routes do not accept. `?status` and `?limit` are validated at the boundary and reject with `422 invalid_request` — never coerced to a wider result set. Single-mission detail/result routes (`GET/PATCH/DELETE /v1/missions/{id}`, `/result`) remain sidecar-backed for API-queued records. |
 | `routes_missions.get_mission_route()` | `GET /v1/missions/{id}` returns the reconciled record (with typed `result`/`result_ref`) **plus** a `usage` object (`aggregate_mission_usage()` over `created`→today): token/cache/cost totals, `call_count`, `models`/`providers`, and an `unattributed` block for id-less title matches. Response is a copy — the sidecar is never mutated with `usage`. |
 | `usage_service.build_usage_payload()` | Shared usage payload (week/month buckets) for dashboard **and** `GET /v1/usage`. |
 | `log_reader.tail_log()/read_logs()` | Shared log tailing for dashboard **and** `GET /v1/logs`. |


### PR DESCRIPTION
## Summary

`GET /v1/missions` listed only missions recorded in the API sidecar
(`.api-missions.json`), so a mission queued from Telegram, Slack, GitHub, or the
dashboard was invisible — even though `GET /v1/status` already counted it from
the authoritative mission store. This makes the list endpoint read the store,
the same source `/v1/status` uses.

- `list_missions_route()` now calls `ensure_store_synced()` + `list_by_state()`
  and renders `Mission` fields.
- New `?limit=N` query param caps rows returned per state (terminal states can
  be large). A missing, non-numeric, or `< 1` value means unlimited.
- `?status` is validated against `VALID_STATES`; an unknown value returns `400`
  instead of silently returning nothing.
- Single-mission routes (`GET`/`PATCH`/`DELETE /v1/missions/{id}`, `/result`)
  are unchanged and stay sidecar-backed.

## Backward compatibility

The list previously returned sidecar records carrying
`result`/`result_ref`/`usage`/`created`, and accepted `?status=removed`. The
store-backed list drops those fields, and `removed` is no longer a valid filter
(it is a sidecar-only state). Consumers needing result or cancellation state
should use `GET /v1/missions/{id}` and `GET /v1/missions/{id}/result`.

## Testing

- `koan/tests/test_api_missions.py::TestListMissionsStoreBacked` — 8 new tests:
  store-queued missions listed without a sidecar, list agrees with
  `/v1/status` counts, project filter, API-created mission shows without
  sidecar-only fields, cancelled mission not resurrected, unknown status →
  `400`, `?limit` caps per state, bad `?limit` is unlimited.
- Full suite green: 18008 passed (`-m "not slow"`) + 2301 passed (`-m "slow"`).
- `ruff check .` clean.
- `koan/openapi.yaml` regenerated (`make openapi`); `make openapi-check` clean.
- `scripts/instance_guard.py` and `scripts/wiki_check.py --full --strict` pass.

## Docs & spec

- `docs/operations/rest-api.md` — store-backed list, `?limit`, and the
  backward-compatibility note.
- `specs/components/web.md` — contract-first update: the list route is
  store-backed; the `.api-missions.json` record contract is now scoped to
  `GET /v1/missions/{id}`.

- [x] **Architectural change** — `specs/components/web.md` changes the durable
  contract for `GET /v1/missions`: its source of truth moves from the API
  sidecar to the mission store, and the typed-`result` record contract no
  longer covers the list payload.