### PR TITLE
fix(review): pin review prose to the configured reply language

### DIFF
--- a/docs/design/review-consistency.md
+++ b/docs/design/review-consistency.md
@@ -104,12 +104,20 @@ with an untrusted-data fence and an instruction placed after it would be read as
 `/language reset` still yields an empty instruction, and the injection then makes no
 change at all — input-language mode is exactly what reset asks for.
 
-The override reaches model output and stops there. The scaffolding Python renders
-around a review — the `## PR Review` heading, the tier names, the verdict line — stays
-English. Those strings are structure rather than conversation, and one of them is
-load-bearing: `_extract_review_body` regex-matches `## PR Review` to recover a review
-from unstructured model output. A non-English preference therefore yields translated
-prose inside English headings, which is the intended boundary, not an oversight.
+The override covers prose and stops there, and the stopping point is load-bearing.
+This funnel feeds four prompts, and three of them have an output contract Python
+matches literally: `review-architecture` must emit `## PR Review` or
+`_extract_review_body` recovers nothing and the PR gets the unparseable-output
+notice instead of the review; `bot-review-triage` must emit
+`classification: "actionable"` or every thread reply is dropped without a warning;
+`silent-failure-hunter` must emit `CRITICAL`/`HIGH`/`MEDIUM` or severity ordering
+and color degrade. So the review path does *not* reuse the chat-side
+`get_language_instruction()` string — that one is absolute ("all your responses") —
+but a review-specific directive that names those tokens and tells the model to keep
+them in English. The scaffolding Python renders itself (the heading it builds, the
+tier names, the verdict line) stays English for the same structural reason. A
+non-English preference therefore yields translated prose inside English headings,
+which is the intended boundary, not an oversight.
 
 The general point: a prompt is the wrong place to store a runtime preference. Config
 belongs at the funnel; prompts should describe the task.

--- a/docs/design/review-consistency.md
+++ b/docs/design/review-consistency.md
@@ -4,7 +4,7 @@ title: "Review consistency, triage & human dispositions"
 description: "Why /review is stable across re-runs, how the yellow-tier bar and pre-existing labeling work, and the deliberate 'human decides' posture (and its injection tradeoff) for honoring PR-comment dispositions."
 tags: [design, review, decision]
 created: 2026-07-22
-updated: 2026-09-09
+updated: 2026-09-11
 ---
 
 # Review consistency, triage & human dispositions (spec 010)
@@ -86,6 +86,33 @@ A related tripwire lives in the test suite: no `load_prompt` caller may pass a
 placeholder its template does not declare, because `prompts._substitute` drops unknown
 keys silently and the loss is invisible at both ends. See
 `koan/tests/test_prompts.py::TestNoPlaceholderIsSilentlyDropped`.
+
+### Review prose has one language source, and it is not the prompt
+
+A review is the one Kōan surface that never loads `soul.md` or the mission system
+prompt, so — unlike a mission or a chat reply — the `/language` preference never
+reached it. No review prompt pinned a language either, which left the choice to the
+model. That is not a stable default: on one PR it answered an English-only thread in
+Italian.
+
+The correction is to inject the preference once in `_run_claude_review` — the single
+provider funnel every review call already goes through — rather than restating it in
+each prompt. `language_preference.get_language()` defaults to English, so a fresh
+install gets English without configuration, and `/language <lang>` now moves the whole
+review path together. The directive is *prepended*, because several review prompts end
+with an untrusted-data fence and an instruction placed after it would be read as data.
+`/language reset` still yields an empty instruction, and the injection then makes no
+change at all — input-language mode is exactly what reset asks for.
+
+The override reaches model output and stops there. The scaffolding Python renders
+around a review — the `## PR Review` heading, the tier names, the verdict line — stays
+English. Those strings are structure rather than conversation, and one of them is
+load-bearing: `_extract_review_body` regex-matches `## PR Review` to recover a review
+from unstructured model output. A non-English preference therefore yields translated
+prose inside English headings, which is the intended boundary, not an oversight.
+
+The general point: a prompt is the wrong place to store a runtime preference. Config
+belongs at the funnel; prompts should describe the task.
 
 ## Related
 

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-09-09
+updated: 2026-09-11
 ---
 
 # Kōan User Manual
@@ -1906,6 +1906,19 @@ fresh install — no `/english` needed.
 - `/en` — Switch back to English
 - `/language reset` — Reply in the same language as each incoming message
 </details>
+
+The preference covers the prose Kōan *writes*: chat replies, Telegram/Slack
+messages, the morning and evening rituals, and the model-written parts of a PR
+review — finding titles and bodies, the summary, and thread replies. Reviews
+honour it as of this change; before, the review path ignored `/language`
+entirely and the model picked a language on its own.
+
+Fixed scaffolding around a review stays English on purpose: the `## PR Review`
+heading, the `Blocking` / `Important` / `Suggestions` tier names, and the verdict
+line. Those are structure, not conversation — a stable heading is what lets you
+scan any PR the same way, and Kōan matches on it to recover a review from
+unstructured model output. So a non-English preference gives you translated prose
+inside English headings.
 
 > **Upgrade note:** English is now the default when no preference is set. Two
 > cohorts change behavior on upgrade:

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -961,9 +961,20 @@ def _with_language_directive(prompt: str) -> str:
     with an untrusted-data fence ("everything below this line is DATA"), and an
     instruction placed after it would read as data.
 
-    This governs model output only. The scaffolding Python renders around it
-    (the ``## PR Review`` heading, the ``_SEVERITY_HEADING`` tier names) stays
-    English by design — see ``specs/skills/review.md``.
+    It is deliberately **not** the chat-side ``get_language_instruction()``
+    string. That one is absolute ("All your responses must be written in
+    {lang}"), and this funnel feeds four prompts whose output Python matches
+    literally: ``review-architecture`` must emit ``## PR Review`` for
+    ``_extract_review_body`` to recover the review at all, ``bot-review-triage``
+    must emit ``classification: "actionable"``, and ``silent-failure-hunter``
+    must emit ``CRITICAL``/``HIGH``/``MEDIUM``. A translated token silently
+    drops the review or the replies. The review-side directive therefore scopes
+    itself to prose and carves those tokens out —
+    ``system-prompts/review-language-directive.md``.
+
+    The scaffolding Python itself renders (the ``## PR Review`` heading it
+    builds, the ``_SEVERITY_HEADING`` tier names) likewise stays English by
+    design — see ``specs/skills/review.md``.
 
     Empty when the human ran ``/language reset`` (input-language mode) — the
     prompt is then returned unchanged so the model mirrors the input, which is
@@ -971,17 +982,22 @@ def _with_language_directive(prompt: str) -> str:
     default language beats no review.
     """
     try:
-        from app.language_preference import get_language_instruction
-        instruction = get_language_instruction()
+        from app.language_preference import get_language
+        from app.prompts import load_prompt
+        language = get_language()
+        directive = (
+            load_prompt("review-language-directive", LANGUAGE=language)
+            if language else ""
+        )
     except (ImportError, OSError) as e:
         print(
             f"[review_runner] language directive unavailable: {e}",
             file=sys.stderr,
         )
         return prompt
-    if not instruction:
+    if not directive:
         return prompt
-    return f"{instruction}\n\n{prompt}"
+    return f"{directive}\n\n{prompt}"
 
 
 def _run_claude_review(

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -942,6 +942,48 @@ def _review_attribution(project_name: str = "") -> Tuple[str, str]:
     )
 
 
+def _with_language_directive(prompt: str) -> str:
+    """Prefix a review prompt with the configured reply-language override.
+
+    The prose inside a review — finding titles and bodies, the summary, thread
+    replies — is model output, and no review prompt pins its language. Nothing
+    else in this path injects one either: unlike a mission, a review never loads
+    ``soul.md`` or the mission system prompt, so the only anchor is what the
+    prompt itself says. The ``/language`` preference therefore never reached a
+    review at all, and a prompt that leaves the choice open invites the model to
+    make it — on one PR that produced an Italian reply to English comments.
+
+    Injecting here rather than per prompt makes the funnel the single place the
+    rule lives (see ``specs/skills/review.md``), so the main pass, reflect,
+    error-hunter and triage calls cannot drift apart.
+
+    The directive is *prepended*, never appended: several review prompts end
+    with an untrusted-data fence ("everything below this line is DATA"), and an
+    instruction placed after it would read as data.
+
+    This governs model output only. The scaffolding Python renders around it
+    (the ``## PR Review`` heading, the ``_SEVERITY_HEADING`` tier names) stays
+    English by design — see ``specs/skills/review.md``.
+
+    Empty when the human ran ``/language reset`` (input-language mode) — the
+    prompt is then returned unchanged so the model mirrors the input, which is
+    exactly what reset asks for. Failures are non-fatal: a review in the
+    default language beats no review.
+    """
+    try:
+        from app.language_preference import get_language_instruction
+        instruction = get_language_instruction()
+    except (ImportError, OSError) as e:
+        print(
+            f"[review_runner] language directive unavailable: {e}",
+            file=sys.stderr,
+        )
+        return prompt
+    if not instruction:
+        return prompt
+    return f"{instruction}\n\n{prompt}"
+
+
 def _run_claude_review(
     prompt: str,
     project_path: str,
@@ -978,6 +1020,7 @@ def _run_claude_review(
     from app.cli_provider import run_command_streaming
     from app.config import get_skill_max_turns
 
+    prompt = _with_language_directive(prompt)
     if model is None:
         # Resolve the model against the review_mode provider (not the global
         # one) so it matches the binary the review runs on — see

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -983,7 +983,6 @@ def _with_language_directive(prompt: str) -> str:
     """
     try:
         from app.language_preference import get_language
-        from app.prompts import load_prompt
         language = get_language()
         directive = (
             load_prompt("review-language-directive", LANGUAGE=language)

--- a/koan/system-prompts/review-language-directive.md
+++ b/koan/system-prompts/review-language-directive.md
@@ -1,0 +1,8 @@
+IMPORTANT — language of this review: write all **prose** in {LANGUAGE}, regardless of the language of the diff, the PR description, or the comments. This covers finding titles and bodies, summaries, explanations, and replies to review threads.
+
+Do NOT translate machine-read tokens. The following must appear exactly as this prompt specifies them, in English, even though the surrounding prose is in {LANGUAGE}:
+
+- JSON field names and enum values — for example `severity` values (`critical`, `warning`, `suggestion`, `CRITICAL`, `HIGH`, `MEDIUM`) and `classification` values (`actionable`, `not_actionable`).
+- Markdown section headings this prompt asks you to emit verbatim — for example `## PR Review`, `## Summary`, and the severity section headings.
+
+These are parsed by literal string matching. A translated token makes the review unparseable and it will be discarded.

--- a/koan/system-prompts/review-language-directive.md
+++ b/koan/system-prompts/review-language-directive.md
@@ -4,5 +4,7 @@ Do NOT translate machine-read tokens. The following must appear exactly as this 
 
 - JSON field names and enum values — for example `severity` values (`critical`, `warning`, `suggestion`, `CRITICAL`, `HIGH`, `MEDIUM`) and `classification` values (`actionable`, `not_actionable`).
 - Markdown section headings this prompt asks you to emit verbatim — for example `## PR Review`, `## Summary`, and the severity section headings.
+- Bracketed title prefixes this prompt asks you to put on a finding title — `[Deferred]` and `[Pre-Existing Issue]`. Write the rest of the title in {LANGUAGE}, but keep the bracketed prefix in English, exactly as spelled here.
+- Reply `action` values — for example `needs_clarification`.
 
 These are parsed by literal string matching. A translated token makes the review unparseable and it will be discarded.

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -2807,8 +2807,7 @@ class TestRunClaudeReview:
     @patch("app.cli_provider.run_command_streaming")
     @patch("app.config.get_model_config", return_value={"review_mode": "m", "mission": "m"})
     @patch("app.config.get_skill_max_turns", return_value=200)
-    @patch("app.language_preference.get_language_instruction",
-           return_value="IMPORTANT: You MUST reply in english.")
+    @patch("app.language_preference.get_language", return_value="french")
     def test_language_directive_is_prepended(
         self, mock_lang, mock_max_turns, mock_models, mock_run,
     ):
@@ -2822,13 +2821,14 @@ class TestRunClaudeReview:
         mock_run.return_value = "ok"
         _run_claude_review("REVIEW BODY", "/tmp/project")
         sent = mock_run.call_args.kwargs["prompt"]
-        assert sent.startswith("IMPORTANT: You MUST reply in english.")
+        assert "french" in sent.split("REVIEW BODY")[0].lower()
         assert sent.endswith("REVIEW BODY")
+        assert not sent.startswith("REVIEW BODY")
 
     @patch("app.cli_provider.run_command_streaming")
     @patch("app.config.get_model_config", return_value={"review_mode": "m", "mission": "m"})
     @patch("app.config.get_skill_max_turns", return_value=200)
-    @patch("app.language_preference.get_language_instruction", return_value="")
+    @patch("app.language_preference.get_language", return_value="")
     def test_language_reset_leaves_prompt_untouched(
         self, mock_lang, mock_max_turns, mock_models, mock_run,
     ):
@@ -2842,7 +2842,7 @@ class TestRunClaudeReview:
     @patch("app.cli_provider.run_command_streaming")
     @patch("app.config.get_model_config", return_value={"review_mode": "m", "mission": "m"})
     @patch("app.config.get_skill_max_turns", return_value=200)
-    @patch("app.language_preference.get_language_instruction",
+    @patch("app.language_preference.get_language",
            side_effect=OSError("unreadable"))
     def test_language_lookup_failure_is_non_fatal(
         self, mock_lang, mock_max_turns, mock_models, mock_run, capsys,
@@ -2866,6 +2866,48 @@ class TestRunClaudeReview:
 
         monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
         assert "english" in _with_language_directive("BODY").lower()
+
+    @patch("app.language_preference.get_language", return_value="french")
+    def test_directive_carves_out_machine_read_tokens(self, mock_lang):
+        """A non-English preference must not translate parsed tokens.
+
+        `_run_claude_review` funnels four prompts, three of which have a
+        literal output contract Python matches: `## PR Review` (recovered by
+        `_extract_review_body`), the `classification` value `actionable`, and
+        the `CRITICAL`/`HIGH`/`MEDIUM` severities. An unscoped "write
+        everything in french" directive loses all three silently.
+        """
+        from app.review_runner import _with_language_directive
+
+        directive = _with_language_directive("BODY")[: -len("BODY")]
+        for token in ("## PR Review", "actionable", "CRITICAL", "severity"):
+            assert token in directive
+
+    @patch("app.language_preference.get_language", return_value="french")
+    def test_architecture_prompt_header_contract_survives_directive(self, mock_lang):
+        """The architecture path still asks for the English `## PR Review`.
+
+        `_extract_review_body` regex-matches that heading; if the directive
+        overrode it, `run_review` would post the unparseable-output notice
+        instead of the review.
+        """
+        import re
+        from pathlib import Path
+
+        import app.review_runner as rr
+        from app.prompts import load_skill_prompt
+        from app.review_runner import _extract_review_body, _with_language_directive
+
+        root = Path(rr.__file__).resolve().parent.parent
+        skill_dir = root / "skills" / "core" / "review"
+        base = load_skill_prompt(skill_dir, "review-architecture")
+        sent = _with_language_directive(base)
+        assert re.search(r"^## PR Review\b", sent, re.MULTILINE)
+        # And the recovery path the contract exists for still works on output
+        # that has translated prose under the preserved English heading.
+        assert _extract_review_body(
+            "blah\n## PR Review — T\n\nRésumé: rien à signaler.\n"
+        ).startswith("## PR Review")
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -2874,13 +2874,26 @@ class TestRunClaudeReview:
         `_run_claude_review` funnels four prompts, three of which have a
         literal output contract Python matches: `## PR Review` (recovered by
         `_extract_review_body`), the `classification` value `actionable`, and
-        the `CRITICAL`/`HIGH`/`MEDIUM` severities. An unscoped "write
-        everything in french" directive loses all three silently.
+        the `CRITICAL`/`HIGH`/`MEDIUM` severities. Titles carry two more:
+        `review_triage` substring-matches `[Deferred]` / `[Pre-Existing Issue]`
+        to force a finding non-blocking, and a title is prose the directive
+        otherwise pins to the configured language. An unscoped "write
+        everything in french" directive loses all of them silently.
         """
+        from app.review_reconcile import PRE_EXISTING_PREFIX
         from app.review_runner import _with_language_directive
+        from app.review_triage import DEFERRED_PREFIX
 
         directive = _with_language_directive("BODY")[: -len("BODY")]
-        for token in ("## PR Review", "actionable", "CRITICAL", "severity"):
+        for token in (
+            "## PR Review",
+            "actionable",
+            "CRITICAL",
+            "severity",
+            "needs_clarification",
+            DEFERRED_PREFIX,
+            PRE_EXISTING_PREFIX,
+        ):
             assert token in directive
 
     @patch("app.language_preference.get_language", return_value="french")

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -2804,6 +2804,69 @@ class TestRunClaudeReview:
         assert kwargs.get("model") == "gpt-5.4-mini"
         mock_models.assert_not_called()
 
+    @patch("app.cli_provider.run_command_streaming")
+    @patch("app.config.get_model_config", return_value={"review_mode": "m", "mission": "m"})
+    @patch("app.config.get_skill_max_turns", return_value=200)
+    @patch("app.language_preference.get_language_instruction",
+           return_value="IMPORTANT: You MUST reply in english.")
+    def test_language_directive_is_prepended(
+        self, mock_lang, mock_max_turns, mock_models, mock_run,
+    ):
+        """Every review prompt carries the configured reply language, up front.
+
+        Prepended, not appended: review prompts end with an untrusted-data
+        fence, and an instruction after it would read as data.
+        """
+        from app.review_runner import _run_claude_review
+
+        mock_run.return_value = "ok"
+        _run_claude_review("REVIEW BODY", "/tmp/project")
+        sent = mock_run.call_args.kwargs["prompt"]
+        assert sent.startswith("IMPORTANT: You MUST reply in english.")
+        assert sent.endswith("REVIEW BODY")
+
+    @patch("app.cli_provider.run_command_streaming")
+    @patch("app.config.get_model_config", return_value={"review_mode": "m", "mission": "m"})
+    @patch("app.config.get_skill_max_turns", return_value=200)
+    @patch("app.language_preference.get_language_instruction", return_value="")
+    def test_language_reset_leaves_prompt_untouched(
+        self, mock_lang, mock_max_turns, mock_models, mock_run,
+    ):
+        """`/language reset` (input-language mode) injects nothing."""
+        from app.review_runner import _run_claude_review
+
+        mock_run.return_value = "ok"
+        _run_claude_review("REVIEW BODY", "/tmp/project")
+        assert mock_run.call_args.kwargs["prompt"] == "REVIEW BODY"
+
+    @patch("app.cli_provider.run_command_streaming")
+    @patch("app.config.get_model_config", return_value={"review_mode": "m", "mission": "m"})
+    @patch("app.config.get_skill_max_turns", return_value=200)
+    @patch("app.language_preference.get_language_instruction",
+           side_effect=OSError("unreadable"))
+    def test_language_lookup_failure_is_non_fatal(
+        self, mock_lang, mock_max_turns, mock_models, mock_run, capsys,
+    ):
+        """A review in the default language beats no review at all."""
+        from app.review_runner import _run_claude_review
+
+        mock_run.return_value = "ok"
+        output, error = _run_claude_review("REVIEW BODY", "/tmp/project")
+        assert (output, error) == ("ok", "")
+        assert mock_run.call_args.kwargs["prompt"] == "REVIEW BODY"
+        assert "language directive unavailable" in capsys.readouterr().err
+
+    def test_default_install_gets_english(self, tmp_path, monkeypatch):
+        """No language.json at all still pins the review to English.
+
+        Guards the regression this fixes: nothing in the review path pinned a
+        language, so the model was free to answer an English thread in another.
+        """
+        from app.review_runner import _with_language_directive
+
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        assert "english" in _with_language_directive("BODY").lower()
+
 
 # ---------------------------------------------------------------------------
 # main() CLI entry point

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -303,8 +303,12 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   contract: the `## PR Review` / `## Summary` headings a prompt asks the model to
   emit verbatim (`_extract_review_body` regex-matches them to recover a review at
   all — a miss posts the unparseable-output notice instead), the `classification`
-  value `actionable` consumed by `_run_bot_comment_triage`, and the
-  `CRITICAL`/`HIGH`/`MEDIUM` severities the error hunter orders and colors by. The
+  value `actionable` consumed by `_run_bot_comment_triage`, the
+  `CRITICAL`/`HIGH`/`MEDIUM` severities the error hunter orders and colors by, the
+  `[Deferred]` / `[Pre-Existing Issue]` title prefixes `review_triage.enforce_deferred`
+  and `enforce_pre_existing` substring-match (a translated prefix silently blocks a PR
+  over a finding the human deferred), and the `comment_replies[].action` value
+  `needs_clarification`. The
   review path therefore does **not** reuse the chat-side
   `get_language_instruction()` string — that one is absolute ("all your responses")
   — but a review-specific directive,

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -297,15 +297,27 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   the override; a review prompt must never independently ask the model to guess
   or mirror a language, because leaving the choice open lets a model answer an
   English thread in an unrelated language.
+- **Machine-read tokens stay English, including in model output.** The language
+  override is scoped to prose and MUST carve out every token Python matches
+  literally, because a translated one fails silently. The carve-out list is the
+  contract: the `## PR Review` / `## Summary` headings a prompt asks the model to
+  emit verbatim (`_extract_review_body` regex-matches them to recover a review at
+  all — a miss posts the unparseable-output notice instead), the `classification`
+  value `actionable` consumed by `_run_bot_comment_triage`, and the
+  `CRITICAL`/`HIGH`/`MEDIUM` severities the error hunter orders and colors by. The
+  review path therefore does **not** reuse the chat-side
+  `get_language_instruction()` string — that one is absolute ("all your responses")
+  — but a review-specific directive,
+  `koan/system-prompts/review-language-directive.md`. Any new prompt behind this
+  funnel that adds a literal output contract MUST extend that carve-out.
 - **Renderer-owned scaffolding stays English, deliberately.** The strings Python
   itself emits around that prose are structure, not conversation, and are **not**
-  localized: the `## PR Review` heading, the `_SEVERITY_HEADING` tier names
-  (`Blocking`/`Important`/`Suggestions`), and the verdict line. They are
-  load-bearing — a stable heading is what lets a human scan any PR the same way,
-  and `_extract_review_body` regex-matches `## PR Review` to recover a
-  review from unstructured model output — so a non-English preference yields English scaffolding around
-  translated prose, by design. Widening the language override to cover them is an
-  architectural change, not a bug fix.
+  localized: the `## PR Review` heading it builds, the `_SEVERITY_HEADING` tier
+  names (`Blocking`/`Important`/`Suggestions`), and the verdict line. A stable
+  heading is what lets a human scan any PR the same way, so a non-English
+  preference yields English scaffolding around translated prose, by design.
+  Widening the language override to cover them is an architectural change, not a
+  bug fix.
 
 ### Consistency, triage & human dispositions (spec 010)
 

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -4,7 +4,7 @@ title: "Skill Spec — review"
 description: "Documents the `/review` skill that queues a code-review mission on PRs/issues, posting findings as a comment with severity-driven LGTM logic and re-review comment handling, covered by the eval harness."
 tags: [skill]
 created: 2026-06-27
-updated: 2026-09-09
+updated: 2026-09-11
 ---
 
 # Skill Spec — `review`
@@ -286,6 +286,26 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   hunter, so this overlap is exercised by
   `TestReviewPostsBeforeEnrichment::test_coverage_note_survives_hunter_append_overlap`
   in `koan/tests/test_review_runner.py`.
+- **Model-written review prose follows the configured reply language.** The
+  prose the model generates — finding titles and bodies, the summary, and thread
+  replies — is written in the language returned by
+  `language_preference.get_language()`, which is **English** unless the human set
+  another with `/language`. The instruction is injected once, centrally, in
+  `_run_claude_review` (the single provider funnel for every review call), not
+  restated per prompt, so no review prompt can drift out of it. Only an explicit
+  `/language reset` (the `{"language": ""}` sentinel, input-language mode) lifts
+  the override; a review prompt must never independently ask the model to guess
+  or mirror a language, because leaving the choice open lets a model answer an
+  English thread in an unrelated language.
+- **Renderer-owned scaffolding stays English, deliberately.** The strings Python
+  itself emits around that prose are structure, not conversation, and are **not**
+  localized: the `## PR Review` heading, the `_SEVERITY_HEADING` tier names
+  (`Blocking`/`Important`/`Suggestions`), and the verdict line. They are
+  load-bearing — a stable heading is what lets a human scan any PR the same way,
+  and `_extract_review_body` regex-matches `## PR Review` to recover a
+  review from unstructured model output — so a non-English preference yields English scaffolding around
+  translated prose, by design. Widening the language override to cover them is an
+  architectural change, not a bug fix.
 
 ### Consistency, triage & human dispositions (spec 010)
 


### PR DESCRIPTION
A review is the one Kōan surface that never loads soul.md or the mission system prompt, so /language never reached it — and no review prompt pinned a language either, which left the choice to the model. On one PR that produced an Italian reply to an English-only comment thread.

Inject the preference once in _run_claude_review, the single provider funnel every review call already goes through, so the main pass, reflect, error-hunter and triage cannot drift apart. get_language() already defaults to English, so a fresh install needs no configuration. The directive is prepended, never appended — several review prompts end with an untrusted-data fence, and an instruction placed after it would read as data. /language reset still yields an empty instruction and the prompt is returned unchanged, which is exactly what reset asks for.

Scope is model output. The scaffolding Python renders around a review stays English by design: the "## PR Review" heading, the _SEVERITY_HEADING tier names, the verdict line. Those are structure rather than conversation, and one is load-bearing — _extract_review_body regex-matches "## PR Review" to recover a review from unstructured model output. State that boundary in the spec rather than leave it as a silent gap.

A prompt is the wrong place to store a runtime preference. Config belongs at the funnel; prompts should describe the task.

<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
